### PR TITLE
Fix edge case when no config is provided

### DIFF
--- a/packages/apollo/src/Command.ts
+++ b/packages/apollo/src/Command.ts
@@ -172,7 +172,14 @@ export abstract class ProjectCommand extends Command {
     flags: Flags
   ) {
     const loadingHandler = new OclifLoadingHandler(this);
-    const rootURI = `file://${parse(filepath).dir}`;
+
+    // When no config is provided, filepath === process.cwd()
+    // In this case, we don't want to look to the .dir since that's the parent
+    const rootURI =
+      filepath === process.cwd()
+        ? `file://${filepath}`
+        : `file://${parse(filepath).dir}`;
+
     const clientIdentity = {
       name: "Apollo CLI",
       version,


### PR DESCRIPTION
When no config is provided, the URI is resolved to the _parent_ directory because we're not handling that case correctly.

To resolve this, the URI should be set to the filepath itself.

The manifestation of the issue can be seen in the screenshot below. In the current state, we're taking the `.dir`, which is undesirable when `filePath` points to the root of the project.

<img width="558" alt="screen shot 2018-11-21 at 11 54 02 am" src="https://user-images.githubusercontent.com/29644393/48866395-8c005500-ed87-11e8-9641-b1831e1fb1c7.png">