### PR TITLE
Add support for Equatable in generated structs

### DIFF
--- a/src/swift/codeGeneration.ts
+++ b/src/swift/codeGeneration.ts
@@ -191,7 +191,7 @@ export function structDeclarationForFragment(
     generator,
     {
       structName,
-      adoptedProtocols: ['GraphQLFragment'],
+      adoptedProtocols: ['GraphQLFragment', 'Equatable'],
       parentType: typeCondition,
       fields,
       inlineFragments,
@@ -351,7 +351,7 @@ export function structDeclarationForSelectionSet(
         structDeclarationForSelectionSet(generator, {
           structName: structNameForInlineFragment(inlineFragment),
           parentType: inlineFragment.typeCondition,
-          adoptedProtocols: ['GraphQLFragment'],
+          adoptedProtocols: ['GraphQLFragment', 'Equatable'],
           fields: inlineFragment.fields,
           fragmentSpreads: inlineFragment.fragmentSpreads
         });
@@ -721,7 +721,7 @@ function equtableDeclarationForStruct(generator: CodeGenerator, structName: stri
   if (fields.length > 0) {
     generator.printNewlineIfNeeded()
 
-    generator.printOnNewline(`static func ==(lhs: ${structName}, rhs: ${structName}) -> Bool`)
+    generator.printOnNewline(`public static func ==(lhs: ${structName}, rhs: ${structName}) -> Bool`)
     generator.withinBlock(() => {
       generator.printOnNewline('return')
       equtableDeclarationForFields(generator, fields)
@@ -730,24 +730,22 @@ function equtableDeclarationForStruct(generator: CodeGenerator, structName: stri
 }
 
 function equtableDeclarationForFields(generator: CodeGenerator, fields: Field[]) {
-  fields.forEach((field, idx) => {
-    if (idx == 0 && fields.length == 1) {
-      generator.print(' ')
-    } else if (idx == 0 && fields.length > 1) {
-      generator.printNewlineIfNeeded()
-      generator.printIndent()
-      generator.printIndent()
-    } else {
-      generator.printNewlineIfNeeded()
-      generator.printIndent()
-      generator.printIndent()
-    }
+  generator.withIndent(() => {
+    fields.forEach((field, idx) => {
+      if (idx == 0 && fields.length > 1) {
+        generator.printNewline()
+        generator.printIndent()
+      } else {
+        generator.printNewline()
+        generator.printIndent()
+      }
 
-    const { propertyName } = propertyFromField(generator.context,field);
-    generator.print(`lhs.${propertyName} == rhs.${propertyName}`)
+      const { propertyName } = propertyFromField(generator.context,field);
+      generator.print(`lhs.${propertyName} == rhs.${propertyName}`)
 
-    if (idx != fields.length - 1) {
-      generator.print(' &&')
-    }
+      if (idx != fields.length - 1) {
+        generator.print(' &&')
+      }
+    })
   })
 }

--- a/src/swift/codeGeneration.ts
+++ b/src/swift/codeGeneration.ts
@@ -740,8 +740,13 @@ function equtableDeclarationForFields(generator: CodeGenerator, fields: Field[])
         generator.printIndent()
       }
 
-      const { propertyName } = propertyFromField(generator.context,field);
-      generator.print(`lhs.${propertyName} == rhs.${propertyName}`)
+      const properties = propertyFromField(generator.context, field);
+      
+      if (properties.isList && properties.isOptional) {
+        generator.print(`lhs.${properties.propertyName} ?? [] == rhs.${properties.propertyName} ?? []`)
+      } else {
+        generator.print(`lhs.${properties.propertyName} == rhs.${properties.propertyName}`)
+      }
 
       if (idx != fields.length - 1) {
         generator.print(' &&')

--- a/test/swift/__snapshots__/codeGeneration.js.snap
+++ b/test/swift/__snapshots__/codeGeneration.js.snap
@@ -1103,7 +1103,7 @@ exports[`Swift code generation #structDeclarationForFragment() should generate a
   public static func ==(lhs: HeroDetails, rhs: HeroDetails) -> Bool {
     return
       lhs.name == rhs.name &&
-      lhs.friends == rhs.friends
+      lhs.friends ?? [] == rhs.friends ?? []
   }
 }"
 `;
@@ -1272,7 +1272,7 @@ exports[`Swift code generation #structDeclarationForSelectionSet() should genera
 
   public static func ==(lhs: Hero, rhs: Hero) -> Bool {
     return
-      lhs.friends == rhs.friends
+      lhs.friends ?? [] == rhs.friends ?? []
   }
 }"
 `;

--- a/test/swift/__snapshots__/codeGeneration.js.snap
+++ b/test/swift/__snapshots__/codeGeneration.js.snap
@@ -237,6 +237,149 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
 }"
 `;
 
+exports[`Swift code generation #classDeclarationForOperation() should generate a class declaration for a query with an inline fragment 1`] = `
+"public final class HeroQuery: GraphQLQuery {
+  public static let operationString =
+    \\"query Hero {\\" +
+    \\"  hero {\\" +
+    \\"    name\\" +
+    \\"    ... on Droid {\\" +
+    \\"      primaryFunction\\" +
+    \\"    }\\" +
+    \\"  }\\" +
+    \\"}\\"
+
+  public init() {
+  }
+
+  public struct Data: GraphQLSelectionSet, Equatable {
+    public static let possibleTypes = [\\"Query\\"]
+
+    public static let selections: [GraphQLSelection] = [
+      GraphQLField(\\"hero\\", type: .object(Hero.self)),
+    ]
+
+    public var snapshot: Snapshot
+
+    public init(snapshot: Snapshot) {
+      self.snapshot = snapshot
+    }
+
+    public init(hero: Hero? = nil) {
+      self.init(snapshot: [\\"__typename\\": \\"Query\\", \\"hero\\": hero])
+    }
+
+    public var hero: Hero? {
+      get {
+        return (snapshot[\\"hero\\"]! as! Snapshot?).flatMap { Hero(snapshot: $0) }
+      }
+      set {
+        snapshot.updateValue(newValue?.snapshot, forKey: \\"hero\\")
+      }
+    }
+
+    public struct Hero: GraphQLSelectionSet, Equatable {
+      public static let possibleTypes = [\\"Human\\", \\"Droid\\"]
+
+      public static let selections: [GraphQLSelection] = [
+        GraphQLField(\\"name\\", type: .nonNull(.scalar(String.self))),
+        GraphQLFragmentSpread(AsDroid.self),
+      ]
+
+      public var snapshot: Snapshot
+
+      public init(snapshot: Snapshot) {
+        self.snapshot = snapshot
+      }
+
+      public static func makeHuman(name: String) -> Hero {
+        return Hero(snapshot: [\\"__typename\\": \\"Human\\", \\"name\\": name])
+      }
+
+      public static func makeDroid(name: String, primaryFunction: String? = nil) -> Hero {
+        return Hero(snapshot: [\\"__typename\\": \\"Droid\\", \\"name\\": name, \\"primaryFunction\\": primaryFunction])
+      }
+
+      /// The name of the character
+      public var name: String {
+        get {
+          return snapshot[\\"name\\"]! as! String
+        }
+        set {
+          snapshot.updateValue(newValue, forKey: \\"name\\")
+        }
+      }
+
+      public var asDroid: AsDroid? {
+        get {
+          if !AsDroid.possibleTypes.contains(__typename) { return nil }
+          return AsDroid(snapshot: snapshot)
+        }
+        set {
+          guard let newValue = newValue else { return }
+          snapshot = newValue.snapshot
+        }
+      }
+
+      public struct AsDroid: GraphQLFragment, Equatable {
+        public static let possibleTypes = [\\"Droid\\"]
+
+        public static let selections: [GraphQLSelection] = [
+          GraphQLField(\\"name\\", type: .nonNull(.scalar(String.self))),
+          GraphQLField(\\"primaryFunction\\", type: .scalar(String.self)),
+        ]
+
+        public var snapshot: Snapshot
+
+        public init(snapshot: Snapshot) {
+          self.snapshot = snapshot
+        }
+
+        public init(name: String, primaryFunction: String? = nil) {
+          self.init(snapshot: [\\"__typename\\": \\"Droid\\", \\"name\\": name, \\"primaryFunction\\": primaryFunction])
+        }
+
+        /// What others call this droid
+        public var name: String {
+          get {
+            return snapshot[\\"name\\"]! as! String
+          }
+          set {
+            snapshot.updateValue(newValue, forKey: \\"name\\")
+          }
+        }
+
+        /// This droid's primary function
+        public var primaryFunction: String? {
+          get {
+            return snapshot[\\"primaryFunction\\"]! as! String?
+          }
+          set {
+            snapshot.updateValue(newValue, forKey: \\"primaryFunction\\")
+          }
+        }
+
+        public static func ==(lhs: AsDroid, rhs: AsDroid) -> Bool {
+          return
+            lhs.name == rhs.name &&
+            lhs.primaryFunction == rhs.primaryFunction
+        }
+      }
+
+      public static func ==(lhs: Hero, rhs: Hero) -> Bool {
+        return
+          lhs.name == rhs.name
+      }
+    }
+
+    public static func ==(lhs: Data, rhs: Data) -> Bool {
+      return
+        lhs.hero == rhs.hero
+    }
+  }
+}"
+`;
+
 exports[`Swift code generation #classDeclarationForOperation() should generate a class declaration for a query with conditional fragment spreads 1`] = `
 "public final class HeroQuery: GraphQLQuery {
   public static let operationString =

--- a/test/swift/__snapshots__/codeGeneration.js.snap
+++ b/test/swift/__snapshots__/codeGeneration.js.snap
@@ -20,7 +20,7 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
     return [\\"episode\\": episode]
   }
 
-  public struct Data: GraphQLSelectionSet {
+  public struct Data: GraphQLSelectionSet, Equatable {
     public static let possibleTypes = [\\"Mutation\\"]
 
     public static let selections: [GraphQLSelection] = [
@@ -46,7 +46,7 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
       }
     }
 
-    public struct CreateReview: GraphQLSelectionSet {
+    public struct CreateReview: GraphQLSelectionSet, Equatable {
       public static let possibleTypes = [\\"Review\\"]
 
       public static let selections: [GraphQLSelection] = [
@@ -83,6 +83,16 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
           snapshot.updateValue(newValue, forKey: \\"commentary\\")
         }
       }
+
+      static func ==(lhs: CreateReview, rhs: CreateReview) -> Bool {
+        return
+                lhs.stars == rhs.stars &&
+                lhs.commentary == rhs.commentary
+      }
+    }
+
+    static func ==(lhs: Data, rhs: Data) -> Bool {
+      return lhs.createReview == rhs.createReview
     }
   }
 }"
@@ -104,7 +114,7 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
   public init() {
   }
 
-  public struct Data: GraphQLSelectionSet {
+  public struct Data: GraphQLSelectionSet, Equatable {
     public static let possibleTypes = [\\"Query\\"]
 
     public static let selections: [GraphQLSelection] = [
@@ -130,7 +140,7 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
       }
     }
 
-    public struct Hero: GraphQLSelectionSet {
+    public struct Hero: GraphQLSelectionSet, Equatable {
       public static let possibleTypes = [\\"Human\\", \\"Droid\\"]
 
       public static let selections: [GraphQLSelection] = [
@@ -210,7 +220,15 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
             }
           }
         }
+
+        static func ==(lhs: AsDroid, rhs: AsDroid) -> Bool {
+          return lhs.name == rhs.name
+        }
       }
+    }
+
+    static func ==(lhs: Data, rhs: Data) -> Bool {
+      return lhs.hero == rhs.hero
     }
   }
 }"
@@ -230,7 +248,7 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
   public init() {
   }
 
-  public struct Data: GraphQLSelectionSet {
+  public struct Data: GraphQLSelectionSet, Equatable {
     public static let possibleTypes = [\\"Query\\"]
 
     public static let selections: [GraphQLSelection] = [
@@ -256,7 +274,7 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
       }
     }
 
-    public struct Hero: GraphQLSelectionSet {
+    public struct Hero: GraphQLSelectionSet, Equatable {
       public static let possibleTypes = [\\"Human\\", \\"Droid\\"]
 
       public static let selections: [GraphQLSelection] = [
@@ -345,6 +363,10 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
             }
           }
         }
+
+        static func ==(lhs: AsDroid, rhs: AsDroid) -> Bool {
+          return lhs.primaryFunction == rhs.primaryFunction
+        }
       }
 
       public struct Fragments {
@@ -361,6 +383,10 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
           }
         }
       }
+    }
+
+    static func ==(lhs: Data, rhs: Data) -> Bool {
+      return lhs.hero == rhs.hero
     }
   }
 }"
