### PR TITLE
[Swift] Don't singularize non-list-typed field names

### DIFF
--- a/packages/apollo-codegen-swift/src/__tests__/__snapshots__/codeGeneration.ts.snap
+++ b/packages/apollo-codegen-swift/src/__tests__/__snapshots__/codeGeneration.ts.snap
@@ -1466,6 +1466,62 @@ exports[`Swift code generation #structDeclarationForSelectionSet() should genera
 }"
 `;
 
+exports[`Swift code generation #structDeclarationForSelectionSet() should not singularize non-list properties 1`] = `
+"public struct SingularDetails: GraphQLSelectionSet {
+  public static let possibleTypes = [\\"SingularlyDetailedType\\"]
+
+  public static let selections: [GraphQLSelection] = [
+    GraphQLField(\\"details\\", type: .nonNull(.object(Details.selections))),
+  ]
+
+  public private(set) var resultMap: ResultMap
+
+  public init(unsafeResultMap: ResultMap) {
+    self.resultMap = unsafeResultMap
+  }
+
+  public init(details: Details) {
+    self.init(unsafeResultMap: [\\"__typename\\": \\"SingularlyDetailedType\\", \\"details\\": details.resultMap])
+  }
+
+  public var details: Details {
+    get {
+      return Details(unsafeResultMap: resultMap[\\"details\\"]! as! ResultMap)
+    }
+    set {
+      resultMap.updateValue(newValue.resultMap, forKey: \\"details\\")
+    }
+  }
+
+  public struct Details: GraphQLSelectionSet {
+    public static let possibleTypes = [\\"SingularDetails\\"]
+
+    public static let selections: [GraphQLSelection] = [
+      GraphQLField(\\"details\\", type: .nonNull(.scalar(String.self))),
+    ]
+
+    public private(set) var resultMap: ResultMap
+
+    public init(unsafeResultMap: ResultMap) {
+      self.resultMap = unsafeResultMap
+    }
+
+    public init(details: String) {
+      self.init(unsafeResultMap: [\\"__typename\\": \\"SingularDetails\\", \\"details\\": details])
+    }
+
+    public var details: String {
+      get {
+        return resultMap[\\"details\\"]! as! String
+      }
+      set {
+        resultMap.updateValue(newValue, forKey: \\"details\\")
+      }
+    }
+  }
+}"
+`;
+
 exports[`Swift code generation #typeDeclarationForGraphQLType() should escape identifiers in cases of enum declaration for a GraphQLEnumType 1`] = `
 "public enum AlbumPrivacies: RawRepresentable, Equatable, Hashable, Apollo.JSONDecodable, Apollo.JSONEncodable {
   public typealias RawValue = String

--- a/packages/apollo-codegen-swift/src/__tests__/codeGeneration.ts
+++ b/packages/apollo-codegen-swift/src/__tests__/codeGeneration.ts
@@ -29,7 +29,7 @@ describe("Swift code generation", () => {
   let generator: SwiftAPIGenerator;
 
   beforeEach(() => {
-    generator = new SwiftAPIGenerator({});
+    generator = new SwiftAPIGenerator({ options: {} });
   });
 
   function compile(
@@ -555,6 +555,31 @@ describe("Swift code generation", () => {
 
       generator.structDeclarationForSelectionSet({
         structName: "Hero",
+        selectionSet
+      });
+
+      expect(generator.output).toMatchSnapshot();
+    });
+
+    it("should not singularize non-list properties", () => {
+      const { operations } = compile(
+        `
+        query SingularDetails {
+          singularlyDetailed {
+            details {
+              details
+            }
+          }
+        }
+      `,
+        miscSchema
+      );
+
+      const selectionSet = (operations["SingularDetails"].selectionSet
+        .selections[0] as Field).selectionSet as SelectionSet;
+
+      generator.structDeclarationForSelectionSet({
+        structName: "SingularDetails",
         selectionSet
       });
 

--- a/packages/apollo-codegen-swift/src/__tests__/codeGeneration.ts
+++ b/packages/apollo-codegen-swift/src/__tests__/codeGeneration.ts
@@ -7,8 +7,11 @@ import {
 } from "graphql";
 
 import { loadSchema } from "apollo-codegen-core/lib/loading";
-const schema = loadSchema(
+const starwarsSchema = loadSchema(
   require.resolve("../../../common-test/fixtures/starwars/schema.json")
+);
+const miscSchema = loadSchema(
+  require.resolve("../../../common-test/fixtures/misc/schema.json")
 );
 
 import {
@@ -31,6 +34,7 @@ describe("Swift code generation", () => {
 
   function compile(
     source: string,
+    schema: GraphQLSchema = starwarsSchema,
     options: CompilerOptions = { mergeInFieldsFromFragmentSpreads: true }
   ): CompilerContext {
     const document = parse(source);
@@ -137,6 +141,7 @@ describe("Swift code generation", () => {
           name
         }
       `,
+        starwarsSchema,
         { generateOperationIds: true, mergeInFieldsFromFragmentSpreads: true }
       );
 
