### PR TITLE
Fixes around GraphQLList fields for JS Targets

### DIFF
--- a/src/flow/codeGeneration.js
+++ b/src/flow/codeGeneration.js
@@ -16,8 +16,6 @@ import {
 
 import  { isTypeProperSuperTypeOf } from '../utilities/graphql';
 
-import * as Inflector from 'inflected';
-
 import {
   join,
   wrap,

--- a/src/javascript/flow/__tests__/__snapshots__/codeGeneration.ts.snap
+++ b/src/javascript/flow/__tests__/__snapshots__/codeGeneration.ts.snap
@@ -12,7 +12,7 @@ Object {
 // GraphQL query operation: HeroName
 // ====================================================
 
-export type HeroName_hero_Human_friends = {
+export type HeroName_hero_Human_friend = {
   __typename: \\"Human\\",
   name: string, // What this human calls themselves
 } | {
@@ -22,15 +22,15 @@ export type HeroName_hero_Human_friends = {
 
 export type HeroName_hero = {
   __typename: \\"Human\\",
-  name: string,                          // What this human calls themselves
-  id: string,                            // The ID of the human
-  homePlanet: ?string,                   // The home planet of the human, or null if unknown
-  friends: ?HeroName_hero_Human_friends, // This human's friends, or an empty list if they have none
+  name: string,                              // What this human calls themselves
+  id: string,                                // The ID of the human
+  homePlanet: ?string,                       // The home planet of the human, or null if unknown
+  friends: ?(?HeroName_hero_Human_friend)[], // This human's friends, or an empty list if they have none
 } | {
   __typename: \\"Droid\\",
-  name: string,                          // What others call this droid
-  id: string,                            // The ID of the droid
-  appearsIn: (?Episode)[],               // The movies this droid appears in
+  name: string,                              // What others call this droid
+  id: string,                                // The ID of the droid
+  appearsIn: (?Episode)[],                   // The movies this droid appears in
 };
 
 export type HeroName = {
@@ -90,7 +90,7 @@ export type Episode = \\"NEWHOPE\\" | \\"EMPIRE\\" | \\"JEDI\\";
 // GraphQL fragment: humanFragment
 // ====================================================
 
-export type humanFragment_friends = {
+export type humanFragment_friend = {
   __typename: \\"Human\\",
   name: string, // What this human calls themselves
 } | {
@@ -100,8 +100,8 @@ export type humanFragment_friends = {
 
 export type humanFragment = {
   __typename: \\"Human\\",
-  homePlanet: ?string,             // The home planet of the human, or null if unknown
-  friends: ?humanFragment_friends, // This human's friends, or an empty list if they have none
+  homePlanet: ?string,                 // The home planet of the human, or null if unknown
+  friends: ?(?humanFragment_friend)[], // This human's friends, or an empty list if they have none
 };
 
 //==============================================================
@@ -338,22 +338,22 @@ Object {
 // GraphQL query operation: HeroName
 // ====================================================
 
-export type HeroName_hero_Human_friends = {
+export type HeroName_hero_Human_friend = {
   __typename: \\"Human\\" | \\"Droid\\",
   name: string, // The name of the character
 };
 
 export type HeroName_hero = {
   __typename: \\"Human\\",
-  name: string,                          // What this human calls themselves
-  id: string,                            // The ID of the human
-  homePlanet: ?string,                   // The home planet of the human, or null if unknown
-  friends: ?HeroName_hero_Human_friends, // This human's friends, or an empty list if they have none
+  name: string,                              // What this human calls themselves
+  id: string,                                // The ID of the human
+  homePlanet: ?string,                       // The home planet of the human, or null if unknown
+  friends: ?(?HeroName_hero_Human_friend)[], // This human's friends, or an empty list if they have none
 } | {
   __typename: \\"Droid\\",
-  name: string,                          // What others call this droid
-  id: string,                            // The ID of the droid
-  appearsIn: (?Episode)[],               // The movies this droid appears in
+  name: string,                              // What others call this droid
+  id: string,                                // The ID of the droid
+  appearsIn: (?Episode)[],                   // The movies this droid appears in
 };
 
 export type HeroName = {
@@ -389,28 +389,28 @@ Object {
 // GraphQL query operation: HeroName
 // ====================================================
 
-export type HeroName_hero_Human_friends = {
+export type HeroName_hero_Human_friend = {
   __typename: \\"Human\\" | \\"Droid\\",
   name: string, // The name of the character
 };
 
-export type HeroName_hero_Droid_friends = {
+export type HeroName_hero_Droid_friend = {
   __typename: \\"Human\\" | \\"Droid\\",
   id: string, // The ID of the character
 };
 
 export type HeroName_hero = {
   __typename: \\"Human\\",
-  name: string,                          // What this human calls themselves
-  id: string,                            // The ID of the human
-  homePlanet: ?string,                   // The home planet of the human, or null if unknown
-  friends: ?HeroName_hero_Human_friends, // This human's friends, or an empty list if they have none
+  name: string,                              // What this human calls themselves
+  id: string,                                // The ID of the human
+  homePlanet: ?string,                       // The home planet of the human, or null if unknown
+  friends: ?(?HeroName_hero_Human_friend)[], // This human's friends, or an empty list if they have none
 } | {
   __typename: \\"Droid\\",
-  name: string,                          // What others call this droid
-  id: string,                            // The ID of the droid
-  appearsIn: (?Episode)[],               // The movies this droid appears in
-  friends: ?HeroName_hero_Droid_friends, // This droid's friends, or an empty list if they have none
+  name: string,                              // What others call this droid
+  id: string,                                // The ID of the droid
+  appearsIn: (?Episode)[],                   // The movies this droid appears in
+  friends: ?(?HeroName_hero_Droid_friend)[], // This droid's friends, or an empty list if they have none
 };
 
 export type HeroName = {

--- a/src/javascript/flow/codeGeneration.ts
+++ b/src/javascript/flow/codeGeneration.ts
@@ -3,7 +3,6 @@ import { stripIndent } from 'common-tags';
 import {
   GraphQLEnumType,
   GraphQLInputObjectType,
-  GraphQLNonNull,
 } from 'graphql';
 import * as path from 'path';
 

--- a/src/javascript/naming.js
+++ b/src/javascript/naming.js
@@ -1,0 +1,9 @@
+import * as Inflector from 'inflected';
+
+/**
+ * Generally every type name that is generated should be 'singular'.
+ * Lists of items are represented using Array<> or [].
+ */
+export function getTypeNameFromFieldName(propertyName) {
+  return Inflector.singularize(propertyName);
+}

--- a/src/javascript/typescript/__tests__/__snapshots__/codeGeneration.ts.snap
+++ b/src/javascript/typescript/__tests__/__snapshots__/codeGeneration.ts.snap
@@ -12,24 +12,24 @@ Object {
 // GraphQL query operation: HeroName
 // ====================================================
 
-export interface HeroName_hero_Human_friends_Human {
+export interface HeroName_hero_Human_friend_Human {
   __typename: \\"Human\\";
   name: string;  // What this human calls themselves
 }
 
-export interface HeroName_hero_Human_friends_Droid {
+export interface HeroName_hero_Human_friend_Droid {
   __typename: \\"Droid\\";
   id: string;  // The ID of the droid
 }
 
-export type HeroName_hero_Human_friends = HeroName_hero_Human_friends_Human | HeroName_hero_Human_friends_Droid;
+export type HeroName_hero_Human_friend = HeroName_hero_Human_friend_Human | HeroName_hero_Human_friend_Droid;
 
 export interface HeroName_hero_Human {
   __typename: \\"Human\\";
-  name: string;                                            // What this human calls themselves
-  id: string;                                              // The ID of the human
-  homePlanet: string | null;                               // The home planet of the human, or null if unknown
-  friends: (HeroName_hero_Human_friends | null)[] | null;  // This human's friends, or an empty list if they have none
+  name: string;                                           // What this human calls themselves
+  id: string;                                             // The ID of the human
+  homePlanet: string | null;                              // The home planet of the human, or null if unknown
+  friends: (HeroName_hero_Human_friend | null)[] | null;  // This human's friends, or an empty list if they have none
 }
 
 export interface HeroName_hero_Droid {
@@ -106,22 +106,22 @@ export enum Episode {
 // GraphQL fragment: humanFragment
 // ====================================================
 
-export interface humanFragment_friends_Human {
+export interface humanFragment_friend_Human {
   __typename: \\"Human\\";
   name: string;  // What this human calls themselves
 }
 
-export interface humanFragment_friends_Droid {
+export interface humanFragment_friend_Droid {
   __typename: \\"Droid\\";
   id: string;  // The ID of the droid
 }
 
-export type humanFragment_friends = humanFragment_friends_Human | humanFragment_friends_Droid;
+export type humanFragment_friend = humanFragment_friend_Human | humanFragment_friend_Droid;
 
 export interface humanFragment {
   __typename: \\"Human\\";
-  homePlanet: string | null;                         // The home planet of the human, or null if unknown
-  friends: (humanFragment_friends | null)[] | null;  // This human's friends, or an empty list if they have none
+  homePlanet: string | null;                        // The home planet of the human, or null if unknown
+  friends: (humanFragment_friend | null)[] | null;  // This human's friends, or an empty list if they have none
 }
 
 //==============================================================
@@ -374,17 +374,17 @@ Object {
 // GraphQL query operation: HeroName
 // ====================================================
 
-export interface HeroName_hero_Human_friends {
+export interface HeroName_hero_Human_friend {
   __typename: \\"Human\\" | \\"Droid\\";
   name: string;  // The name of the character
 }
 
 export interface HeroName_hero_Human {
   __typename: \\"Human\\";
-  name: string;                                            // What this human calls themselves
-  id: string;                                              // The ID of the human
-  homePlanet: string | null;                               // The home planet of the human, or null if unknown
-  friends: (HeroName_hero_Human_friends | null)[] | null;  // This human's friends, or an empty list if they have none
+  name: string;                                           // What this human calls themselves
+  id: string;                                             // The ID of the human
+  homePlanet: string | null;                              // The home planet of the human, or null if unknown
+  friends: (HeroName_hero_Human_friend | null)[] | null;  // This human's friends, or an empty list if they have none
 }
 
 export interface HeroName_hero_Droid {
@@ -433,30 +433,30 @@ Object {
 // GraphQL query operation: HeroName
 // ====================================================
 
-export interface HeroName_hero_Human_friends {
+export interface HeroName_hero_Human_friend {
   __typename: \\"Human\\" | \\"Droid\\";
   name: string;  // The name of the character
 }
 
 export interface HeroName_hero_Human {
   __typename: \\"Human\\";
-  name: string;                                            // What this human calls themselves
-  id: string;                                              // The ID of the human
-  homePlanet: string | null;                               // The home planet of the human, or null if unknown
-  friends: (HeroName_hero_Human_friends | null)[] | null;  // This human's friends, or an empty list if they have none
+  name: string;                                           // What this human calls themselves
+  id: string;                                             // The ID of the human
+  homePlanet: string | null;                              // The home planet of the human, or null if unknown
+  friends: (HeroName_hero_Human_friend | null)[] | null;  // This human's friends, or an empty list if they have none
 }
 
-export interface HeroName_hero_Droid_friends {
+export interface HeroName_hero_Droid_friend {
   __typename: \\"Human\\" | \\"Droid\\";
   id: string;  // The ID of the character
 }
 
 export interface HeroName_hero_Droid {
   __typename: \\"Droid\\";
-  name: string;                                            // What others call this droid
-  id: string;                                              // The ID of the droid
-  appearsIn: (Episode | null)[];                           // The movies this droid appears in
-  friends: (HeroName_hero_Droid_friends | null)[] | null;  // This droid's friends, or an empty list if they have none
+  name: string;                                           // What others call this droid
+  id: string;                                             // The ID of the droid
+  appearsIn: (Episode | null)[];                          // The movies this droid appears in
+  friends: (HeroName_hero_Droid_friend | null)[] | null;  // This droid's friends, or an empty list if they have none
 }
 
 export type HeroName_hero = HeroName_hero_Human | HeroName_hero_Droid;

--- a/src/javascript/typescript/helpers.ts
+++ b/src/javascript/typescript/helpers.ts
@@ -13,6 +13,8 @@ import {
 import * as t from '@babel/types';
 
 import { CompilerOptions } from '../../compiler';
+import * as Inflector from 'inflected';
+import { createTypeFromGraphQLTypeFn } from '../flow/helpers';
 
 const builtInScalarMap = {
   [GraphQLString.name]: t.TSStringKeyword(),
@@ -26,9 +28,14 @@ export interface TypeFromGraphQLTypeOptions {
   replaceObjectTypeIdentifierWith?: t.Identifier;
 }
 
+type createTypeFromGraphQLTypeFn = (
+  graphQLType: GraphQLType,
+  options?: TypeFromGraphQLTypeOptions
+) => t.TSType;
+
 export function createTypeFromGraphQLTypeFunction(
   compilerOptions: CompilerOptions
-): (graphQLType: GraphQLType, options?: TypeFromGraphQLTypeOptions) => t.TSType {
+): createTypeFromGraphQLTypeFn {
   return function typeFromGraphQLType(graphQLType: GraphQLType, {
     nullable = true,
     replaceObjectTypeIdentifierWith

--- a/src/javascript/typescript/helpers.ts
+++ b/src/javascript/typescript/helpers.ts
@@ -13,8 +13,6 @@ import {
 import * as t from '@babel/types';
 
 import { CompilerOptions } from '../../compiler';
-import * as Inflector from 'inflected';
-import { createTypeFromGraphQLTypeFn } from '../flow/helpers';
 
 const builtInScalarMap = {
   [GraphQLString.name]: t.TSStringKeyword(),


### PR DESCRIPTION
- Singularize type names when they are 'items' in an array
- Fix flow-modern type generation around arrays

Fixes #325