### PR TITLE
Add option to allow namespace export/declare for Typescript

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -80,11 +80,27 @@ yargs
         demand: false,
         describe: "Don't attempt to map custom scalars [temporary option]",
         default: false
+      },
+      "ts-namespace": {
+        demand: false,
+        describe: "Typescript: An [optional] namespace name for generated types.",
+        default: null
+      },
+      "ts-namespace-type": {
+        demand: false,
+        describe: "Typescript: How the namespace should be generated. Either `export` or `declare`." +
+                  "Defaults to `export`, unless the `output` path ends in `.d.ts`, in which case it deafults to `declare`.",
+        default: null
       }
     },
     argv => {
       const inputPaths = argv.input.map(input => path.resolve(input));
-      const options = { passthroughCustomScalars: argv["passthrough-custom-scalars"] };
+
+      const options = {
+        passthroughCustomScalars: argv["passthrough-custom-scalars"],
+        tsNamespace: argv["ts-namespace"],
+        tsNamespaceType: (argv["ts-namespace-type"] || (argv["ts-namespace"] && argv.output.match(/\.d\.ts$/) ? "declare" : "export"))
+      };
       generate(inputPaths, argv.schema, argv.output, argv.target, options);
     },
   )

--- a/src/typescript/codeGeneration.js
+++ b/src/typescript/codeGeneration.js
@@ -37,6 +37,21 @@ export function generateSource(context) {
   const generator = new CodeGenerator(context);
 
   generator.printOnNewline('//  This file was automatically generated and should not be edited.');
+
+  if (context.tsNamespace) {
+    const exportType = context.tsNamespaceType || 'export';
+    generator.printOnNewline(exportType + " namespace "+context.tsNamespace);
+    generator.withinBlock(() => {
+      generateDeclarations(context, generator);
+    });
+  } else {
+    generateDeclarations(context, generator);
+  }
+
+  return generator.output;
+}
+
+function generateDeclarations(context, generator) {
   typeDeclarationForGraphQLType(context.typesUsed.forEach(type =>
     typeDeclarationForGraphQLType(generator, type)
   ));
@@ -47,8 +62,6 @@ export function generateSource(context) {
   Object.values(context.fragments).forEach(operation =>
     interfaceDeclarationForFragment(generator, operation)
   );
-
-  return generator.output;
 }
 
 export function typeDeclarationForGraphQLType(generator, type) {

--- a/test/typescript/codeGeneration.js
+++ b/test/typescript/codeGeneration.js
@@ -69,6 +69,36 @@ describe('TypeScript code generation', function() {
       `);
     });
 
+    it(`should generate in a namespace`, function() {
+      const context = this.compileFromSource(`
+        query HeroName {
+          hero {
+            name
+          }
+        }
+      `);
+
+      let contextWithNamespace = Object.assign({}, context, {
+        tsNamespace: "GQL",
+        tsNamespaceType: "declare"
+      });
+      let source = generateSource(contextWithNamespace);
+
+      expect(source).to.include(stripIndent`
+        declare namespace GQL {
+      `);
+
+      contextWithNamespace = Object.assign({}, context, {
+        tsNamespace: "MyNamespace",
+        tsNamespaceType: "export"
+      });
+      source = generateSource(contextWithNamespace);
+
+      expect(source).to.include(stripIndent`
+        export namespace MyNamespace {
+      `);
+    });
+
     it(`should generate simple query operations including input variables`, function() {
       const context = this.compileFromSource(`
         query HeroName($episode: Episode) {
@@ -269,7 +299,7 @@ describe('TypeScript code generation', function() {
         fragment Friend on Character {
           name
         }
-        
+
         query HeroAndFriendsNames($episode: Episode) {
           hero(episode: $episode) {
             name
@@ -284,25 +314,25 @@ describe('TypeScript code generation', function() {
 
       expect(source).to.include(stripIndent`
         //  This file was automatically generated and should not be edited.
-        
+
         // The episodes in the Star Wars trilogy
         export type Episode =
           "NEWHOPE" | // Star Wars Episode IV: A New Hope, released in 1977.
           "EMPIRE" | // Star Wars Episode V: The Empire Strikes Back, released in 1980.
           "JEDI"; // Star Wars Episode VI: Return of the Jedi, released in 1983.
-        
-        
+
+
         export interface HeroAndFriendsNamesQueryVariables {
           episode: Episode | null;
         }
-        
+
         export interface HeroAndFriendsNamesQuery {
           hero: {
             name: string,
             friends: Array<FriendFragment>,
           } | null;
         }
-        
+
         export interface FriendFragment {
           name: string;
         }


### PR DESCRIPTION
I find it useful to be able to declare a namespace and reference a global `query.schema.d.ts` file in my project, instead of having to import interfaces everywhere.

This PR adds the ability to wrap the typescript generated file in a namespace, and the option of whether to use the format `declare namespace` (for `*.d.ts` files), or `export namespace` for usage as a importable module. 