### PR TITLE
turn back on operation checks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,7 +78,7 @@ jobs:
             # This should cache the npm cache instead of node_modules, which is needed because
             # npm ci actually removes node_modules before installing to guarantee a clean slate.
             - ~/.npm
-      - run: ./packages/apollo/bin/run queries:check --queries="packages/apollo/src/operations/*" --key=$STAGING_API_KEY --engine=https://engine-staging-graphql.apollographql.com/api/graphql
+      - run: ./packages/apollo/bin/run client:check
 
 ignore_doc_branches: &ignore_doc_branches
   filters:

--- a/apollo.config.js
+++ b/apollo.config.js
@@ -1,7 +1,8 @@
 module.exports = {
   client: {
     name: "Apollo CLI",
-    service: "engine-api-prod"
+    service: "engine-api-prod",
+    includes: ["./packages/apollo-language-server/**/*.ts"]
   },
   engine: {
     frontend: "https://engine-staging.apollographql.com",


### PR DESCRIPTION
This PR re-enables operation validation against the pushed engine service