### PR TITLE
Fix local schema fetch

### DIFF
--- a/packages/apollo/src/commands/schema/publish.ts
+++ b/packages/apollo/src/commands/schema/publish.ts
@@ -71,7 +71,7 @@ export default class SchemaPublish extends Command {
             );
           }
 
-          ctx.schema = await fetchSchema(ctx.currentSchema.endpoint).catch(
+          ctx.schema = await fetchSchema(ctx.currentSchema.schema || ctx.currentSchema.endpoint).catch(
             this.error
           );
         }


### PR DESCRIPTION
<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [x] feature
- [x] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->

As per the docs, the schema is only supposed to be fetched from the remote endpoint if no local schema is provided (_" // if not defined the an introspection query will be run"_). However, the `schema` property which holds the path to the local schema is never passed to `fetchSchema`.

Since Apollo CLI will always use the endpoint, it's impossible to provide a local schema using the config file. My endpoint requires authentication, so I have to provide a local file.