### PR TITLE
Associate `*.gql` files with graphql language in GraphQLProject

### DIFF
--- a/packages/apollo-language-server/src/project/base.ts
+++ b/packages/apollo-language-server/src/project/base.ts
@@ -34,6 +34,7 @@ export type DocumentUri = string;
 
 const fileAssociations: { [extension: string]: string } = {
   ".graphql": "graphql",
+  ".gql": "graphql",
   ".js": "javascript",
   ".ts": "typescript",
   ".jsx": "javascriptreact",


### PR DESCRIPTION
Codegen wasn't working for me with my files ending in ".gql". As my IDE plugin recognizes "*.gql" files as graphql, this is very confusing.

I see two possible further improvements:
1. Warn when including a file without language association
2. Fallback to `graphql` language