### PR TITLE
filter objects in getter to only include known typenames

### DIFF
--- a/packages/apollo-codegen-swift/src/__tests__/__snapshots__/codeGeneration.ts.snap
+++ b/packages/apollo-codegen-swift/src/__tests__/__snapshots__/codeGeneration.ts.snap
@@ -819,7 +819,9 @@ exports[`Swift code generation #structDeclarationForFragment() should generate a
   /// The friends of the character, or an empty list if they have none
   public var friends: [Friend?]? {
     get {
-      return (resultMap[\\"friends\\"] as? [ResultMap?]).flatMap { (value: [ResultMap?]) -> [Friend?] in value.map { (value: ResultMap?) -> Friend? in value.flatMap { (value: ResultMap) -> Friend in Friend(unsafeResultMap: value) } } }
+      return (resultMap[\\"friends\\"] as? [ResultMap?]).flatMap { (value: [ResultMap?]) -> [Friend?] in value.map { (value: ResultMap?) -> Friend? in value.flatMap { (value: ResultMap) -> Friend in Friend(unsafeResultMap: value) } } }.filter({
+        Friend.possibleTypes.contains($0.__typename)
+      })
     }
     set {
       resultMap.updateValue(newValue.flatMap { (value: [Friend?]) -> [ResultMap?] in value.map { (value: Friend?) -> ResultMap? in value.flatMap { (value: Friend) -> ResultMap in value.resultMap } } }, forKey: \\"friends\\")
@@ -967,7 +969,9 @@ exports[`Swift code generation #structDeclarationForSelectionSet() should genera
   /// The friends of the character, or an empty list if they have none
   public var friends: [Friend?]? {
     get {
-      return (resultMap[\\"friends\\"] as? [ResultMap?]).flatMap { (value: [ResultMap?]) -> [Friend?] in value.map { (value: ResultMap?) -> Friend? in value.flatMap { (value: ResultMap) -> Friend in Friend(unsafeResultMap: value) } } }
+      return (resultMap[\\"friends\\"] as? [ResultMap?]).flatMap { (value: [ResultMap?]) -> [Friend?] in value.map { (value: ResultMap?) -> Friend? in value.flatMap { (value: ResultMap) -> Friend in Friend(unsafeResultMap: value) } } }.filter({
+        Friend.possibleTypes.contains($0.__typename)
+      })
     }
     set {
       resultMap.updateValue(newValue.flatMap { (value: [Friend?]) -> [ResultMap?] in value.map { (value: Friend?) -> ResultMap? in value.flatMap { (value: Friend) -> ResultMap in value.resultMap } } }, forKey: \\"friends\\")

--- a/packages/apollo-codegen-swift/src/codeGeneration.ts
+++ b/packages/apollo-codegen-swift/src/codeGeneration.ts
@@ -647,7 +647,15 @@ export class SwiftAPIGenerator extends SwiftGenerator<CompilerContext> {
                 expression,
                 "ResultMap",
                 structName
-              )}`
+              )}.filter`
+            );
+            this.withinBlock(
+              () =>
+                this.printOnNewline(
+                  `${structName}.possibleTypes.contains($0.__typename)`
+                ),
+              "({",
+              "})"
             );
           });
           this.printOnNewline("set");


### PR DESCRIPTION
This is a solution to the problem described here:

> We have generated a Swift API for a schema that includes an interface.
>
> When we now add an additional type that implements this interface to the server, the app crashes. This can of course be fixed by regenerating the api, but this doesn't help for apps already running on a user's device.
> https://github.com/apollographql/apollo-ios/issues/400

I'm not sure if this is the only place where this filtering has to be done, but this at least fixes it for our use case.

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->