### PR TITLE
Fix the existence of the wrong schema judgment

### DIFF
--- a/src/downloadSchema.ts
+++ b/src/downloadSchema.ts
@@ -33,7 +33,7 @@ export default async function downloadSchema(url: string, outputPath: string, ad
     throw new ToolError(`Error while fetching introspection query result: ${error.message}`);
   }
 
-  if (result.errors) {
+  if (result.errors && result.errors.length > 0) {
     throw new ToolError(`Errors in introspection query result: ${result.errors}`);
   }
 


### PR DESCRIPTION
Like the following response of graphql server:
```json
{ 
  data: {},
  errors: [],
  extensions: null
}
```

The `errors` field may be an empty array.
