### PR TITLE
Add option to always generate *Variables type definition

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -127,6 +127,11 @@ yargs
         describe: 'Optional namespace for generated types [currently Swift and Scala-only]',
         type: 'string'
       },
+      "always-generate-variables": {
+        demand: false,
+        describe: "Always generate operation variables type declarations, even if there are no variables",
+        default: false
+      },
       "passthrough-custom-scalars": {
         demand: false,
         describe: "Don't attempt to map custom scalars [temporary option]",
@@ -188,6 +193,7 @@ yargs
         passthroughCustomScalars: argv["passthrough-custom-scalars"] || argv["custom-scalars-prefix"] !== '',
         customScalarsPrefix: argv["custom-scalars-prefix"] || '',
         addTypename: argv["add-typename"],
+        alwaysGenerateOperationVariables: argve['always-generate-variables'],
         namespace: argv.namespace,
         operationIdsPath: argv["operation-ids-path"],
         generateOperationIds: !!argv["operation-ids-path"],

--- a/src/compiler/index.ts
+++ b/src/compiler/index.ts
@@ -34,6 +34,7 @@ import {
 
 export interface CompilerOptions {
   addTypename?: boolean;
+  alwaysGenerateOperationVariables?: boolean;
   mergeInFieldsFromFragmentSpreads?: boolean;
   passthroughCustomScalars?: boolean;
   customScalarsPrefix?: string;

--- a/src/flow/codeGeneration.js
+++ b/src/flow/codeGeneration.js
@@ -136,7 +136,7 @@ export function interfaceVariablesDeclarationForOperation(
     source,
   }
 ) {
-  if (!variables || variables.length < 1) {
+  if (!(generator.context.options.alwaysGenerateOperationVariables || variables.length > 0)) {
     return null;
   }
   const interfaceName = `${interfaceNameFromOperation({operationName, operationType})}Variables`;

--- a/src/javascript/flow/__tests__/__snapshots__/codeGeneration.ts.snap
+++ b/src/javascript/flow/__tests__/__snapshots__/codeGeneration.ts.snap
@@ -277,6 +277,8 @@ export type CustomScalar = {
   commentTest: ?CustomScalar_commentTest
 };
 
+export type CustomScalarVariables = {};
+
 //==============================================================
 // START Enums and Input Objects
 // All enums and input objects are included in every output file

--- a/src/javascript/flow/__tests__/codeGeneration.ts
+++ b/src/javascript/flow/__tests__/codeGeneration.ts
@@ -15,7 +15,8 @@ function compile(
   source: string,
   options: CompilerOptions = {
     mergeInFieldsFromFragmentSpreads: true,
-    addTypename: true
+    addTypename: true,
+    alwaysGenerateOperationVariables: true,
   }
 ): CompilerContext {
   const document = parse(source);
@@ -269,7 +270,8 @@ describe('Flow codeGeneration', () => {
     const output = generateSource(
       compileToIR(miscSchema, document, {
         mergeInFieldsFromFragmentSpreads: true,
-        addTypename: true
+        addTypename: true,
+        alwaysGenerateOperationVariables: true,
       })
     );
 

--- a/src/javascript/flow/codeGeneration.ts
+++ b/src/javascript/flow/codeGeneration.ts
@@ -180,7 +180,7 @@ export class FlowAPIGenerator extends FlowGenerator {
     this.scopeStackPop();
 
     // Generate the variables interface if the operation has any variables
-    if (variables.length > 0) {
+    if (this.context.options.alwaysGenerateOperationVariables || variables.length > 0) {
       const interfaceName = operationName + 'Variables';
       this.scopeStackPush(interfaceName);
       this.printer.enqueue(this.exportDeclaration(

--- a/src/javascript/typescript/__tests__/__snapshots__/codeGeneration.ts.snap
+++ b/src/javascript/typescript/__tests__/__snapshots__/codeGeneration.ts.snap
@@ -309,6 +309,8 @@ export interface CustomScalar {
   commentTest: CustomScalar_commentTest | null;
 }
 
+export interface CustomScalarVariables {}
+
 //==============================================================
 // START Enums and Input Objects
 // All enums and input objects are included in every output file

--- a/src/javascript/typescript/__tests__/codeGeneration.ts
+++ b/src/javascript/typescript/__tests__/codeGeneration.ts
@@ -15,7 +15,8 @@ function compile(
   source: string,
   options: CompilerOptions = {
     mergeInFieldsFromFragmentSpreads: true,
-    addTypename: true
+    addTypename: true,
+    alwaysGenerateOperationVariables: true,
   }
 ): CompilerContext {
   const document = parse(source);
@@ -269,7 +270,8 @@ describe('Typescript codeGeneration', () => {
     const output = generateSource(
       compileToIR(miscSchema, document, {
         mergeInFieldsFromFragmentSpreads: true,
-        addTypename: true
+        addTypename: true,
+        alwaysGenerateOperationVariables: true,
       })
     );
 

--- a/src/javascript/typescript/codeGeneration.ts
+++ b/src/javascript/typescript/codeGeneration.ts
@@ -171,7 +171,7 @@ export class TypescriptAPIGenerator extends TypescriptGenerator {
     this.scopeStackPop();
 
     // Generate the variables interface if the operation has any variables
-    if (variables.length > 0) {
+    if (this.context.options.alwaysGenerateOperationVariables || variables.length > 0) {
       const interfaceName = operationName + 'Variables';
       this.scopeStackPush(interfaceName);
       this.printer.enqueue(this.exportDeclaration(

--- a/src/scala/codeGeneration.js
+++ b/src/scala/codeGeneration.js
@@ -140,7 +140,7 @@ export function classDeclarationForOperation(
 
     generator.printNewlineIfNeeded();
 
-    if (variables && variables.length > 0) {
+    if (generator.context.options.alwaysGenerateOperationVariables || variables.length > 0) {
       const properties = variables.map(({ name, type }) => {
         const propertyName = escapeIdentifierIfNeeded(name);
         const typeName = typeNameFromGraphQLType(generator.context, type);

--- a/src/swift/codeGeneration.ts
+++ b/src/swift/codeGeneration.ts
@@ -177,7 +177,7 @@ export class SwiftAPIGenerator extends SwiftGenerator<CompilerContext> {
 
         this.printNewlineIfNeeded();
 
-        if (variables && variables.length > 0) {
+        if (this.context.options.alwaysGenerateOperationVariables || variables.length > 0) {
           const properties = variables.map(({ name, type }) => {
             const typeName = this.helpers.typeNameFromGraphQLType(type);
             const isOptional = !(

--- a/src/typescript/codeGeneration.ts
+++ b/src/typescript/codeGeneration.ts
@@ -131,7 +131,7 @@ export function interfaceVariablesDeclarationForOperation(
     variables
   }: LegacyOperation
 ) {
-  if (!variables || variables.length < 1) {
+  if (!(generator.context.options.alwaysGenerateOperationVariables || variables.length > 0)) {
     return;
   }
   const interfaceName = `${interfaceNameFromOperation({ operationName, operationType })}Variables`;


### PR DESCRIPTION
Adds the `--always-generate-variables` cli flag and `alwaysGenerateOperationVariables` compiler option to generate `*Variables` definitions for all operations, regardless of whether a given operation require any variables. This facilitates consistent type imports per operation.

The option defaults to `false` for backwards compatibility, however has been enabled in some of the tests+snapshots to demonstrate that it's working.

Noticed during review here:
https://github.com/apollographql/apollo-codegen/pull/348#discussion_r160053935

> Omitting a definition prevents other code generators from consistently importing `*Query, *Variables` types for each operation without having to do the same kind of check.
> 
> It would be helpful in those cases to have a type generated for consistency, like:
> ```ts
> export type SomeStaticQueryVariables = {};
> ```