### PR TITLE
Support localSchemaFile flag to push to a service from local schema

### DIFF
--- a/packages/apollo/src/Command.ts
+++ b/packages/apollo/src/Command.ts
@@ -69,9 +69,6 @@ export abstract class ProjectCommand extends Command {
     endpoint: flags.string({
       description: "The url of your service"
     }),
-    localSchemaFile: flags.string({
-      description: "Path to your local GraphQL schema file"
-    }),
     key: flags.string({
       description: "The API key for the Apollo Engine service",
       default: () => process.env.ENGINE_API_KEY
@@ -144,6 +141,11 @@ export abstract class ProjectCommand extends Command {
 
     if (flags.localSchemaFile) {
       config.setDefaults({
+        client: {
+          service: {
+            localSchemaFile: flags.localSchemaFile
+          }
+        },
         service: {
           localSchemaFile: flags.localSchemaFile
         }

--- a/packages/apollo/src/Command.ts
+++ b/packages/apollo/src/Command.ts
@@ -26,8 +26,19 @@ export interface ProjectContext<Flags = any, Args = any> {
   args: Args;
 }
 
+export interface Flags {
+  config?: string;
+  header?: string[];
+  endpoint?: string;
+  localSchemaFile?: string;
+  key?: string;
+  engine?: string;
+  frontend?: string;
+  tag?: string;
+}
+
 const headersArrayToObject = (
-  arr: string[]
+  arr?: string[]
 ): Record<string, string> | undefined => {
   if (!arr) return;
   return arr
@@ -57,6 +68,9 @@ export abstract class ProjectCommand extends Command {
     }),
     endpoint: flags.string({
       description: "The url of your service"
+    }),
+    localSchemaFile: flags.string({
+      description: "Path to your local GraphQL schema file"
     }),
     key: flags.string({
       description: "The API key for the Apollo Engine service",
@@ -96,7 +110,7 @@ export abstract class ProjectCommand extends Command {
       });
   }
 
-  protected async createConfig(flags: any) {
+  protected async createConfig(flags: Flags) {
     let service;
     if (process.env.ENGINE_API_KEY)
       service = getServiceFromKey(process.env.ENGINE_API_KEY);
@@ -124,6 +138,14 @@ export abstract class ProjectCommand extends Command {
             url: flags.endpoint,
             headers: headersArrayToObject(flags.header)
           }
+        }
+      });
+    }
+
+    if (flags.localSchemaFile) {
+      config.setDefaults({
+        service: {
+          localSchemaFile: flags.localSchemaFile
         }
       });
     }

--- a/packages/apollo/src/Command.ts
+++ b/packages/apollo/src/Command.ts
@@ -140,16 +140,21 @@ export abstract class ProjectCommand extends Command {
     }
 
     if (flags.localSchemaFile) {
-      config.setDefaults({
-        client: {
+      if (isClientConfig(config)) {
+        config.setDefaults({
+          client: {
+            service: {
+              localSchemaFile: flags.localSchemaFile
+            }
+          }
+        });
+      } else if (isServiceConfig(config)) {
+        config.setDefaults({
           service: {
             localSchemaFile: flags.localSchemaFile
           }
-        },
-        service: {
-          localSchemaFile: flags.localSchemaFile
-        }
-      });
+        });
+      }
     }
 
     // load per command type defaults;
@@ -161,7 +166,11 @@ export abstract class ProjectCommand extends Command {
     return { config, filepath, isEmpty };
   }
 
-  protected createService(config: ApolloConfig, filepath: string, flags: any) {
+  protected createService(
+    config: ApolloConfig,
+    filepath: string,
+    flags: Flags
+  ) {
     const loadingHandler = new OclifLoadingHandler(this);
     const rootURI = `file://${parse(filepath).dir}`;
     const clientIdentity = {

--- a/packages/apollo/src/commands/client/codegen.ts
+++ b/packages/apollo/src/commands/client/codegen.ts
@@ -45,7 +45,8 @@ export default class Generate extends ClientCommand {
       required: true
     }),
     localSchemaFile: flags.string({
-      description: "Path to your local GraphQL schema file"
+      description:
+        "Path to your local GraphQL schema file (introspection result or SDL)"
     }),
     addTypename: flags.boolean({
       description: "Automatically add __typename to your queries",

--- a/packages/apollo/src/commands/client/codegen.ts
+++ b/packages/apollo/src/commands/client/codegen.ts
@@ -44,6 +44,9 @@ export default class Generate extends ClientCommand {
         "Type of code generator to use (swift | typescript | flow | scala), inferred from output",
       required: true
     }),
+    localSchemaFile: flags.string({
+      description: "Path to your local GraphQL schema file"
+    }),
     addTypename: flags.boolean({
       description: "Automatically add __typename to your queries",
       default: true

--- a/packages/apollo/src/commands/client/extract.ts
+++ b/packages/apollo/src/commands/client/extract.ts
@@ -22,8 +22,8 @@ const engineSignature = (_TODO_operationAST: DocumentNode): string => {
   return engineDefaultSignature(_TODO_operationAST, "TODO");
 };
 
-export default class ServicePush extends ClientCommand {
-  static description = "Push a service to Engine";
+export default class ClientExtract extends ClientCommand {
+  static description = "Extract queries from a client";
   static flags = {
     ...ClientCommand.flags
   };

--- a/packages/apollo/src/commands/service/push.ts
+++ b/packages/apollo/src/commands/service/push.ts
@@ -14,6 +14,9 @@ export default class ServicePush extends ProjectCommand {
       char: "t",
       description: "The tag to publish this service to",
       default: "current"
+    }),
+    localSchemaFile: flags.string({
+      description: "Path to your local GraphQL schema file"
     })
   };
 

--- a/packages/apollo/src/commands/service/push.ts
+++ b/packages/apollo/src/commands/service/push.ts
@@ -12,7 +12,7 @@ export default class ServicePush extends ProjectCommand {
     ...ProjectCommand.flags,
     tag: flags.string({
       char: "t",
-      description: "The published tag to check this service against",
+      description: "The tag to publish this service to",
       default: "current"
     })
   };
@@ -27,6 +27,7 @@ export default class ServicePush extends ProjectCommand {
           if (!config.name) {
             throw new Error("No service found to link to Engine");
           }
+
           const schema = await project.resolveSchema({ tag: flags.tag });
           gitContext = await gitInfo();
 

--- a/packages/apollo/src/commands/service/push.ts
+++ b/packages/apollo/src/commands/service/push.ts
@@ -16,7 +16,8 @@ export default class ServicePush extends ProjectCommand {
       default: "current"
     }),
     localSchemaFile: flags.string({
-      description: "Path to your local GraphQL schema file"
+      description:
+        "Path to your local GraphQL schema file (introspection result or SDL)"
     })
   };
 


### PR DESCRIPTION
Pushing from a local schema was previously supported through the CLI via the --endpoint flag. We could continue to support that through some logic where we parse that flag but instead I've chosen to add a new flag that's more semantic and less magic.

This PR also allows `client:codegen` to point to a local schema from the CLI with the same flag.

* Tested and successfully published with a local .gql schema using the --localSchemaFile flag.
* Tested and successfully generated typescript types with a local .gql schema using the same flag.

Fixes #672

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->