### PR TITLE
Allow custom configs

### DIFF
--- a/packages/apollo-language-server/src/config.ts
+++ b/packages/apollo-language-server/src/config.ts
@@ -118,6 +118,7 @@ const defaultSearchPlaces = [
   `${MODULE_NAME}.config.ts`
 ];
 
+// Based on order, a provided config file will take precedence over the defaults
 const getSearchPlaces = (configFile?: string) => [
   ...(configFile ? [configFile] : []),
   ...defaultSearchPlaces
@@ -136,7 +137,7 @@ export interface LoadConfigSettings {
   // the current working directory to start looking for the config
   // config loading only works on node so we default to
   // process.cwd()
-  cwd?: string;
+  configLocation?: string;
   name?: string;
   type?: "service" | "client";
 }
@@ -255,23 +256,23 @@ export function isServiceConfig(config: ApolloConfig): config is ServiceConfig {
 
 // XXX load .env files automatically
 export const loadConfig = async ({
-  cwd,
+  configLocation,
   name,
   type
 }: LoadConfigSettings): Promise<ConfigResult<ApolloConfig>> => {
   const explorer = cosmiconfig(MODULE_NAME, {
-    searchPlaces: getSearchPlaces(cwd),
+    searchPlaces: getSearchPlaces(configLocation),
     loaders
   });
 
-  let loadedConfig = (await explorer.search(cwd)) as ConfigResult<
+  let loadedConfig = (await explorer.search(configLocation)) as ConfigResult<
     ApolloConfigFormat
   >;
 
   if (!loadedConfig) {
     loadedConfig = {
       isEmpty: false,
-      filepath: cwd || process.cwd(),
+      filepath: configLocation || process.cwd(),
       config:
         type === "client"
           ? {

--- a/packages/apollo-language-server/src/config.ts
+++ b/packages/apollo-language-server/src/config.ts
@@ -137,7 +137,7 @@ export interface LoadConfigSettings {
   // the current working directory to start looking for the config
   // config loading only works on node so we default to
   // process.cwd()
-  configLocation?: string;
+  configPath?: string;
   name?: string;
   type?: "service" | "client";
 }
@@ -256,23 +256,23 @@ export function isServiceConfig(config: ApolloConfig): config is ServiceConfig {
 
 // XXX load .env files automatically
 export const loadConfig = async ({
-  configLocation,
+  configPath,
   name,
   type
 }: LoadConfigSettings): Promise<ConfigResult<ApolloConfig>> => {
   const explorer = cosmiconfig(MODULE_NAME, {
-    searchPlaces: getSearchPlaces(configLocation),
+    searchPlaces: getSearchPlaces(configPath),
     loaders
   });
 
-  let loadedConfig = (await explorer.search(configLocation)) as ConfigResult<
+  let loadedConfig = (await explorer.search(configPath)) as ConfigResult<
     ApolloConfigFormat
   >;
 
   if (!loadedConfig) {
     loadedConfig = {
       isEmpty: false,
-      filepath: configLocation || process.cwd(),
+      filepath: configPath || process.cwd(),
       config:
         type === "client"
           ? {

--- a/packages/apollo-language-server/src/config.ts
+++ b/packages/apollo-language-server/src/config.ts
@@ -112,11 +112,17 @@ export type ApolloConfigFormat =
 
 // config settings
 const MODULE_NAME = "apollo";
-const searchPlaces = [
+const defaultSearchPlaces = [
   "package.json",
   `${MODULE_NAME}.config.js`,
   `${MODULE_NAME}.config.ts`
 ];
+
+const getSearchPlaces = (configFile?: string) => [
+  ...(configFile ? [configFile] : []),
+  ...defaultSearchPlaces
+];
+
 const loaders = {
   // XXX improve types for config
   ".json": (cosmiconfig as any).loadJson as LoaderEntry,
@@ -130,7 +136,7 @@ export interface LoadConfigSettings {
   // the current working directory to start looking for the config
   // config loading only works on node so we default to
   // process.cwd()
-  cwd: string;
+  cwd?: string;
   name?: string;
   type?: "service" | "client";
 }
@@ -254,7 +260,7 @@ export const loadConfig = async ({
   type
 }: LoadConfigSettings): Promise<ConfigResult<ApolloConfig>> => {
   const explorer = cosmiconfig(MODULE_NAME, {
-    searchPlaces,
+    searchPlaces: getSearchPlaces(cwd),
     loaders
   });
 

--- a/packages/apollo-language-server/src/workspace.ts
+++ b/packages/apollo-language-server/src/workspace.ts
@@ -123,7 +123,7 @@ export class GraphQLWorkspace {
         `Loading Apollo Config in folder ${configFolder}`,
         (async () => {
           try {
-            const config = await loadConfig({ configLocation: configFolder });
+            const config = await loadConfig({ configPath: configFolder });
             return config && config.config;
           } catch (e) {
             console.error(e);

--- a/packages/apollo-language-server/src/workspace.ts
+++ b/packages/apollo-language-server/src/workspace.ts
@@ -123,7 +123,7 @@ export class GraphQLWorkspace {
         `Loading Apollo Config in folder ${configFolder}`,
         (async () => {
           try {
-            const config = await loadConfig({ cwd: configFolder });
+            const config = await loadConfig({ configLocation: configFolder });
             return config && config.config;
           } catch (e) {
             console.error(e);

--- a/packages/apollo/src/Command.ts
+++ b/packages/apollo/src/Command.ts
@@ -102,7 +102,7 @@ export abstract class ProjectCommand extends Command {
       service = getServiceFromKey(process.env.ENGINE_API_KEY);
     if (flags.key) service = getServiceFromKey(flags.key);
     const loadedConfig = await loadConfig({
-      configLocation: flags.config,
+      configPath: flags.config,
       name: service,
       type: this.type
     });

--- a/packages/apollo/src/Command.ts
+++ b/packages/apollo/src/Command.ts
@@ -102,7 +102,7 @@ export abstract class ProjectCommand extends Command {
       service = getServiceFromKey(process.env.ENGINE_API_KEY);
     if (flags.key) service = getServiceFromKey(flags.key);
     const loadedConfig = await loadConfig({
-      cwd: flags.config,
+      configLocation: flags.config,
       name: service,
       type: this.type
     });


### PR DESCRIPTION
Cosmiconfig needs to know it can look elsewhere when a custom config is specified. This allows the --config to be something other than apollo.config.js.

Note: if a custom config is specified, it will take precedence over our defaults.

Fixes #683

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->