### PR TITLE
Allow --no-addTypename in 

### DIFF
--- a/packages/apollo/src/commands/client/codegen.ts
+++ b/packages/apollo/src/commands/client/codegen.ts
@@ -46,8 +46,10 @@ export default class Generate extends ClientCommand {
         "Path to your local GraphQL schema file (introspection result or SDL)"
     }),
     addTypename: flags.boolean({
-      description: "Automatically add __typename to your queries",
-      default: true
+      description:
+        "[default: true] Automatically add __typename to your queries, can be unset with --no-addTypename",
+      default: true,
+      allowNo: true
     }),
     passthroughCustomScalars: flags.boolean({
       description: "Use your own types for custom scalars"


### PR DESCRIPTION
Should be able to set --addTypename to false with --no-addTypename  in apollo client:codegen command.

Follow up for PR #713 
By agreement of @jbaxleyiii

This should resolve Issue #680 