### PR TITLE
Add schema:print command

### DIFF
--- a/packages/apollo-codegen-core/src/localfs.ts
+++ b/packages/apollo-codegen-core/src/localfs.ts
@@ -1,4 +1,5 @@
-export const fs = require("fs");
+import * as fs from "fs";
+export { fs };
 
 export function withGlobalFS<T>(thunk: () => T): T {
   return thunk();

--- a/packages/apollo/src/commands/schema/print.ts
+++ b/packages/apollo/src/commands/schema/print.ts
@@ -1,0 +1,49 @@
+import { Command, flags } from "@oclif/command";
+import { fs } from "apollo-codegen-core/lib/localfs";
+import { promisify } from "util";
+
+import { printSchema, buildClientSchema } from "graphql";
+
+export default class SchemaDownload extends Command {
+  static description =
+    "Prints a schema from a json file containing an introspection result.";
+
+  static flags = {
+    help: flags.help({
+      char: "h",
+      description: "Show command help"
+    })
+  };
+
+  static args = [
+    {
+      name: "schema",
+      required: true,
+      description: "Path to your schema in json form",
+      default: "./schema.json"
+    }
+  ];
+
+  async run() {
+    const { args } = this.parse(SchemaDownload);
+
+    let schemaString;
+    try {
+      schemaString = (await promisify(fs.readFile)(args.schema)).toString();
+    } catch (error) {
+      this.error("File(" + args.schema + ") read failed with ", error);
+      return;
+    }
+
+    let schema;
+    try {
+      schema = JSON.parse(schemaString);
+    } catch (error) {
+      this.error("schema loaded kis invalid json", error);
+      return;
+    }
+
+    const executableSchema = buildClientSchema(schema);
+    this.log(printSchema(executableSchema));
+  }
+}

--- a/packages/apollo/src/generate.ts
+++ b/packages/apollo/src/generate.ts
@@ -244,7 +244,7 @@ function writeOperationIdsMap(context: CompilerContext) {
       };
     });
   fs.writeFileSync(
-    context.options.operationIdsPath,
+    context.options.operationIdsPath!,
     JSON.stringify(operationIdsMap, null, 2)
   );
 }


### PR DESCRIPTION
The command receives a json file input and prints the schema

Future extensions could include printing the schema directly from Engine or adding flags to limit the output to certain fields/types/remove comments. 

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [x] feature
- [ ] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->