@@ -380,7 +406,7 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
   public init() {
   }
 
-  public struct Data: GraphQLSelectionSet {
+  public struct Data: GraphQLSelectionSet, Equatable {
     public static let possibleTypes = [\\"Query\\"]
 
     public static let selections: [GraphQLSelection] = [
@@ -406,7 +432,7 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
       }
     }
 
-    public struct Hero: GraphQLSelectionSet {
+    public struct Hero: GraphQLSelectionSet, Equatable {
       public static let possibleTypes = [\\"Human\\", \\"Droid\\"]
 
       public static let selections: [GraphQLSelection] = [
@@ -458,6 +484,14 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
           }
         }
       }
+
+      static func ==(lhs: Hero, rhs: Hero) -> Bool {
+        return lhs.name == rhs.name
+      }
+    }
+
+    static func ==(lhs: Data, rhs: Data) -> Bool {
+      return lhs.hero == rhs.hero
     }
   }
 }"
@@ -482,7 +516,7 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
     return [\\"episode\\": episode]
   }
 
-  public struct Data: GraphQLSelectionSet {
+  public struct Data: GraphQLSelectionSet, Equatable {
     public static let possibleTypes = [\\"Query\\"]
 
     public static let selections: [GraphQLSelection] = [
@@ -508,7 +542,7 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
       }
     }
 
-    public struct Hero: GraphQLSelectionSet {
+    public struct Hero: GraphQLSelectionSet, Equatable {
       public static let possibleTypes = [\\"Human\\", \\"Droid\\"]
 
       public static let selections: [GraphQLSelection] = [
@@ -538,6 +572,14 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
           snapshot.updateValue(newValue, forKey: \\"name\\")
         }
       }
+
+      static func ==(lhs: Hero, rhs: Hero) -> Bool {
+        return lhs.name == rhs.name
+      }
+    }
+
+    static func ==(lhs: Data, rhs: Data) -> Bool {
+      return lhs.hero == rhs.hero
     }
   }
 }"