@@ -241,7 +246,7 @@ describe("Swift code generation", () => {
         generator.propertyAssignmentForField({
           responseKey: "response_key",
           propertyName: "propertyName",
-          type: schema.getType("Droid")
+          type: starwarsSchema.getType("Droid")
         })
       ).toBe(
         '"response_key": propertyName.flatMap { (value: Droid) -> ResultMap in value.resultMap }'
@@ -253,7 +258,7 @@ describe("Swift code generation", () => {
         generator.propertyAssignmentForField({
           responseKey: "response_key",
           propertyName: "propertyName",
-          type: new GraphQLNonNull(schema.getType("Droid"))
+          type: new GraphQLNonNull(starwarsSchema.getType("Droid"))
         })
       ).toBe('"response_key": propertyName.resultMap');
     });
@@ -263,7 +268,7 @@ describe("Swift code generation", () => {
         generator.propertyAssignmentForField({
           responseKey: "response_key",
           propertyName: "propertyName",
-          type: new GraphQLList(schema.getType("Droid"))
+          type: new GraphQLList(starwarsSchema.getType("Droid"))
         })
       ).toBe(
         '"response_key": propertyName.flatMap { (value: [Droid?]) -> [ResultMap?] in value.map { (value: Droid?) -> ResultMap? in value.flatMap { (value: Droid) -> ResultMap in value.resultMap } } }'
@@ -275,7 +280,9 @@ describe("Swift code generation", () => {
         generator.propertyAssignmentForField({
           responseKey: "response_key",
           propertyName: "propertyName",
-          type: new GraphQLList(new GraphQLNonNull(schema.getType("Droid")))
+          type: new GraphQLList(
+            new GraphQLNonNull(starwarsSchema.getType("Droid"))
+          )
         })
       ).toBe(
         '"response_key": propertyName.flatMap { (value: [Droid]) -> [ResultMap] in value.map { (value: Droid) -> ResultMap in value.resultMap } }'
@@ -287,7 +294,9 @@ describe("Swift code generation", () => {
         generator.propertyAssignmentForField({
           responseKey: "response_key",
           propertyName: "propertyName",
-          type: new GraphQLNonNull(new GraphQLList(schema.getType("Droid")))
+          type: new GraphQLNonNull(
+            new GraphQLList(starwarsSchema.getType("Droid"))
+          )
         })
       ).toBe(
         '"response_key": propertyName.map { (value: Droid?) -> ResultMap? in value.flatMap { (value: Droid) -> ResultMap in value.resultMap } }'
@@ -300,7 +309,7 @@ describe("Swift code generation", () => {
           responseKey: "response_key",
           propertyName: "propertyName",
           type: new GraphQLNonNull(
-            new GraphQLList(new GraphQLNonNull(schema.getType("Droid")))
+            new GraphQLList(new GraphQLNonNull(starwarsSchema.getType("Droid")))
           )
         })
       ).toBe(
@@ -555,7 +564,9 @@ describe("Swift code generation", () => {
 
   describe("#typeDeclarationForGraphQLType()", () => {
     it("should generate an enum declaration for a GraphQLEnumType", () => {
-      generator.typeDeclarationForGraphQLType(schema.getType("Episode"));
+      generator.typeDeclarationForGraphQLType(
+        starwarsSchema.getType("Episode")
+      );
 
       expect(generator.output).toMatchSnapshot();
     });
@@ -572,7 +583,9 @@ describe("Swift code generation", () => {
     });
 
     it("should generate a struct declaration for a GraphQLInputObjectType", () => {
-      generator.typeDeclarationForGraphQLType(schema.getType("ReviewInput"));
+      generator.typeDeclarationForGraphQLType(
+        starwarsSchema.getType("ReviewInput")
+      );
 
       expect(generator.output).toMatchSnapshot();
     });

--- a/packages/apollo-codegen-swift/src/codeGeneration.ts
+++ b/packages/apollo-codegen-swift/src/codeGeneration.ts
@@ -623,7 +623,7 @@ export class SwiftAPIGenerator extends SwiftGenerator<CompilerContext> {
     this.withinBlock(() => {
       if (isCompositeType(unmodifiedFieldType)) {
         const structName = escapeIdentifierIfNeeded(
-          this.helpers.structNameForPropertyName(propertyName)
+          this.helpers.structNameForPropertyName(propertyName, type)
         );
 
         if (isList(type)) {
@@ -805,7 +805,8 @@ export class SwiftAPIGenerator extends SwiftGenerator<CompilerContext> {
             const { name, alias, args, type } = selection;
             const responseKey = selection.alias || selection.name;
             const structName = this.helpers.structNameForPropertyName(
-              responseKey
+              responseKey,
+              type
             );
 
             this.printOnNewline(`GraphQLField(`);

--- a/packages/apollo-codegen-swift/src/helpers.ts
+++ b/packages/apollo-codegen-swift/src/helpers.ts
@@ -27,7 +27,10 @@ import {
   FragmentSpread,
   Argument
 } from "apollo-codegen-core/lib/compiler";
-import { isMetaFieldName } from "apollo-codegen-core/lib/utilities/graphql";
+import {
+  isList,
+  isMetaFieldName
+} from "apollo-codegen-core/lib/utilities/graphql";
 import { Variant } from "apollo-codegen-core/lib/compiler/visitors/typeCase";
 import { collectAndMergeFields } from "apollo-codegen-core/lib/compiler/visitors/collectAndMergeFields";
 
@@ -113,8 +116,11 @@ export class Helpers {
     return pascalCase(name);
   }
 
-  structNameForPropertyName(propertyName: string) {
-    return pascalCase(Inflector.singularize(propertyName));
+  structNameForPropertyName(propertyName: string, type: GraphQLType) {
+    if (isList(type)) {
+      propertyName = Inflector.singularize(propertyName);
+    }
+    return pascalCase(propertyName);
   }
 
   structNameForFragmentName(fragmentName: string) {
@@ -134,17 +140,16 @@ export class Helpers {
     namespace?: string
   ): Field & Property & Struct {
     const { responseKey, isConditional } = field;
+    let type = field.type;
 
     const propertyName = isMetaFieldName(responseKey)
       ? responseKey
       : camelCase(responseKey);
 
     const structName = join(
-      [namespace, this.structNameForPropertyName(responseKey)],
+      [namespace, this.structNameForPropertyName(responseKey, type)],
       "."
     );
-
-    let type = field.type;
 
     if (isConditional && type instanceof GraphQLNonNull) {
       type = type.ofType;

--- a/packages/common-test/fixtures/misc/schema.graphql
+++ b/packages/common-test/fixtures/misc/schema.graphql
@@ -73,6 +73,17 @@ input Duplicate {
 
 union UnionTestCase = PartialA | PartialB
 
+type SingularDetails {
+  details: String!
+}
+
+interface SingularlyDetailed {
+  details: SingularDetails!
+}
+type SingularlyDetailedType implements SingularlyDetailed {
+  details: SingularDetails!
+}
+
 type Query {
   misc: OddType
   commentTest: CommentTest
@@ -80,6 +91,7 @@ type Query {
   unionTest: UnionTestCase
   scalarTest: Boolean!
   nesting: Nesting!
+  singularlyDetailed: SingularlyDetailedType
 }
 
 type Mutation {

--- a/packages/common-test/fixtures/misc/schema.json
+++ b/packages/common-test/fixtures/misc/schema.json
@@ -86,6 +86,17 @@
           },
           "isDeprecated": false,
           "deprecationReason": null
+        }, {
+          "name": "singularlyDetailed",
+          "description": null,
+          "args": [],
+          "type": {
+            "kind": "OBJECT",
+            "name": "SingularlyDetailedType",
+            "ofType": null
+          },
+          "isDeprecated": false,
+          "deprecationReason": null
         }],
         "inputFields": null,
         "interfaces": [],
@@ -388,6 +399,86 @@
                 "name": "EnumCommentTestCase",
                 "ofType": null
               }
+            }
+          },
+          "isDeprecated": false,
+          "deprecationReason": null
+        }],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      }, {
+        "kind": "OBJECT",
+        "name": "SingularlyDetailedType",
+        "description": null,
+        "fields": [{
+          "name": "details",
+          "description": null,
+          "args": [],
+          "type": {
+            "kind": "NON_NULL",
+            "name": null,
+            "ofType": {
+              "kind": "OBJECT",
+              "name": "SingularDetails",
+              "ofType": null
+            }
+          },
+          "isDeprecated": false,
+          "deprecationReason": null
+        }],
+        "inputFields": null,
+        "interfaces": [{
+          "kind": "INTERFACE",
+          "name": "SingularlyDetailed",
+          "ofType": null
+        }],
+        "enumValues": null,
+        "possibleTypes": null
+      }, {
+        "kind": "INTERFACE",
+        "name": "SingularlyDetailed",
+        "description": null,
+        "fields": [{
+          "name": "details",
+          "description": null,
+          "args": [],
+          "type": {
+            "kind": "NON_NULL",
+            "name": null,
+            "ofType": {
+              "kind": "OBJECT",
+              "name": "SingularDetails",
+              "ofType": null
+            }
+          },
+          "isDeprecated": false,
+          "deprecationReason": null
+        }],
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": [{
+          "kind": "OBJECT",
+          "name": "SingularlyDetailedType",
+          "ofType": null
+        }]
+      }, {
+        "kind": "OBJECT",
+        "name": "SingularDetails",
+        "description": null,
+        "fields": [{
+          "name": "details",
+          "description": null,
+          "args": [],
+          "type": {
+            "kind": "NON_NULL",
+            "name": null,
+            "ofType": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
             }
           },
           "isDeprecated": false,


### PR DESCRIPTION
<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] has-reproduction
- [ ] feature
- [ ] blocking
- [ ] good first review

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->

The impetus for this request is a field named `sys` of remote type `Sys`, which gets turned into a struct named `Sy` because its name gets singularised.
This _may_ result in source-incompatibility, but in a good direction?