### PR TITLE
Empty 'errors' list in introspection fix

### DIFF
--- a/packages/apollo-language-server/src/schema/providers/introspection.ts
+++ b/packages/apollo-language-server/src/schema/providers/introspection.ts
@@ -34,7 +34,7 @@ export class IntrospectionSchemaProvider implements GraphQLSchemaProvider {
       })
     )) as ExecutionResult<IntrospectionQuery>;
 
-    if (errors) {
+    if (errors && errors.length > 0) {
       // XXX better error handling of GraphQL errors
       throw new Error(errors.map(({ message }: Error) => message).join("\n"));
     }

--- a/packages/apollo-language-server/src/schema/providers/introspection.ts
+++ b/packages/apollo-language-server/src/schema/providers/introspection.ts
@@ -34,7 +34,7 @@ export class IntrospectionSchemaProvider implements GraphQLSchemaProvider {
       })
     )) as ExecutionResult<IntrospectionQuery>;
 
-    if (errors && errors.length > 0) {
+    if (errors && errors.length) {
       // XXX better error handling of GraphQL errors
       throw new Error(errors.map(({ message }: Error) => message).join("\n"));
     }


### PR DESCRIPTION
Some server implementations return an empty list rather than null in response objects. Added an array size check to introspection to catch cases when an empty `errors` list is returned.