@@ -559,7 +601,7 @@ exports[`Swift code generation #classDeclarationForOperation() when generateOper
   public init() {
   }
 
-  public struct Data: GraphQLSelectionSet {
+  public struct Data: GraphQLSelectionSet, Equatable {
     public static let possibleTypes = [\\"Query\\"]
 
     public static let selections: [GraphQLSelection] = [
@@ -585,7 +627,7 @@ exports[`Swift code generation #classDeclarationForOperation() when generateOper
       }
     }
 
-    public struct Hero: GraphQLSelectionSet {
+    public struct Hero: GraphQLSelectionSet, Equatable {
       public static let possibleTypes = [\\"Human\\", \\"Droid\\"]
 
       public static let selections: [GraphQLSelection] = [
@@ -637,6 +679,14 @@ exports[`Swift code generation #classDeclarationForOperation() when generateOper
           }
         }
       }
+
+      static func ==(lhs: Hero, rhs: Hero) -> Bool {
+        return lhs.name == rhs.name
+      }
+    }
+
+    static func ==(lhs: Data, rhs: Data) -> Bool {
+      return lhs.hero == rhs.hero
     }
   }
 }"
@@ -746,6 +796,12 @@ exports[`Swift code generation #structDeclarationForFragment() should generate a
       }
     }
   }
+
+  static func ==(lhs: HeroDetails, rhs: HeroDetails) -> Bool {
+    return
+        lhs.name == rhs.name &&
+        lhs.appearsIn == rhs.appearsIn
+  }
 }"
 `;
 
@@ -792,6 +848,12 @@ exports[`Swift code generation #structDeclarationForFragment() should generate a
     set {
       snapshot.updateValue(newValue, forKey: \\"primaryFunction\\")
     }
