### PR TITLE
fix: add missin dotenv dep

### DIFF
--- a/packages/apollo-language-server/package.json
+++ b/packages/apollo-language-server/package.json
@@ -1,4 +1,4 @@
-{
+"dotenv": "^6.1.0",{
   "name": "apollo-language-server",
   "description": "A language server for Apollo GraphQL projects",
   "version": "1.0.1",
@@ -31,6 +31,7 @@
     "await-to-js": "^2.0.1",
     "core-js": "^3.0.0-beta.3",
     "cosmiconfig": "^5.0.6",
+    "dotenv": "^6.1.0",
     "glob": "^7.1.3",
     "graphql": "^14.0.2",
     "graphql-tag": "^2.10.0",

--- a/packages/apollo-language-server/package.json
+++ b/packages/apollo-language-server/package.json
@@ -1,4 +1,4 @@
-"dotenv": "^6.1.0",{
+{
   "name": "apollo-language-server",
   "description": "A language server for Apollo GraphQL projects",
   "version": "1.0.1",


### PR DESCRIPTION
Should prevent this error:

```
Error: Cannot find module 'dotenv'
    at Object.exports.loadConfig (~/Projects/test-vue-cli-apollo/node_modules/apollo-language-server/lib/config.js:141:21)
```