### PR TITLE
Make sure writtenFiles is propagates

### DIFF
--- a/packages/apollo/src/commands/client/codegen.ts
+++ b/packages/apollo/src/commands/client/codegen.ts
@@ -174,7 +174,7 @@ export default class Generate extends ClientCommand {
                   kind: Kind.DOCUMENT,
                   definitions: [...operations, ...fragments]
                 };
-                generate(
+                return generate(
                   document,
                   schema,
                   typeof args.output === "string"


### PR DESCRIPTION
Currently whenever `client:codegen` is used the command outputs the following:

```
 ✔ Generating query files with 'typescript' target - wrote undefined files
```

`undefined` is because `writtenFiles` is `undefined`. `writtenFiles` is `undefined` because `write` doesn't return any value. `generate` returns the number of written files, so that should be returned in `write` as well.


<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [ ] docs
- [x] bug

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->