### PR TITLE
New Feature: Add Python document extractor to the language server

### DIFF
--- a/packages/apollo-language-server/src/project/base.ts
+++ b/packages/apollo-language-server/src/project/base.ts
@@ -37,7 +37,8 @@ const fileAssociations: { [extension: string]: string } = {
   ".js": "javascript",
   ".ts": "typescript",
   ".jsx": "javascriptreact",
-  ".tsx": "typescriptreact"
+  ".tsx": "typescriptreact",
+  ".py": "python"
 };
 
 export interface GraphQLProjectConfig {


### PR DESCRIPTION
Python does not have tagged templates but it's safe to assume that the user will use a function named `gql()` to wrap document literals in code.

There is currently no GitHub issue tracking this feature, it was however discussed on the Apollo Slack.

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [x] feature
- [ ] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->