### PR TITLE
Fix --key flag/env variable precendece

### DIFF
--- a/packages/apollo-language-server/src/config.ts
+++ b/packages/apollo-language-server/src/config.ts
@@ -269,7 +269,8 @@ export const loadConfig = async ({
     ApolloConfigFormat
   >;
 
-  if (!loadedConfig) {
+  // If there's a name passed in (from env/flag), it overrides the config file
+  if (!loadedConfig || name) {
     loadedConfig = {
       isEmpty: false,
       filepath: configPath || process.cwd(),

--- a/packages/apollo-language-server/src/config.ts
+++ b/packages/apollo-language-server/src/config.ts
@@ -269,7 +269,9 @@ export const loadConfig = async ({
     ApolloConfigFormat
   >;
 
-  // If there's a name passed in (from env/flag), it overrides the config file
+  // If there's a name passed in (from env/flag), it merges with the config file, to
+  // overwrite either the client's service (if a client project), or the service's name.
+  // if there's no config file, it uses the `DefaultConfigBase` to fill these in.
   if (!loadedConfig || name) {
     loadedConfig = {
       isEmpty: false,
@@ -277,9 +279,21 @@ export const loadConfig = async ({
       config:
         type === "client"
           ? {
-              client: { service: name!, ...DefaultConfigBase }
+              ...(loadedConfig ? loadedConfig.config : {}),
+              client: {
+                ...DefaultConfigBase,
+                ...(loadedConfig ? loadedConfig.config.client : {}),
+                service: name!
+              }
             }
-          : { service: { name: name!, ...DefaultConfigBase } }
+          : {
+              ...(loadedConfig ? loadedConfig.config : {}),
+              service: {
+                ...DefaultConfigBase,
+                ...(loadedConfig ? loadedConfig.config.service : {}),
+                name: name!
+              }
+            }
     };
   }
 


### PR DESCRIPTION
## Problem

- When running the Apollo CLI from a repo that has an `apollo.config.js` file, the config's engine service `name` always took precedence over a passed in `--key` flag and/or environment variables. 

## Solution

- Make sure that the config loader uses the proper service/client name. 
- If there's a `name` passed in (from `.env` file or from flags), it should overwrite the `client.service`/`service.name` from the loaded file.