+  }
+
+  static func ==(lhs: DroidDetails, rhs: DroidDetails) -> Bool {
+    return
+        lhs.name == rhs.name &&
+        lhs.primaryFunction == rhs.primaryFunction
   }
 }"
 `;
@@ -847,7 +909,7 @@ exports[`Swift code generation #structDeclarationForFragment() should generate a
     }
   }
 
-  public struct Friend: GraphQLSelectionSet {
+  public struct Friend: GraphQLSelectionSet, Equatable {
     public static let possibleTypes = [\\"Human\\", \\"Droid\\"]
 
     public static let selections: [GraphQLSelection] = [
@@ -877,6 +939,16 @@ exports[`Swift code generation #structDeclarationForFragment() should generate a
         snapshot.updateValue(newValue, forKey: \\"name\\")
       }
     }
+
+    static func ==(lhs: Friend, rhs: Friend) -> Bool {
+      return lhs.name == rhs.name
+    }
+  }
+
+  static func ==(lhs: HeroDetails, rhs: HeroDetails) -> Bool {
+    return
+        lhs.name == rhs.name &&
+        lhs.friends == rhs.friends
   }
 }"
 `;
@@ -929,11 +1001,17 @@ exports[`Swift code generation #structDeclarationForFragment() should generate a
       snapshot.updateValue(newValue, forKey: \\"appearsIn\\")
     }
   }
+
+  static func ==(lhs: HeroDetails, rhs: HeroDetails) -> Bool {
+    return
+        lhs.name == rhs.name &&
+        lhs.appearsIn == rhs.appearsIn
+  }
 }"
 `;
 
 exports[`Swift code generation #structDeclarationForSelectionSet() should escape reserved keywords in a struct declaration for a selection set 1`] = `
-"public struct Hero: GraphQLSelectionSet {
+"public struct Hero: GraphQLSelectionSet, Equatable {
   public static let possibleTypes = [\\"Human\\", \\"Droid\\"]
 
   public static let selections: [GraphQLSelection] = [
@@ -962,11 +1040,15 @@ exports[`Swift code generation #structDeclarationForSelectionSet() should escape
       snapshot.updateValue(newValue, forKey: \\"private\\")
     }
   }
+
+  static func ==(lhs: Hero, rhs: Hero) -> Bool {
+    return lhs.\`private\` == rhs.\`private\`
+  }
 }"
 `;
 
 exports[`Swift code generation #structDeclarationForSelectionSet() should generate a nested struct declaration for a selection set with subselections 1`] = `
-"public struct Hero: GraphQLSelectionSet {
+"public struct Hero: GraphQLSelectionSet, Equatable {
   public static let possibleTypes = [\\"Human\\", \\"Droid\\"]
 
   public static let selections: [GraphQLSelection] = [
@@ -996,7 +1078,7 @@ exports[`Swift code generation #structDeclarationForSelectionSet() should genera
     }
   }
 
-  public struct Friend: GraphQLSelectionSet {
+  public struct Friend: GraphQLSelectionSet, Equatable {
     public static let possibleTypes = [\\"Human\\", \\"Droid\\"]
 
     public static let selections: [GraphQLSelection] = [
@@ -1025,12 +1107,20 @@ exports[`Swift code generation #structDeclarationForSelectionSet() should genera
         snapshot.updateValue(newValue, forKey: \\"name\\")
       }
     }
+
+    static func ==(lhs: Friend, rhs: Friend) -> Bool {
+      return lhs.name == rhs.name
+    }
+  }
+
+  static func ==(lhs: Hero, rhs: Hero) -> Bool {
+    return lhs.friends == rhs.friends
   }
 }"
 `;
 
 exports[`Swift code generation #structDeclarationForSelectionSet() should generate a struct declaration for a fragment spread nested in an inline fragment 1`] = `
-"public struct Hero: GraphQLSelectionSet {
+"public struct Hero: GraphQLSelectionSet, Equatable {
   public static let possibleTypes = [\\"Human\\", \\"Droid\\"]
 
   public static let selections: [GraphQLSelection] = [
@@ -1104,7 +1194,7 @@ exports[`Swift code generation #structDeclarationForSelectionSet() should genera
 `;
 
 exports[`Swift code generation #structDeclarationForSelectionSet() should generate a struct declaration for a selection set 1`] = `
-"public struct Hero: GraphQLSelectionSet {
+"public struct Hero: GraphQLSelectionSet, Equatable {
   public static let possibleTypes = [\\"Human\\", \\"Droid\\"]
 
   public static let selections: [GraphQLSelection] = [
@@ -1133,11 +1223,15 @@ exports[`Swift code generation #structDeclarationForSelectionSet() should genera
       snapshot.updateValue(newValue, forKey: \\"name\\")
     }
   }
+
+  static func ==(lhs: Hero, rhs: Hero) -> Bool {
+    return lhs.name == rhs.name
+  }
 }"
 `;
 
 exports[`Swift code generation #structDeclarationForSelectionSet() should generate a struct declaration for a selection set with a fragment spread that matches the parent type 1`] = `
-"public struct Hero: GraphQLSelectionSet {
+"public struct Hero: GraphQLSelectionSet, Equatable {
   public static let possibleTypes = [\\"Human\\", \\"Droid\\"]
 
   public static let selections: [GraphQLSelection] = [
@@ -1188,11 +1282,15 @@ exports[`Swift code generation #structDeclarationForSelectionSet() should genera
       }
     }
   }
+
+  static func ==(lhs: Hero, rhs: Hero) -> Bool {
+    return lhs.name == rhs.name
+  }
 }"
 `;
 
 exports[`Swift code generation #structDeclarationForSelectionSet() should generate a struct declaration for a selection set with a fragment spread with a more specific type condition 1`] = `
-"public struct Hero: GraphQLSelectionSet {
+"public struct Hero: GraphQLSelectionSet, Equatable {
   public static let possibleTypes = [\\"Human\\", \\"Droid\\"]
 
   public static let selections: [GraphQLSelection] = [
@@ -1245,11 +1343,15 @@ exports[`Swift code generation #structDeclarationForSelectionSet() should genera
       }
     }
   }
+
+  static func ==(lhs: Hero, rhs: Hero) -> Bool {
+    return lhs.name == rhs.name
+  }
 }"
 `;
 
 exports[`Swift code generation #structDeclarationForSelectionSet() should generate a struct declaration for a selection set with an inline fragment 1`] = `
-"public struct Hero: GraphQLSelectionSet {
+"public struct Hero: GraphQLSelectionSet, Equatable {
   public static let possibleTypes = [\\"Human\\", \\"Droid\\"]
 
   public static let selections: [GraphQLSelection] = [
@@ -1326,6 +1428,16 @@ exports[`Swift code generation #structDeclarationForSelectionSet() should genera
         snapshot.updateValue(newValue, forKey: \\"primaryFunction\\")
       }
     }
+
+    static func ==(lhs: AsDroid, rhs: AsDroid) -> Bool {
+      return
+            lhs.name == rhs.name &&
+            lhs.primaryFunction == rhs.primaryFunction
+    }
+  }
+
+  static func ==(lhs: Hero, rhs: Hero) -> Bool {
+    return lhs.name == rhs.name
   }
 }"
 `;

--- a/test/swift/__snapshots__/codeGeneration.js.snap
+++ b/test/swift/__snapshots__/codeGeneration.js.snap
@@ -84,15 +84,16 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
         }
       }
 
-      static func ==(lhs: CreateReview, rhs: CreateReview) -> Bool {
+      public static func ==(lhs: CreateReview, rhs: CreateReview) -> Bool {
         return
-                lhs.stars == rhs.stars &&
-                lhs.commentary == rhs.commentary
+          lhs.stars == rhs.stars &&
+          lhs.commentary == rhs.commentary
       }
     }
 
-    static func ==(lhs: Data, rhs: Data) -> Bool {
-      return lhs.createReview == rhs.createReview
+    public static func ==(lhs: Data, rhs: Data) -> Bool {
+      return
+        lhs.createReview == rhs.createReview
     }
   }
 }"
@@ -172,7 +173,7 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
         }
       }
 
-      public struct AsDroid: GraphQLFragment {
+      public struct AsDroid: GraphQLFragment, Equatable {
         public static let possibleTypes = [\\"Droid\\"]
 
         public static let selections: [GraphQLSelection] = [
@@ -221,14 +222,16 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
           }
         }
 
-        static func ==(lhs: AsDroid, rhs: AsDroid) -> Bool {
-          return lhs.name == rhs.name
+        public static func ==(lhs: AsDroid, rhs: AsDroid) -> Bool {
+          return
+            lhs.name == rhs.name
         }
       }
     }
 
-    static func ==(lhs: Data, rhs: Data) -> Bool {
-      return lhs.hero == rhs.hero
+    public static func ==(lhs: Data, rhs: Data) -> Bool {
+      return
+        lhs.hero == rhs.hero
     }
   }
 }"
@@ -315,7 +318,7 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
         }
       }
 
-      public struct AsDroid: GraphQLFragment {
+      public struct AsDroid: GraphQLFragment, Equatable {
         public static let possibleTypes = [\\"Droid\\"]
 
         public static let selections: [GraphQLSelection] = [
@@ -364,8 +367,9 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
           }
         }
 
-        static func ==(lhs: AsDroid, rhs: AsDroid) -> Bool {
-          return lhs.primaryFunction == rhs.primaryFunction
+        public static func ==(lhs: AsDroid, rhs: AsDroid) -> Bool {
+          return
+            lhs.primaryFunction == rhs.primaryFunction
         }
       }
 
@@ -385,8 +389,9 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
       }
     }
 
-    static func ==(lhs: Data, rhs: Data) -> Bool {
-      return lhs.hero == rhs.hero
+    public static func ==(lhs: Data, rhs: Data) -> Bool {
+      return
+        lhs.hero == rhs.hero
     }
   }
 }"
@@ -485,13 +490,15 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
         }
       }
 
-      static func ==(lhs: Hero, rhs: Hero) -> Bool {
-        return lhs.name == rhs.name
+      public static func ==(lhs: Hero, rhs: Hero) -> Bool {
+        return
+          lhs.name == rhs.name
       }
     }
 
-    static func ==(lhs: Data, rhs: Data) -> Bool {
-      return lhs.hero == rhs.hero
+    public static func ==(lhs: Data, rhs: Data) -> Bool {
+      return
+        lhs.hero == rhs.hero
     }
   }
 }"
@@ -573,13 +580,15 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
         }
       }
 
-      static func ==(lhs: Hero, rhs: Hero) -> Bool {
-        return lhs.name == rhs.name
+      public static func ==(lhs: Hero, rhs: Hero) -> Bool {
+        return
+          lhs.name == rhs.name
       }
     }
 
-    static func ==(lhs: Data, rhs: Data) -> Bool {
-      return lhs.hero == rhs.hero
+    public static func ==(lhs: Data, rhs: Data) -> Bool {
+      return
+        lhs.hero == rhs.hero
     }
   }
 }"
@@ -680,13 +689,15 @@ exports[`Swift code generation #classDeclarationForOperation() when generateOper
         }
       }
 
