### PR TITLE
Restore skipSSLValidation flag

### DIFF
--- a/packages/apollo-language-server/src/schema/providers/introspection.ts
+++ b/packages/apollo-language-server/src/schema/providers/introspection.ts
@@ -10,10 +10,8 @@ import {
   IntrospectionQuery,
   parse
 } from "graphql";
-import { Agent, AgentOptions } from "https";
+import { Agent } from "http";
 import { fetch } from "apollo-env";
-import { URL } from "url";
-
 import { RemoteServiceConfig } from "../../config";
 import { GraphQLSchemaProvider, SchemaChangeUnsubscribeHandler } from "./base";
 
@@ -23,23 +21,11 @@ export class IntrospectionSchemaProvider implements GraphQLSchemaProvider {
   async resolveSchema() {
     if (this.schema) return this.schema;
     const { skipSSLValidation, url, headers } = this.config;
-    let options: HttpLink.Options = { uri: url, fetch };
-
-    if (skipSSLValidation) {
-      const urlObject = new URL(url);
-      const host = urlObject.host;
-      const port = +urlObject.port || 443;
-
-      const agentOptions: AgentOptions = {
-        host: host,
-        port: port,
-        rejectUnauthorized: false
-      };
-
-      const agent = new Agent(agentOptions);
-
-      options.fetchOptions = { agent: agent };
-    }
+    const options: HttpLink.Options = {
+      uri: url,
+      fetch,
+      ...(skipSSLValidation && { fetchOptions: { agent: new Agent() } })
+    };
 
     const { data, errors } = (await toPromise(
       linkExecute(createHttpLink(options), {

--- a/packages/apollo/src/Command.ts
+++ b/packages/apollo/src/Command.ts
@@ -35,6 +35,7 @@ export interface Flags {
   engine?: string;
   frontend?: string;
   tag?: string;
+  skipSSLValidation?: boolean;
 }
 
 const headersArrayToObject = (
@@ -133,7 +134,8 @@ export abstract class ProjectCommand extends Command {
         service: {
           endpoint: {
             url: flags.endpoint,
-            headers: headersArrayToObject(flags.header)
+            headers: headersArrayToObject(flags.header),
+            ...(flags.skipSSLValidation && { skipSSLValidation: true })
           }
         }
       });

--- a/packages/apollo/src/commands/service/download.ts
+++ b/packages/apollo/src/commands/service/download.ts
@@ -14,6 +14,10 @@ export default class ServiceDownload extends ProjectCommand {
       char: "t",
       description: "The published tag to check this service against",
       default: "current"
+    }),
+    skipSSLValidation: flags.boolean({
+      char: "k",
+      description: "Allow connections to an SSL site without certs"
     })
   };
 


### PR DESCRIPTION
This restores the skipSSLValidation flag so a schema introspection can be downloaded via http.

For reference: https://github.com/apollographql/apollo-tooling/pull/565
I ran into errors trying to use this^ implementation with `https`. Using `http.Agent` worked for me, though based on the config from the previous implementation I'm curious if I'm overlooking something.
>TypeError [ERR_INVALID_PROTOCOL]: Protocol "http:" not supported. Expected "https:"

Fixes: #728