### PR TITLE
Make operationDefinition on GraphQLOperation static.

### DIFF
--- a/packages/apollo-codegen-swift/src/__tests__/__snapshots__/codeGeneration.ts.snap
+++ b/packages/apollo-codegen-swift/src/__tests__/__snapshots__/codeGeneration.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`Swift code generation #classDeclarationForOperation() should generate a class declaration for a mutation with variables 1`] = `
 "public final class CreateReviewMutation: GraphQLMutation {
-  public let operationDefinition =
+  public static let operationDefinition =
     \\"mutation CreateReview($episode: Episode) {\\\\n  createReview(episode: $episode, review: {stars: 5, commentary: \\\\\\"Wow!\\\\\\"}) {\\\\n    stars\\\\n    commentary\\\\n  }\\\\n}\\"
 
   public var episode: Episode?
@@ -85,10 +85,10 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
 
 exports[`Swift code generation #classDeclarationForOperation() should generate a class declaration for a query with a fragment spread nested in an inline fragment 1`] = `
 "public final class HeroQuery: GraphQLQuery {
-  public let operationDefinition =
+  public static let operationDefinition =
     \\"query Hero {\\\\n  hero {\\\\n    ... on Droid {\\\\n      ...HeroDetails\\\\n    }\\\\n  }\\\\n}\\"
 
-  public var queryDocument: String { return operationDefinition.appending(HeroDetails.fragmentDefinition) }
+  public var queryDocument: String { return HeroQuery.operationDefinition.appending(HeroDetails.fragmentDefinition) }
 
   public init() {
   }
@@ -215,10 +215,10 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
 
 exports[`Swift code generation #classDeclarationForOperation() should generate a class declaration for a query with conditional fragment spreads 1`] = `
 "public final class HeroQuery: GraphQLQuery {
-  public let operationDefinition =
+  public static let operationDefinition =
     \\"query Hero {\\\\n  hero {\\\\n    ...DroidDetails\\\\n  }\\\\n}\\"
 
-  public var queryDocument: String { return operationDefinition.appending(DroidDetails.fragmentDefinition) }
+  public var queryDocument: String { return HeroQuery.operationDefinition.appending(DroidDetails.fragmentDefinition) }
 
   public init() {
   }
@@ -373,10 +373,10 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
 
 exports[`Swift code generation #classDeclarationForOperation() should generate a class declaration for a query with fragment spreads 1`] = `
 "public final class HeroQuery: GraphQLQuery {
-  public let operationDefinition =
+  public static let operationDefinition =
     \\"query Hero {\\\\n  hero {\\\\n    ...HeroDetails\\\\n  }\\\\n}\\"
 
-  public var queryDocument: String { return operationDefinition.appending(HeroDetails.fragmentDefinition) }
+  public var queryDocument: String { return HeroQuery.operationDefinition.appending(HeroDetails.fragmentDefinition) }
 
   public init() {
   }
@@ -470,7 +470,7 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
 
 exports[`Swift code generation #classDeclarationForOperation() should generate a class declaration for a query with variables 1`] = `
 "public final class HeroNameQuery: GraphQLQuery {
-  public let operationDefinition =
+  public static let operationDefinition =
     \\"query HeroName($episode: Episode) {\\\\n  hero(episode: $episode) {\\\\n    name\\\\n  }\\\\n}\\"
 
   public var episode: Episode?
@@ -546,12 +546,12 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
 
 exports[`Swift code generation #classDeclarationForOperation() should generate a class declaration with an operationIdentifier property when generateOperationIds is specified 1`] = `
 "public final class HeroQuery: GraphQLQuery {
-  public let operationDefinition =
+  public static let operationDefinition =
     \\"query Hero {\\\\n  hero {\\\\n    ...HeroDetails\\\\n  }\\\\n}\\"
 
   public let operationIdentifier: String? = \\"90d0d674eb6a7b33776f63200d6cec3d09f881247c360a2ac9a29037a02210c4\\"
 
-  public var queryDocument: String { return operationDefinition.appending(HeroDetails.fragmentDefinition) }
+  public var queryDocument: String { return HeroQuery.operationDefinition.appending(HeroDetails.fragmentDefinition) }
 
   public init() {
   }