-      static func ==(lhs: Hero, rhs: Hero) -> Bool {
-        return lhs.name == rhs.name
+      public static func ==(lhs: Hero, rhs: Hero) -> Bool {
+        return
+          lhs.name == rhs.name
       }
     }
 
-    static func ==(lhs: Data, rhs: Data) -> Bool {
-      return lhs.hero == rhs.hero
+    public static func ==(lhs: Data, rhs: Data) -> Bool {
+      return
+        lhs.hero == rhs.hero
     }
   }
 }"
@@ -727,7 +738,7 @@ exports[`Swift code generation #initializerDeclarationForProperties() should gen
 `;
 
 exports[`Swift code generation #structDeclarationForFragment() should generate a struct declaration for a fragment that includes a fragment spread 1`] = `
-"public struct HeroDetails: GraphQLFragment {
+"public struct HeroDetails: GraphQLFragment, Equatable {
   public static let fragmentString =
     \\"fragment HeroDetails on Character {\\" +
     \\"  name\\" +
@@ -797,16 +808,16 @@ exports[`Swift code generation #structDeclarationForFragment() should generate a
     }
   }
 
-  static func ==(lhs: HeroDetails, rhs: HeroDetails) -> Bool {
+  public static func ==(lhs: HeroDetails, rhs: HeroDetails) -> Bool {
     return
-        lhs.name == rhs.name &&
-        lhs.appearsIn == rhs.appearsIn
+      lhs.name == rhs.name &&
+      lhs.appearsIn == rhs.appearsIn
   }
 }"
 `;
 
 exports[`Swift code generation #structDeclarationForFragment() should generate a struct declaration for a fragment with a concrete type condition 1`] = `
