### PR TITLE
Allow fragments only for codegen

### DIFF
--- a/packages/apollo/src/commands/client/codegen.ts
+++ b/packages/apollo/src/commands/client/codegen.ts
@@ -166,7 +166,7 @@ export default class Generate extends ClientCommand {
 
                 if (!operations.length && !fragments.length) {
                   throw new Error(
-                    "No document sets found to generate code for."
+                    "No operations or fragments found to generate code for."
                   );
                 }
 

--- a/packages/apollo/src/commands/client/codegen.ts
+++ b/packages/apollo/src/commands/client/codegen.ts
@@ -164,7 +164,7 @@ export default class Generate extends ClientCommand {
                 const operations = Object.values(this.project.operations);
                 const fragments = Object.values(this.project.fragments);
 
-                if (!operations.length) {
+                if (!operations.length && !fragments.length) {
                   throw new Error(
                     "No document sets found to generate code for."
                   );


### PR DESCRIPTION
Only throw an error if we have neither operations _or_ fragments.

Tested this on a demo project with fragments only to confirm the fix.

Fixes #684 
<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->