### PR TITLE
[flow] De-duplicate common types by moving them to a global file when option is set

### DIFF
--- a/packages/apollo/README.md
+++ b/packages/apollo/README.md
@@ -72,6 +72,7 @@ OPTIONS
 
   --globalTypesFile=globalTypesFile          By default, TypeScript will put a file named "globalTypes.ts" inside the
                                              "output" directory. Set "globalTypesFile" to specify a different path.
+                                             Similarly, Flow will put common types in a global file, only if this option is set.
 
   --key=key                                  The API key for the Apollo Engine service
 

--- a/packages/apollo/src/commands/codegen/__tests__/__snapshots__/generate.test.ts.snap
+++ b/packages/apollo/src/commands/codegen/__tests__/__snapshots__/generate.test.ts.snap
@@ -491,6 +491,42 @@ export interface SimpleQuery {
 "
 `;
 
+exports[`successful codegen writes Flow global types to a custom path when globalTypesFile is set 1`] = `
+"/* tslint:disable */
+// This file was automatically generated and should not be edited.
+
+import { SomeEnum } from \\"./../../__foo__/bar.flow.js\\";
+
+// ====================================================
+// GraphQL query operation: SimpleQuery
+// ====================================================
+
+export interface SimpleQuery {
+  hello: string;
+  someEnum: SomeEnum;
+}
+"
+`;
+
+exports[`successful codegen writes Flow global types to a custom path when globalTypesFile is set 2`] = `
+"/* tslint:disable */
+// This file was automatically generated and should not be edited.
+
+//==============================================================
+// START Enums and Input Objects
+//==============================================================
+
+export enum SomeEnum {
+  bar = \\"bar\\",
+  foo = \\"foo\\",
+}
+
+//==============================================================
+// END Enums and Input Objects
+//==============================================================
+"
+`;
+
 exports[`successful codegen writes Flow types into a __generated__ directory next to sources when no output is set 1`] = `
 "
 

--- a/packages/apollo/src/commands/codegen/__tests__/generate.test.ts
+++ b/packages/apollo/src/commands/codegen/__tests__/generate.test.ts
@@ -505,6 +505,41 @@ describe("successful codegen", () => {
     .do(() => {
       vol.fromJSON({
         "schema.json": JSON.stringify(fullSchema.__schema),
+        "directory/component.tsx": `
+          gql\`
+            query SimpleQuery {
+              hello
+              someEnum
+            }
+          \`;
+        `
+      });
+    })
+    .command([
+      "codegen:generate",
+      "--schema=schema.json",
+      "--queries=**/*.tsx",
+      "--target=typescript",
+      "--globalTypesFile=__foo__/bar.flow.js"
+    ])
+    .it(
+      "writes Flow global types to a custom path when globalTypesFile is set",
+      () => {
+        expect(
+          mockFS
+            .readFileSync("directory/__generated__/SimpleQuery.ts")
+            .toString()
+        ).toMatchSnapshot();
+        expect(
+          mockFS.readFileSync("__foo__/bar.flow.js").toString()
+        ).toMatchSnapshot();
+      }
+    );
+
+  test
+    .do(() => {
+      vol.fromJSON({
+        "schema.json": JSON.stringify(fullSchema.__schema),
         "directory/component.jsx": `
           gql\`
             query SimpleQuery {

--- a/packages/apollo/src/commands/codegen/generate.ts
+++ b/packages/apollo/src/commands/codegen/generate.ts
@@ -97,7 +97,7 @@ export default class Generate extends Command {
     }),
     globalTypesFile: flags.string({
       description:
-        'By default, TypeScript will put a file named "globalTypes.ts" inside the "output" directory. Set "globalTypesFile" to specify a different path.'
+        'By default, TypeScript will put a file named "globalTypes.ts" inside the "output" directory. Set "globalTypesFile" to specify a different path. Similarly, Flow will put common types in a global file, only if this option is set.'
     }),
     watch: flags.boolean({
       description: "Watch the query files to auto-generate on changes."

--- a/packages/apollo/src/generate.ts
+++ b/packages/apollo/src/generate.ts
@@ -94,6 +94,16 @@ export default function generate(
     } = {};
 
     if (nextToSources) {
+      if (options.globalTypesFile) {
+        const globalTypesDir = path.dirname(options.globalTypesFile);
+        if (!fs.existsSync(globalTypesDir)) {
+          fs.mkdirSync(globalTypesDir);
+        }
+        outFiles[options.globalTypesFile] = {
+          output: common
+        };
+      }
+
       generatedFiles.forEach(({ sourcePath, fileName, content }) => {
         const dir = path.join(path.dirname(sourcePath), outputPath);
 
@@ -102,7 +112,9 @@ export default function generate(
         }
 
         outFiles[path.join(dir, fileName)] = {
-          output: content.fileContents + common
+          output: options.globalTypesFile
+            ? content.fileContents
+            : content.fileContents + common
         };
       });
 


### PR DESCRIPTION
Flow now respects the `--globalTypesFile ` option, and writes common types (inputs, enums) to the specified file.
This is opt-in behavior, so I don't believe there are any breaking changes