### PR TITLE
Add @types/listr to apollo package devDeps

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   },
   "dependencies": {
     "@apollographql/apollo-tools": "file:packages/apollo-tools",
+    "@types/listr": "^0.13.0",
     "apollo": "file:packages/apollo",
     "apollo-codegen-core": "file:packages/apollo-codegen-core",
     "apollo-codegen-flow": "file:packages/apollo-codegen-flow",
@@ -58,7 +59,6 @@
     "@types/graphql": "^14.0.2",
     "@types/inflected": "^1.1.29",
     "@types/jest": "^23.3.1",
-    "@types/listr": "^0.13.0",
     "@types/lodash": "^4.14.109",
     "@types/minimatch": "^3.0.3",
     "@types/nock": "^9.3.0",

--- a/packages/apollo/package-lock.json
+++ b/packages/apollo/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo",
-  "version": "2.0.0-beta.0",
+  "version": "2.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -289,6 +289,15 @@
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-5.0.4.tgz",
       "integrity": "sha512-DsknoBvD8s+RFfSGjmERJ7ZOP1HI0UZRA3FSI+Zakhrc/Gy26YQsLI+m5V5DHxroHRJqCDLKJp7Hixn8zyaF7g==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/listr": {
+      "version": "0.13.0",
+      "resolved": "http://registry.npmjs.org/@types/listr/-/listr-0.13.0.tgz",
+      "integrity": "sha512-8DOy0JCGwwAf76xmU0sRzSZCWKSPPA9djRcTYTsyqBPnMdGOjZ5tjmNswC4J9mgKZudte2tuTo1l14R1/t5l/g==",
+      "dev": true,
       "requires": {
         "@types/node": "*"
       }

--- a/packages/apollo/package.json
+++ b/packages/apollo/package.json
@@ -64,6 +64,7 @@
     "vscode-uri": "^1.0.6"
   },
   "devDependencies": {
+    "@types/listr": "^0.13.0",
     "typescript": "^3.0.3"
   },
   "oclif": {


### PR DESCRIPTION
I ran into issues with referencing the apollo package from a typescript
file, since the listr types are not present in the package.json on
publish. Unfortunately lerna doesn't ensure that all used dependencies
show up in the package.json on publish. Maybe there is a flag we can use
to ensure that we don't run into these sort of annoying issues in the
future.