### PR TITLE
[vscode] Use `tagName` from config to extract documents.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,6 +14,14 @@
       "stopOnEntry": false,
       "sourceMaps": true,
       "outFiles": ["${workspaceRoot}/packages/vscode-apollo/lib/**/*.js"]
-    }
+    },
+    {
+      "name": "Attach to TS Server",
+      "type": "node",
+      "request": "attach",
+      "protocol": "inspector",
+      "port": 6009,
+      "sourceMaps": true,
+  }
   ]
 }

--- a/packages/apollo-language-server/src/document.ts
+++ b/packages/apollo-language-server/src/document.ts
@@ -52,7 +52,8 @@ export class GraphQLDocument {
 }
 
 export function extractGraphQLDocuments(
-  document: TextDocument
+  document: TextDocument,
+  tagName: string = "gql"
 ): GraphQLDocument[] | null {
   switch (document.languageId) {
     case "graphql":
@@ -63,22 +64,23 @@ export function extractGraphQLDocuments(
     case "javascriptreact":
     case "typescript":
     case "typescriptreact":
-      return extractGraphQLDocumentsFromJSTemplateLiterals(document);
+      return extractGraphQLDocumentsFromJSTemplateLiterals(document, tagName);
     case "python":
-      return extractGraphQLDocumentsFromPythonStrings(document);
+      return extractGraphQLDocumentsFromPythonStrings(document, tagName);
     default:
       return null;
   }
 }
 
 function extractGraphQLDocumentsFromJSTemplateLiterals(
-  document: TextDocument
+  document: TextDocument,
+  tagName: string
 ): GraphQLDocument[] | null {
   const text = document.getText();
 
   const documents: GraphQLDocument[] = [];
 
-  const regExp = /gql\s*`([\s\S]+?)`/gm;
+  const regExp = new RegExp(`${tagName}\\s*\`([\\s\\S]+?)\``, "gm");
 
   let result;
   while ((result = regExp.exec(text)) !== null) {
@@ -98,13 +100,17 @@ function extractGraphQLDocumentsFromJSTemplateLiterals(
 }
 
 function extractGraphQLDocumentsFromPythonStrings(
-  document: TextDocument
+  document: TextDocument,
+  tagName: string
 ): GraphQLDocument[] | null {
   const text = document.getText();
 
   const documents: GraphQLDocument[] = [];
 
-  const regExp = /\b(gql\s*\(\s*[bfru]*("(?:"")?|'(?:'')?))([\s\S]+?)\2\s*\)/gm;
+  const regExp = new RegExp(
+    `\\b(${tagName}\\s*\\(\\s*[bfru]*("(?:"")?|'(?:'')?))([\\s\\S]+?)\\2\\s*\\)`,
+    "gm"
+  );
 
   let result;
   while ((result = regExp.exec(text)) !== null) {

--- a/packages/apollo-language-server/src/project/base.ts
+++ b/packages/apollo-language-server/src/project/base.ts
@@ -178,7 +178,10 @@ export abstract class GraphQLProject implements GraphQLSchemaProvider {
   }
 
   documentDidChange(document: TextDocument) {
-    const documents = extractGraphQLDocuments(document);
+    const documents = extractGraphQLDocuments(
+      document,
+      this.config.client && this.config.client.tagName
+    );
     if (documents) {
       this.documentsByFile.set(document.uri, documents);
       this.invalidate();


### PR DESCRIPTION
Now other tags (such as Relay’s `graphql` tag) will actually be recognized with a `apollo.config.js` file like the following:

```js
module.exports = {
  client: {
    service: {
      name: "local",
      localSchemaFile: "./data/schema.graphql",
    },
    includes: ["src/**/*.{ts,tsx,graphql}"],
    excludes: ["**/node_modules", "**/__tests__"],
    tagName: "graphql",
  }
}
```