### PR TITLE
Prevent unnecessary failures in *:check

### DIFF
--- a/packages/apollo/src/commands/client/check.ts
+++ b/packages/apollo/src/commands/client/check.ts
@@ -49,8 +49,6 @@ export default class ClientCheck extends ClientCommand {
       ({ type }: Change) => type === ChangeType.FAILURE
     );
 
-    const exit = failures.length > 0 ? 1 : 0;
-
     const count = operations.length;
     this.log(`\n${count} operations extracted and validated`);
     if (changes.length === 0) {
@@ -66,6 +64,9 @@ export default class ClientCheck extends ClientCommand {
     });
     this.log("\n");
     // exit with failing status if we have failures
-    this.exit(exit);
+    if (failures.length > 0) {
+      this.exit();
+    }
+    return;
   }
 }

--- a/packages/apollo/src/commands/service/check.ts
+++ b/packages/apollo/src/commands/service/check.ts
@@ -50,8 +50,6 @@ export default class ServiceCheck extends ProjectCommand {
       ({ type }: Change) => type === ChangeType.FAILURE
     );
 
-    const exit = failures.length > 0 ? 1 : 0;
-
     if (changes.length === 0) {
       return this.log("\nNo changes present between schemas\n");
     }
@@ -65,6 +63,9 @@ export default class ServiceCheck extends ProjectCommand {
     });
     this.log("\n");
     // exit with failing status if we have failures
-    this.exit(exit);
+    if (failures.length > 0) {
+      this.exit();
+    }
+    return;
   }
 }


### PR DESCRIPTION
*:check currently calls this.exit() on success cases. This should only be called if there are failures, else
the script throws an error.

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->