### PR TITLE
Don't swallow errors from Engine

### DIFF
--- a/packages/apollo-language-server/src/engine/index.ts
+++ b/packages/apollo-language-server/src/engine/index.ts
@@ -131,7 +131,7 @@ export class ApolloEngineClient extends GraphQLDataSource {
       }
       // use error logger
       if (errors) {
-        throw new Error(errors.map(error => `${error.message}`).join("\n"));
+        throw new Error(errors.map(error => error.message).join("\n"));
       }
       if (!data) {
         throw new Error("Error in request from Engine");
@@ -152,7 +152,7 @@ export class ApolloEngineClient extends GraphQLDataSource {
       }
       // use error logger
       if (errors) {
-        throw new Error(errors.map(error => `${error.message}`).join("\n"));
+        throw new Error(errors.map(error => error.message).join("\n"));
       }
       if (!data) {
         throw new Error("Error in request from Engine");
@@ -171,7 +171,7 @@ export class ApolloEngineClient extends GraphQLDataSource {
         }
         // use error logger
         if (errors) {
-          throw new Error(errors.map(error => `${error.message}`).join("\n"));
+          throw new Error(errors.map(error => error.message).join("\n"));
         }
         if (!data) {
           throw new Error("Error in request from Engine");
@@ -191,7 +191,7 @@ export class ApolloEngineClient extends GraphQLDataSource {
         }
         // use error logger
         if (errors) {
-          throw new Error(errors.map(error => `${error.message}`).join("\n"));
+          throw new Error(errors.map(error => error.message).join("\n"));
         }
         if (!data) {
           throw new Error("Error in request from Engine");

--- a/packages/apollo-language-server/src/engine/index.ts
+++ b/packages/apollo-language-server/src/engine/index.ts
@@ -130,9 +130,9 @@ export class ApolloEngineClient extends GraphQLDataSource {
         );
       }
       // use error logger
-      // if (errors) {
-      //   throw new Error(errors);
-      // }
+      if (errors) {
+        throw new Error(errors.map(error => `${error.message}`).join("\n"));
+      }
       if (!data) {
         throw new Error("Error in request from Engine");
       }
@@ -151,9 +151,9 @@ export class ApolloEngineClient extends GraphQLDataSource {
         );
       }
       // use error logger
-      // if (errors) {
-      //   throw new Error(errors);
-      // }
+      if (errors) {
+        throw new Error(errors.map(error => `${error.message}`).join("\n"));
+      }
       if (!data) {
         throw new Error("Error in request from Engine");
       }
@@ -170,9 +170,9 @@ export class ApolloEngineClient extends GraphQLDataSource {
           );
         }
         // use error logger
-        // if (errors) {
-        //   throw new Error(errors);
-        // }
+        if (errors) {
+          throw new Error(errors.map(error => `${error.message}`).join("\n"));
+        }
         if (!data) {
           throw new Error("Error in request from Engine");
         }
@@ -190,9 +190,9 @@ export class ApolloEngineClient extends GraphQLDataSource {
           );
         }
         // use error logger
-        // if (errors) {
-        //   throw new Error(errors);
-        // }
+        if (errors) {
+          throw new Error(errors.map(error => `${error.message}`).join("\n"));
+        }
         if (!data) {
           throw new Error("Error in request from Engine");
         }


### PR DESCRIPTION
Throw errors we receive from Engine so we can provide the right feedback to users and handle the errors.

Tested for `client:check` and `client:push` using invalid operations against a published schema.

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->