### PR TITLE
Stop excluding object and list literals from operation manifests.

### DIFF
--- a/packages/apollo/src/commands/client/extract.ts
+++ b/packages/apollo/src/commands/client/extract.ts
@@ -1,7 +1,6 @@
 import { createHash } from "crypto";
 import { writeFileSync } from "fs";
 import {
-  hideLiterals,
   printWithReducedWhitespace,
   sortAST,
   defaultSignature as engineDefaultSignature
@@ -9,6 +8,7 @@ import {
 import { DocumentNode } from "graphql";
 
 import { ClientCommand } from "../../Command";
+import { hideCertainLiterals } from "./push";
 
 // XXX this is duplicated code
 const manifestOperationHash = (str: string): string =>
@@ -52,7 +52,7 @@ export default class ClientExtract extends ClientCommand {
               // kept because the registered operations should mirror those in the
               // client bundle minus any PII which lives within string literals.
               const printed = printWithReducedWhitespace(
-                sortAST(hideLiterals(operationAST))
+                sortAST(hideCertainLiterals(operationAST))
               );
 
               return {


### PR DESCRIPTION
The initial implementation of the manifest generation used by `client:push`
and `client:extract` commands was re-using the same AST traversal technique
as that by Apollo Engine Reporting.  That technique removed ALL literals
from the calculated signature.  That technique was primarily employed for
purposes of normalizing operations for use within metric reporting purposes,
but also touted better safety by avoiding shipping literals.

That said, that algorithm removed string, integer, float, list and object
literals - which is a bit more than we'd like to remove for manifest
purposes, where some of those literals have important meaning.

After this commit, we'll still redact string and numeric literals, but
object and list literals (which often contain string and numeric literals,
of course) will be left as is.  This should maintain a better balance
overall, though it's worth pointing out that the use of GraphQL 'variables'
is still very much preferred when providing arguments to a function.  This
is true in the case of the operation manifest, but also just in general for
caching implementations, etc.