--- a/packages/apollo-codegen-swift/src/__tests__/__snapshots__/codeGeneration.ts.snap
+++ b/packages/apollo-codegen-swift/src/__tests__/__snapshots__/codeGeneration.ts.snap
@@ -1467,7 +1467,7 @@ exports[`Swift code generation #structDeclarationForSelectionSet() should genera
 `;
 
 exports[`Swift code generation #typeDeclarationForGraphQLType() should escape identifiers in cases of enum declaration for a GraphQLEnumType 1`] = `
-"public enum AlbumPrivacies: RawRepresentable, Equatable, Apollo.JSONDecodable, Apollo.JSONEncodable {
+"public enum AlbumPrivacies: RawRepresentable, Equatable, Hashable, Apollo.JSONDecodable, Apollo.JSONEncodable {
   public typealias RawValue = String
   case \`public\`
   case \`private\`
@@ -1544,7 +1544,7 @@ public struct ReviewInput: GraphQLMapConvertible {
 
 exports[`Swift code generation #typeDeclarationForGraphQLType() should generate an enum declaration for a GraphQLEnumType 1`] = `
 "/// The episodes in the Star Wars trilogy
-public enum Episode: RawRepresentable, Equatable, Apollo.JSONDecodable, Apollo.JSONEncodable {
+public enum Episode: RawRepresentable, Equatable, Hashable, Apollo.JSONDecodable, Apollo.JSONEncodable {
   public typealias RawValue = String
   /// Star Wars Episode IV: A New Hope, released in 1977.
   case newhope

--- a/packages/apollo-codegen-swift/src/codeGeneration.ts
+++ b/packages/apollo-codegen-swift/src/codeGeneration.ts
@@ -890,7 +890,7 @@ export class SwiftAPIGenerator extends SwiftGenerator<CompilerContext> {
     this.printNewlineIfNeeded();
     this.comment(description || undefined);
     this.printOnNewline(
-      `public enum ${name}: RawRepresentable, Equatable, Apollo.JSONDecodable, Apollo.JSONEncodable`
+      `public enum ${name}: RawRepresentable, Equatable, Hashable, Apollo.JSONDecodable, Apollo.JSONEncodable`
     );
     this.withinBlock(() => {
       this.printOnNewline("public typealias RawValue = String");

--- a/packages/apollo-codegen-swift/src/codeGeneration.ts
+++ b/packages/apollo-codegen-swift/src/codeGeneration.ts
@@ -146,7 +146,7 @@ export class SwiftAPIGenerator extends SwiftGenerator<CompilerContext> {
       selectionSet
     } = operation;
 
-    let className;
+    let className: string;
     let protocol;
 
     switch (operationType) {
@@ -176,7 +176,7 @@ export class SwiftAPIGenerator extends SwiftGenerator<CompilerContext> {
       },
       () => {
         if (source) {
-          this.printOnNewline("public let operationDefinition =");
+          this.printOnNewline("public static let operationDefinition =");
           this.withIndent(() => {
             this.multilineString(source);
           });
@@ -203,7 +203,7 @@ export class SwiftAPIGenerator extends SwiftGenerator<CompilerContext> {
         if (fragmentsReferenced.size > 0) {
           this.printNewlineIfNeeded();
           this.printOnNewline(
-            "public var queryDocument: String { return operationDefinition"
+            `public var queryDocument: String { return ${className}.operationDefinition`
           );
           fragmentsReferenced.forEach(fragmentName => {
             this.print(

--- a/packages/apollo/src/commands/codegen/__tests__/__snapshots__/generate.test.ts.snap
+++ b/packages/apollo/src/commands/codegen/__tests__/__snapshots__/generate.test.ts.snap
@@ -28,7 +28,7 @@ import Apollo",
 import Apollo
 
 public final class OtherQueryQuery: GraphQLQuery {
-  public let operationDefinition =
+  public static let operationDefinition =
     \\"query OtherQuery {\\\\n  hello\\\\n}\\"
 
   public init() {
@@ -152,7 +152,7 @@ exports[`successful codegen infers Swift target and writes types 1`] = `
 import Apollo
 
 public final class SimpleQueryQuery: GraphQLQuery {
-  public let operationDefinition =
+  public static let operationDefinition =
     \\"query SimpleQuery {\\\\n  hello\\\\n}\\"
 
   public init() {
@@ -193,7 +193,7 @@ exports[`successful codegen infers Swift target and writes types when schema is 
 import Apollo
 
 public final class SimpleQueryQuery: GraphQLQuery {
-  public let operationDefinition =
+  public static let operationDefinition =
     \\"query SimpleQuery {\\\\n  hello\\\\n}\\"
 
   public init() {
@@ -234,7 +234,7 @@ exports[`successful codegen infers Swift target and writes types when schema is 
 import Apollo
 
 public final class SimpleQueryQuery: GraphQLQuery {
-  public let operationDefinition =
+  public static let operationDefinition =
     \\"query SimpleQuery {\\\\n  hello\\\\n}\\"
 
   public init() {
@@ -275,7 +275,7 @@ exports[`successful codegen infers Swift target and writes types when schema is 
 import Apollo
 
 public final class SimpleQueryQuery: GraphQLQuery {
-  public let operationDefinition =
+  public static let operationDefinition =
     \\"query SimpleQuery {\\\\n  hello\\\\n}\\"
 
   public init() {


### PR DESCRIPTION
# What

This makes `operationDefinition` on `GraphQLOperation` `static`. 

# Why

Since it is already a constant, there are a couple reasons why making it `static` is nice.

1. It's not allocated each time the class is instantiated.
1. It allows accessing the string outside of the context of an instance.

The latter is the main reason I'm making this PR. We were previously using `requestString` from the older `apollo-codegen` to detect changes in the query in order to invalidate local caches. Ignoring the fact that we could have a better way of determining that, I think this property _should_ be `static` anyway. 

# Problems

This requires a change in apollo-ios as well. Here's my PR -- https://github.com/apollographql/apollo-ios/pull/363