-"public struct DroidDetails: GraphQLFragment {
+"public struct DroidDetails: GraphQLFragment, Equatable {
   public static let fragmentString =
     \\"fragment DroidDetails on Droid {\\" +
     \\"  name\\" +
@@ -850,16 +861,16 @@ exports[`Swift code generation #structDeclarationForFragment() should generate a
     }
   }
 
-  static func ==(lhs: DroidDetails, rhs: DroidDetails) -> Bool {
+  public static func ==(lhs: DroidDetails, rhs: DroidDetails) -> Bool {
     return
-        lhs.name == rhs.name &&
-        lhs.primaryFunction == rhs.primaryFunction
+      lhs.name == rhs.name &&
+      lhs.primaryFunction == rhs.primaryFunction
   }
 }"
 `;
 
 exports[`Swift code generation #structDeclarationForFragment() should generate a struct declaration for a fragment with a subselection 1`] = `
-"public struct HeroDetails: GraphQLFragment {
+"public struct HeroDetails: GraphQLFragment, Equatable {
   public static let fragmentString =
     \\"fragment HeroDetails on Character {\\" +
     \\"  name\\" +
@@ -940,21 +951,22 @@ exports[`Swift code generation #structDeclarationForFragment() should generate a
       }
     }
 
-    static func ==(lhs: Friend, rhs: Friend) -> Bool {
-      return lhs.name == rhs.name
+    public static func ==(lhs: Friend, rhs: Friend) -> Bool {
+      return
+        lhs.name == rhs.name
     }
   }
 
