### PR TITLE
[WIP] add support for java and comment syntax

### DIFF
--- a/packages/apollo-language-server/src/config.ts
+++ b/packages/apollo-language-server/src/config.ts
@@ -50,7 +50,7 @@ export const DefaultEngineConfig = {
 };
 
 export const DefaultConfigBase = {
-  includes: ["src/**/*.{ts,tsx,js,jsx,graphql}"],
+  includes: ["src/**/*.{ts,tsx,js,jsx,graphql,py,kt,java}"],
   excludes: ["**/node_modules", "**/__tests__"]
 };
 

--- a/packages/apollo-language-server/src/project/base.ts
+++ b/packages/apollo-language-server/src/project/base.ts
@@ -39,7 +39,9 @@ const fileAssociations: { [extension: string]: string } = {
   ".ts": "typescript",
   ".jsx": "javascriptreact",
   ".tsx": "typescriptreact",
-  ".py": "python"
+  ".py": "python",
+  ".kt": "kotlin",
+  ".java": "java"
 };
 
 export interface GraphQLProjectConfig {

--- a/packages/vscode-apollo/package.json
+++ b/packages/vscode-apollo/package.json
@@ -79,6 +79,17 @@
       },
       {
         "injectTo": [
+          "source.java",
+          "source.kotlin"
+        ],
+        "scopeName": "inline.graphql.java",
+        "path": "./syntaxes/graphql.java.json",
+        "embeddedLanguages": {
+          "meta.embedded.block.graphql": "graphql"
+        }
+      },
+      {
+        "injectTo": [
           "source.js",
           "source.ts",
           "source.js.jsx",

--- a/packages/vscode-apollo/src/extension.ts
+++ b/packages/vscode-apollo/src/extension.ts
@@ -62,13 +62,17 @@ export function activate(context: ExtensionContext) {
       "typescript",
       "javascriptreact",
       "typescriptreact",
-      "python"
+      "python",
+      "java",
+      "kotlin"
     ],
     synchronize: {
       fileEvents: [
         workspace.createFileSystemWatcher("**/apollo.config.js"),
         workspace.createFileSystemWatcher("**/package.json"),
-        workspace.createFileSystemWatcher("**/*.{graphql,js,ts,jsx,tsx,py}")
+        workspace.createFileSystemWatcher(
+          "**/*.{graphql,js,ts,jsx,tsx,py,java,kt}"
+        )
       ]
     },
     outputChannel

--- a/packages/vscode-apollo/syntaxes/graphql.java.json
+++ b/packages/vscode-apollo/syntaxes/graphql.java.json
@@ -1,0 +1,27 @@
+{
+  "fileTypes": ["java", "kotlin"],
+  "injectionSelector": "L:source -string -comment",
+  "patterns": [
+    {
+      "name": "taggedTemplates",
+      "contentName": "meta.embedded.block.graphql",
+      "begin": "(\\/\\*\\sGraphQL\\s\\*\\/)\\s*(\"\"\")",
+      "beginCaptures": {
+        "1": {
+          "name": "punctuation.definition.comment.kotlin"
+        },
+        "2": {
+          "name": "punctuation.definition.string.begin.kotlin"
+        }
+      },
+      "end": "\"\"\"",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.kotlin"
+        }
+      },
+      "patterns": [{ "include": "source.graphql" }]
+    }
+  ],
+  "scopeName": "inline.graphql.java"
+}

--- a/packages/vscode-apollo/syntaxes/graphql.js.json
+++ b/packages/vscode-apollo/syntaxes/graphql.js.json
@@ -5,12 +5,22 @@
     {
       "name": "taggedTemplates",
       "contentName": "meta.embedded.block.graphql",
-      "begin": "(Relay\\.QL|gql|graphql(\\.experimental)?)(`)",
+      "begin":
+        "\\s*+(?:(?:(Relay)\\??\\.)(QL)|(gql|graphql|graphql\\.experimental)|(/\\* GraphQL \\*/))\\s*(`)",
       "beginCaptures": {
         "1": {
-          "name": "entity.name.function.tagged-template.js"
+          "name": "variable.other.class.js"
         },
         "2": {
+          "name": "entity.name.function.tagged-template.js"
+        },
+        "3": {
+          "name": "entity.name.function.tagged-template.js"
+        },
+        "4": {
+          "name": "comment.graphql.js"
+        },
+        "5": {
           "name": "punctuation.definition.string.template.begin.js"
         }
       },


### PR DESCRIPTION
fixes #724 and adds support for inline string literals with graphql inside for `.java` and `.kt` files