### PR TITLE
Add missing documentation for apollo.config.js

### DIFF
--- a/packages/apollo/README.md
+++ b/packages/apollo/README.md
@@ -133,6 +133,8 @@ OPTIONS
   --passthroughCustomScalars                 Use your own types for custom scalars
 
   --queries=queries                          Glob of files to watch for recompilation
+                                             (misnomer) Path to your GraphQL queries needs to be specified as "includes" in 
+                                             config file
 
   --tagName=tagName                          [default: gql] Name of the template literal tag used to identify template
                                              literals containing GraphQL queries in Javascript/Typescript code
@@ -447,8 +449,18 @@ module.exports = {
     // or a local generated schema file
     service: {
       name: "my-service-name",
-      localSchemaFile: "./path/to/schema.graphl"
-    }
+      localSchemaFile: "./path/to/schema.gql"
+    },
+    
+    // specify where GraphQL queries are located
+    // paths are relative to dir where this config file is located
+    // file extensions could be {graphql,js,jsx,ts,tsx,py}
+    includes: [
+      "./path/to/queries/**/*.graphql"
+    ],
+    excludes: [
+      "./path/to/files/to/exclude/**/*.graphql"
+    ]
   }
 };
 ```
@@ -468,7 +480,7 @@ module.exports = {
     },
 
     // or a local generated schema file
-    localSchemaFile: "./path/to/schema.graphl"
+    localSchemaFile: "./path/to/schema.gql"
   }
 };
 ```


### PR DESCRIPTION
- Add a missing documentation for "includes" and "excludes"
- Add a note to --queries argument in apollo client:codegen command

Problem is referenced in: https://github.com/apollographql/apollo-tooling/issues/696#issuecomment-439035918


<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->