-  static func ==(lhs: HeroDetails, rhs: HeroDetails) -> Bool {
+  public static func ==(lhs: HeroDetails, rhs: HeroDetails) -> Bool {
     return
-        lhs.name == rhs.name &&
-        lhs.friends == rhs.friends
+      lhs.name == rhs.name &&
+      lhs.friends == rhs.friends
   }
 }"
 `;
 
 exports[`Swift code generation #structDeclarationForFragment() should generate a struct declaration for a fragment with an abstract type condition 1`] = `
-"public struct HeroDetails: GraphQLFragment {
+"public struct HeroDetails: GraphQLFragment, Equatable {
   public static let fragmentString =
     \\"fragment HeroDetails on Character {\\" +
     \\"  name\\" +
@@ -1002,10 +1014,10 @@ exports[`Swift code generation #structDeclarationForFragment() should generate a
     }
   }
 
-  static func ==(lhs: HeroDetails, rhs: HeroDetails) -> Bool {
+  public static func ==(lhs: HeroDetails, rhs: HeroDetails) -> Bool {
     return
-        lhs.name == rhs.name &&
-        lhs.appearsIn == rhs.appearsIn
+      lhs.name == rhs.name &&
+      lhs.appearsIn == rhs.appearsIn
   }
 }"
 `;
@@ -1041,8 +1053,9 @@ exports[`Swift code generation #structDeclarationForSelectionSet() should escape
     }
   }
 
-  static func ==(lhs: Hero, rhs: Hero) -> Bool {
-    return lhs.\`private\` == rhs.\`private\`
+  public static func ==(lhs: Hero, rhs: Hero) -> Bool {
+    return
+      lhs.\`private\` == rhs.\`private\`
   }
 }"
 `;
@@ -1108,13 +1121,15 @@ exports[`Swift code generation #structDeclarationForSelectionSet() should genera
       }
     }
 
-    static func ==(lhs: Friend, rhs: Friend) -> Bool {
-      return lhs.name == rhs.name
+    public static func ==(lhs: Friend, rhs: Friend) -> Bool {
+      return
+        lhs.name == rhs.name
     }
   }
 
-  static func ==(lhs: Hero, rhs: Hero) -> Bool {
-    return lhs.friends == rhs.friends
+  public static func ==(lhs: Hero, rhs: Hero) -> Bool {
+    return
+      lhs.friends == rhs.friends
   }
 }"
 `;
@@ -1152,7 +1167,7 @@ exports[`Swift code generation #structDeclarationForSelectionSet() should genera
     }
   }
 
-  public struct AsDroid: GraphQLFragment {
+  public struct AsDroid: GraphQLFragment, Equatable {
     public static let possibleTypes = [\\"Droid\\"]
 
     public static let selections: [GraphQLSelection] = [
@@ -1224,8 +1239,9 @@ exports[`Swift code generation #structDeclarationForSelectionSet() should genera
     }
   }
 
-  static func ==(lhs: Hero, rhs: Hero) -> Bool {
-    return lhs.name == rhs.name
+  public static func ==(lhs: Hero, rhs: Hero) -> Bool {
+    return
+      lhs.name == rhs.name
   }
 }"
 `;
@@ -1283,8 +1299,9 @@ exports[`Swift code generation #structDeclarationForSelectionSet() should genera
     }
   }
 
