### PR TITLE
pass directives from schema modules through buildServiceDefinition

### DIFF
--- a/packages/apollo-tools/src/__tests__/buildServiceDefinition.test.ts
+++ b/packages/apollo-tools/src/__tests__/buildServiceDefinition.test.ts
@@ -111,6 +111,23 @@ Array [
     });
   });
 
+  describe(`directive definitions`, () => {
+    it(`should include directive`, () => {
+      const service = buildServiceDefinition([
+        gql`
+          directive @something on FIELD_DEFINITION
+        `
+      ]);
+
+      expect(service.errors).toBeUndefined();
+
+      expect(service.schema).toBeDefined();
+      const schema = service.schema!;
+      const directive = schema.getDirective("something");
+      expect(directive).toBeDefined();
+    });
+  });
+
   describe(`type extension`, () => {
     it(`should allow extending a type from the same module`, () => {
       const service = buildServiceDefinition([

--- a/packages/apollo-tools/src/__tests__/buildServiceDefinition.test.ts
+++ b/packages/apollo-tools/src/__tests__/buildServiceDefinition.test.ts
@@ -126,6 +126,88 @@ Array [
       const directive = schema.getDirective("something");
       expect(directive).toBeDefined();
     });
+
+    it(`should include directives from different modules`, () => {
+      const service = buildServiceDefinition([
+        gql`
+          directive @something on FIELD_DEFINITION
+        `,
+        gql`
+          directive @another on FIELD_DEFINITION
+        `
+      ]);
+
+      expect(service.errors).toBeUndefined();
+
+      expect(service.schema).toBeDefined();
+      const schema = service.schema!;
+
+      expect(schema.getDirective("something")).toMatchInlineSnapshot(
+        `"@something"`
+      );
+
+      expect(schema.getDirective("another")).toMatchInlineSnapshot(
+        `"@another"`
+      );
+    });
+
+    it(`should not allow two types with the same name in the same module`, () => {
+      const service = buildServiceDefinition([
+        gql`
+          directive @something on FIELD_DEFINITION
+        `,
+        gql`
+          directive @something on FIELD_DEFINITION
+        `
+      ]);
+
+      expect(service.errors).toMatchInlineSnapshot(`
+Array [
+  [GraphQLError: Directive "something" was defined more than once.],
+]
+`);
+    });
+
+    it(`should not allow two types with the same name in different modules`, () => {
+      const service = buildServiceDefinition([
+        gql`
+          directive @something on FIELD_DEFINITION
+        `,
+        gql`
+          directive @something on FIELD_DEFINITION
+        `
+      ]);
+
+      expect(service.errors).toMatchInlineSnapshot(`
+Array [
+  [GraphQLError: Directive "something" was defined more than once.],
+]
+`);
+    });
+
+    it(`should report multiple type duplication errors`, () => {
+      const service = buildServiceDefinition([
+        gql`
+          directive @something on FIELD_DEFINITION
+        `,
+        gql`
+          directive @something on FIELD_DEFINITION
+        `,
+        gql`
+          directive @another on FIELD_DEFINITION
+        `,
+        gql`
+          directive @another on FIELD_DEFINITION
+        `
+      ]);
+
+      expect(service.errors).toMatchInlineSnapshot(`
+Array [
+  [GraphQLError: Directive "something" was defined more than once.],
+  [GraphQLError: Directive "another" was defined more than once.],
+]
+`);
+    });
   });
 
   describe(`type extension`, () => {

--- a/packages/apollo-tools/src/buildServiceDefinition.ts
+++ b/packages/apollo-tools/src/buildServiceDefinition.ts
@@ -2,6 +2,7 @@ import {
   GraphQLSchema,
   DocumentNode,
   TypeDefinitionNode,
+  DirectiveDefinitionNode,
   isTypeDefinitionNode,
   TypeExtensionNode,
   isTypeExtensionNode,
@@ -34,7 +35,7 @@ export function buildServiceDefinition(
   const errors: GraphQLError[] = [];
 
   const typeDefinitionsMap: {
-    [name: string]: TypeDefinitionNode[];
+    [name: string]: (TypeDefinitionNode | DirectiveDefinitionNode)[];
   } = Object.create(null);
 
   const typeExtensionsMap: {
@@ -49,7 +50,10 @@ export function buildServiceDefinition(
       module = { typeDefs: module };
     }
     for (const definition of module.typeDefs.definitions) {
-      if (isTypeDefinitionNode(definition)) {
+      if (
+        isTypeDefinitionNode(definition) ||
+        definition.kind === Kind.DIRECTIVE_DEFINITION
+      ) {
         const typeName = definition.name.value;
 
         if (typeDefinitionsMap[typeName]) {


### PR DESCRIPTION
Directive definitions were discarded when merging types from modules in `buildServiceSchema`.  The fix is nearly trivial, because `Kind.DIRECTIVE_DEFINITION` is a unique case that is neither a schema definition nor a type definition.