### PR TITLE
Add support for queries, includes, and excludes flags for codegen

### DIFF
--- a/packages/apollo/src/Command.ts
+++ b/packages/apollo/src/Command.ts
@@ -231,6 +231,16 @@ export abstract class ClientCommand extends ProjectCommand {
       char: "t",
       description: "The published service tag for this client",
       default: "current"
+    }),
+    queries: flags.string({
+      description: "Deprecated in favor of the includes flag"
+    }),
+    includes: flags.string({
+      description: "Glob of files to search for GraphQL operations"
+    }),
+    excludes: flags.string({
+      description:
+        "Glob of files to exclude for GraphQL operations. Caveat: this doesn't currently work in watch mode"
     })
   };
   public project!: GraphQLClientProject;
@@ -251,6 +261,15 @@ export abstract class ClientCommand extends ProjectCommand {
           headers: headersArrayToObject(flags.headers)
         };
       }
+
+      if (flags.includes || flags.queries) {
+        config.client.includes = [flags.includes || flags.queries];
+      }
+
+      if (flags.excludes) {
+        config.client.excludes = [flags.excludes];
+      }
+
       return config;
     };
   }

--- a/packages/apollo/src/Command.ts
+++ b/packages/apollo/src/Command.ts
@@ -10,10 +10,7 @@ import {
   loadConfig,
   isClientConfig,
   isServiceConfig,
-  ApolloConfig,
-  LoadingHandler,
-  ApolloConfigFormat,
-  ClientConfig
+  ApolloConfig
 } from "apollo-language-server";
 import { OclifLoadingHandler } from "./OclifLoadingHandler";
 

--- a/packages/apollo/src/commands/client/codegen.ts
+++ b/packages/apollo/src/commands/client/codegen.ts
@@ -32,9 +32,6 @@ export default class Generate extends ClientCommand {
   static flags = {
     ...ClientCommand.flags,
 
-    queries: flags.string({
-      description: "Glob of files to watch for recompilation"
-    }),
     watch: flags.boolean({
       description: "Watch for file changes and reload codegen"
     }),
@@ -116,7 +113,7 @@ export default class Generate extends ClientCommand {
 
   async run() {
     const {
-      flags: { watch, queries }
+      flags: { watch }
     } = this.parse(Generate);
 
     const run = () =>
@@ -221,7 +218,7 @@ export default class Generate extends ClientCommand {
 
     if (watch) {
       await run().catch(() => {});
-      const watcher = new Gaze(queries!);
+      const watcher = new Gaze(this.project.config.client.includes);
       watcher.on("all", (event, file) => {
         // console.log("\nChange detected, generating types...");
         this.project.fileDidChange(Uri.file(file).toString());


### PR DESCRIPTION
After the overhaul, support for the queries flag in codegen was altered. This restores previous behavior and add includes and excludes flags.

Note: excludes patterns don't work in watch mode due to a limitation with
Gaze, the file watcher we're using.

Tested:
* Using flags in combinations: `includes`, `includes + excludes`, `queries`
* With `watch` flag