### PR TITLE
Small bug fix: Correctly incorporate column offset in decorations

### DIFF
--- a/packages/apollo-language-server/src/__tests__/diagnostics.ts
+++ b/packages/apollo-language-server/src/__tests__/diagnostics.ts
@@ -45,6 +45,12 @@ const documentWithTypes = new GraphQLDocument(
       }
     }`)
 );
+const documentWithOffset = new GraphQLDocument(
+  new Source(`query QueryWithOffset { hero { nam } }`, "testDocument", {
+    line: 5,
+    column: 10
+  })
+);
 describe("Language server diagnostics", () => {
   describe("#collectExecutableDefinitionDiagnositics", () => {
     it("returns no diagnostics for a correct document", () => {
@@ -67,6 +73,14 @@ describe("Language server diagnostics", () => {
         documentWithTypes
       );
       expect(diagnostics.length).toEqual(0);
+    });
+    it("correctly offsets locations", () => {
+      const diagnostics = collectExecutableDefinitionDiagnositics(
+        schema,
+        documentWithOffset
+      );
+      expect(diagnostics.length).toEqual(1);
+      expect(diagnostics[0].range.start.character).toEqual(40);
     });
   });
 });

--- a/packages/apollo-language-server/src/utilities/source.ts
+++ b/packages/apollo-language-server/src/utilities/source.ts
@@ -62,7 +62,11 @@ export function positionFromSourceLocation(
     (source.locationOffset ? source.locationOffset.line - 1 : 0) +
       location.line -
       1,
-    location.column - 1
+    (source.locationOffset && location.line === 1
+      ? source.locationOffset.column - 1
+      : 0) +
+      location.column -
+      1
   );
 }
 


### PR DESCRIPTION
This fixes the case where error markers are placed incorrectly when an error refers to a range in the first line of inlined GraphQL.

Previously error locations (and thus editor decorations) would disregard the column offset. Error were reported like this:

```
foo = gql`query Foo { bar }`
            ^^^
```

This change makes the location add the column offset it referring to the first line:

```
foo = gql`query Foo { bar }`
                      ^^^
```

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->