### PR TITLE
VSCode Loading State / Error Messages (on init)

### DIFF
--- a/packages/apollo-language-server/package.json
+++ b/packages/apollo-language-server/package.json
@@ -18,8 +18,7 @@
     "install-dependencies-into-extension": "yarn install --no-lockfile --force --production --modules-folder ../apollo-vscode/server/node_modules",
     "prebuild": "npm run clean",
     "build": "npm run install-dependencies-into-extension && tsc -p .",
-    "watch": "npm run install-dependencies-into-extension && tsc -w -p .",
-    "watchOnly": "tsc -w -p .",
+    "watch": "tsc -w",
     "prepare": "npm run build"
   },
   "engines": {

--- a/packages/apollo-language-server/src/languageProvider.ts
+++ b/packages/apollo-language-server/src/languageProvider.ts
@@ -385,7 +385,7 @@ ${argumentNode.description}
     const project = this.workspace.projectForFile(uri);
     if (!project) return [];
 
-    await project.readyPromise;
+    await project.whenInitialized;
 
     const docsAndSets = project.documentsAt(uri);
     if (!docsAndSets) return [];

--- a/packages/apollo-language-server/src/loadingHandler.ts
+++ b/packages/apollo-language-server/src/loadingHandler.ts
@@ -50,6 +50,6 @@ export class LoadingHandler {
     }
   }
   showError(message: string) {
-    this.connection.window.showErrorMessage(message);
+    this.connection.window.showErrorMessage(`Apollo: ${message}`);
   }
 }

--- a/packages/apollo-language-server/src/project.ts
+++ b/packages/apollo-language-server/src/project.ts
@@ -174,7 +174,9 @@ export class GraphQLProject {
         })
         .catch(() => {
           this.loadingHandler.showError(
-            `Error loading Engine data for ${this.config.name}`
+            `Error loading Engine data for ${
+              this.config.name
+            }. Please confirm your Engine API key is valid.`
           );
         })
     );

--- a/packages/apollo-language-server/src/project.ts
+++ b/packages/apollo-language-server/src/project.ts
@@ -160,7 +160,7 @@ export class GraphQLProject {
 
   async initializeProject() {
     await this.loadingHandler.handle(
-      "Apollo: Loading Engine stats",
+      "Apollo: Initializing extension...",
       this.loadEngineData()
         .then(async () => {
           this._onSchemaTags && this._onSchemaTags(this.schemaTags);

--- a/packages/apollo-language-server/src/server.ts
+++ b/packages/apollo-language-server/src/server.ts
@@ -116,7 +116,8 @@ connection.onDidChangeWatchedFiles(params => {
     const filePath = Uri.parse(change.uri).fsPath;
     if (
       filePath.endsWith("apollo.config.js") ||
-      filePath.endsWith("package.json")
+      filePath.endsWith("package.json") ||
+      filePath.endsWith(".env")
     ) {
       const projectForConfig = Array.from(
         workspace.projectsByFolderUri.values()

--- a/packages/apollo-language-server/src/workspace.ts
+++ b/packages/apollo-language-server/src/workspace.ts
@@ -55,17 +55,14 @@ export class GraphQLWorkspace {
 
     const projectConfigs = Array.from(apolloConfigFolders).flatMap(
       configFolder => {
-        return this.loadingHandler.handleSync(
-          `Loading Apollo Config in folder ${configFolder}`,
-          () => {
-            try {
-              return [findAndLoadConfig(configFolder, false, true)];
-            } catch (e) {
-              console.error(e);
-              return [];
-            }
-          }
-        );
+        try {
+          return [findAndLoadConfig(configFolder, false, true)];
+        } catch (e) {
+          this.loadingHandler.showError(
+            `Failed to load apollo.config.js in folder ${configFolder}`
+          );
+          return [];
+        }
       }
     );
 

--- a/packages/apollo-vscode/src/extension.ts
+++ b/packages/apollo-vscode/src/extension.ts
@@ -1,5 +1,5 @@
 import { join, resolve } from "path";
-import { readFileSync } from "fs";
+import { readFileSync, existsSync } from "fs";
 import {
   window,
   workspace,
@@ -23,13 +23,12 @@ import StatusBar from "./statusBar";
 export const getIdFromKey = (key: string) => key.split(":")[1];
 
 // Parse the .env file and load the ENGINE_API_KEY into process.env
-const env: { [key: string]: string } = workspace.rootPath
-  ? require("dotenv").parse(readFileSync(resolve(workspace.rootPath, ".env")))
-  : {};
-
-const key = "ENGINE_API_KEY";
-if (env[key]) {
-  process.env[key] = env[key];
+const envPath = workspace.rootPath ? resolve(workspace.rootPath, ".env") : null;
+if (envPath && existsSync(envPath)) {
+  const env: { [key: string]: string } = workspace.rootPath
+    ? require("dotenv").parse(readFileSync(envPath))
+    : {};
+  process.env["ENGINE_API_KEY"] = env["ENGINE_API_KEY"];
 }
 
 function sideViewColumn() {

--- a/packages/apollo-vscode/src/statusBar.ts
+++ b/packages/apollo-vscode/src/statusBar.ts
@@ -17,7 +17,16 @@ export default class ApolloStatusBar {
     }
 
     this.statusBarItem.text = "Apollo GraphQL $(rocket)";
-    this.statusBarItem.show();
+  }
+
+  public showWarningState(tooltip?: string) {
+    if (!window.activeTextEditor) {
+      this.statusBarItem.hide();
+      return;
+    }
+
+    this.statusBarItem.tooltip = tooltip;
+    this.statusBarItem.text = "Apollo GraphQL $(issue-opened)";
   }
 
   public dispose() {


### PR DESCRIPTION
This PR improves messaging to the user while the extension boots up.

Note: the extension doesn't activate w/o an `apollo.config.js` file present, so assume one exists.

* Warn user if no .env file is found
* Warn user if no ENGINE_API_KEY is specified (when .env file is present)
* Only display one message while initial loading promises resolve.

* Error specifically if extension fails to scan files
* Error specifically if engine stats fail to load.

All errors and warnings are actionable, but feel free to suggest improvements on the copy.