### PR TITLE
Warn on GraphQL parser exceptions

### DIFF
--- a/packages/apollo-codegen-core/src/loading.ts
+++ b/packages/apollo-codegen-core/src/loading.ts
@@ -186,7 +186,11 @@ export function loadQueryDocuments(
     .map(source => {
       try {
         return parse(source!);
-      } catch {
+      } catch (e) {
+        const name = (source && source.name) || "";
+        console.warn(stripIndents`
+        Warning: error parsing GraphQL file ${name}
+        ${e.stack}`);
         return null;
       }
     })


### PR DESCRIPTION
When [GraphQL](https://github.com/graphql/graphql-js/blob/master/src/language/parser.js#L124) `parse` fails to parse file(s) errors are silently ignored.

Was having an issue with a whitespace character in one of our `.graphql` files which was rather difficult to trace. This character is added as a result of saving the file in XCode, so it'd be a common use case.

**Example:**

```
Warning: error parsing GraphQL file "Queries/Enrollments.graphql"
Syntax Error: Cannot contain the invalid character "\u0010".

Queries/Enrollments.graphql (6:1)
5: }
6: 
^
7: 

at syntaxError (/../code/apollo-cli/node_modules/graphql/error/syntaxError.js:24:10)
at readToken (/../code/apollo-cli/node_modules/graphql/language/lexer.js:174:34)
at Object.lookahead (/../code/apollo-cli/node_modules/graphql/language/lexer.js:61:43)
at Object.advanceLexer [as advance] (/../code/apollo-cli/node_modules/graphql/language/lexer.js:52:33)
at skip (/../code/apollo-cli/node_modules/graphql/language/parser.js:1284:11)
at many (/../code/apollo-cli/node_modules/graphql/language/parser.js:1349:11)
at parseSelectionSet (/../code/apollo-cli/node_modules/graphql/language/parser.js:272:17)
at parseOperationDefinition (/../code/apollo-cli/node_modules/graphql/language/parser.js:209:19)
at parseExecutableDefinition (/../code/apollo-cli/node_modules/graphql/language/parser.js:166:16)
at parseDefinition (/../code/apollo-cli/node_modules/graphql/language/parser.js:132:16)
```

The stacktrace isn't useful, but `e.message` does not contain the filename, line number and preview.

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->