-  static func ==(lhs: Hero, rhs: Hero) -> Bool {
-    return lhs.name == rhs.name
+  public static func ==(lhs: Hero, rhs: Hero) -> Bool {
+    return
+      lhs.name == rhs.name
   }
 }"
 `;
@@ -1344,8 +1361,9 @@ exports[`Swift code generation #structDeclarationForSelectionSet() should genera
     }
   }
 
-  static func ==(lhs: Hero, rhs: Hero) -> Bool {
-    return lhs.name == rhs.name
+  public static func ==(lhs: Hero, rhs: Hero) -> Bool {
+    return
+      lhs.name == rhs.name
   }
 }"
 `;
@@ -1393,7 +1411,7 @@ exports[`Swift code generation #structDeclarationForSelectionSet() should genera
     }
   }
 
-  public struct AsDroid: GraphQLFragment {
+  public struct AsDroid: GraphQLFragment, Equatable {
     public static let possibleTypes = [\\"Droid\\"]
 
     public static let selections: [GraphQLSelection] = [
@@ -1429,15 +1447,16 @@ exports[`Swift code generation #structDeclarationForSelectionSet() should genera
       }
     }
 
-    static func ==(lhs: AsDroid, rhs: AsDroid) -> Bool {
+    public static func ==(lhs: AsDroid, rhs: AsDroid) -> Bool {
       return
-            lhs.name == rhs.name &&
-            lhs.primaryFunction == rhs.primaryFunction
+        lhs.name == rhs.name &&
+        lhs.primaryFunction == rhs.primaryFunction
     }
   }
 
-  static func ==(lhs: Hero, rhs: Hero) -> Bool {
-    return lhs.name == rhs.name
+  public static func ==(lhs: Hero, rhs: Hero) -> Bool {
+    return
+      lhs.name == rhs.name
   }
 }"
 `;

--- a/test/swift/codeGeneration.js
+++ b/test/swift/codeGeneration.js
@@ -47,7 +47,7 @@ describe('Swift code generation', function() {
         typesUsed: {},
         options: { mergeInFieldsFromFragmentSpreads: true },
       }
-      generator = new CodeGenerator(context);  
+      generator = new CodeGenerator(context);
     };
 
     compileFromSource = (source, options = { generateOperationIds: false }) => {
@@ -112,6 +112,23 @@ describe('Swift code generation', function() {
       classDeclarationForOperation(generator, operations['Hero'], Object.values(fragments));
       expect(generator.output).toMatchSnapshot();
     });
+
+    test(`should generate a class declaration for a query with an inline fragment`, function() {
+      const { operations, fragments } = compileFromSource(`
+        query Hero {
+          hero {
+            name
+            ... on Droid {
+              primaryFunction
+            }
+          }
+        }
+      `)
+
+      classDeclarationForOperation(generator, operations['Hero'], Object.values(fragments));
+
+      expect(generator.output).toMatchSnapshot();
+    })
 
     test(`should generate a class declaration for a query with a fragment spread nested in an inline fragment`, function() {
       const { operations, fragments } = compileFromSource(`


### PR DESCRIPTION
As talked about in #215, this PR will automatically generate `Equatable` definitions.

There are two new functions: `equtableDeclarationForStruct` and `equtableDeclarationForFields`. The test snapshots have been updated as well.

Let me know if any changes need to be made.