### PR TITLE
New Feature: Add Python support to the editor plugin

### DIFF
--- a/packages/vscode-apollo/package.json
+++ b/packages/vscode-apollo/package.json
@@ -88,6 +88,16 @@
         "embeddedLanguages": {
           "meta.embedded.block.graphql": "graphql"
         }
+      },
+      {
+        "injectTo": [
+          "source.python"
+        ],
+        "scopeName": "inline.graphql.python",
+        "path": "./syntaxes/graphql.py.json",
+        "embeddedLanguages": {
+          "meta.embedded.block.graphql": "graphql"
+        }
       }
     ],
     "commands": [

--- a/packages/vscode-apollo/src/extension.ts
+++ b/packages/vscode-apollo/src/extension.ts
@@ -59,13 +59,14 @@ export function activate(context: ExtensionContext) {
       "javascript",
       "typescript",
       "javascriptreact",
-      "typescriptreact"
+      "typescriptreact",
+      "python"
     ],
     synchronize: {
       fileEvents: [
         workspace.createFileSystemWatcher("**/apollo.config.js"),
         workspace.createFileSystemWatcher("**/package.json"),
-        workspace.createFileSystemWatcher("**/*.{graphql,js,ts,jsx,tsx}")
+        workspace.createFileSystemWatcher("**/*.{graphql,js,ts,jsx,tsx,py}")
       ]
     }
   };

--- a/packages/vscode-apollo/syntaxes/graphql.py.json
+++ b/packages/vscode-apollo/syntaxes/graphql.py.json
@@ -1,0 +1,57 @@
+{
+  "fileTypes": ["python"],
+  "injectionSelector": "L:source -string -comment",
+  "patterns": [
+    {
+      "name": "meta.function-call.python",
+      "begin": "\\b(gql)\\s*(\\()",
+      "beginCaptures": {
+        "1": {
+          "name": "meta.function-call.generic.python"
+        },
+        "2": {
+          "name": "punctuation.definition.arguments.begin.python"
+        }
+      },
+      "end": "(\\))",
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.definition.arguments.end.python"
+        }
+      },
+      "patterns": [
+        {
+          "name": "taggedTemplates",
+          "contentName": "meta.embedded.block.graphql",
+          "begin": "([bfru]*)((\"(?:\"\")?|'(?:'')?))",
+          "beginCaptures": {
+            "1": {
+              "name": "storage.type.string.python"
+            },
+            "2": {
+              "name": "string.quoted.multi.python"
+            },
+            "3": {
+              "name": "punctuation.definition.string.begin.python"
+            }
+          },
+          "end": "((\\3))",
+          "endCaptures": {
+            "1": {
+              "name": "string.quoted.multi.python"
+            },
+            "2": {
+              "name": "punctuation.definition.string.end.python"
+            }
+          },
+          "patterns": [
+            {
+              "include": "source.graphql"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "scopeName": "inline.graphql.python"
+}


### PR DESCRIPTION
This depends on the language server supporting Python (PR #693) for IntelliSense.

Apollo config defaults to JS/TS files only, so it's required to add `*.py` to `apollo.config.js` under `client.includes` before completion/validation starts to work.

Here's everything in action:

<img width="1063" alt="GraphQL inlines in Python" src="https://user-images.githubusercontent.com/81205/48415905-065d2380-e74f-11e8-9011-f113ae9ded96.png">

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [x] feature
- [ ] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->