### PR TITLE
Add a note about client schemas

### DIFF
--- a/packages/apollo/README.md
+++ b/packages/apollo/README.md
@@ -71,8 +71,7 @@ OPTIONS
 
   --header=header                        Additional headers to send to server for introspectionQuery
 
-  --includes=includes                    Glob of files to search for GraphQL operations. This should be used to find queries
-                                         *and* any client schema extensions
+  --includes=includes                    Glob of files to search for GraphQL operations
 
   --key=key                              The API key for the Apollo Engine service
 
@@ -126,8 +125,7 @@ OPTIONS
 
   --header=header                            Additional headers to send to server for introspectionQuery
 
-  --includes=includes                        Glob of files to search for GraphQL operations. This should be used to find
-                                             queries *and* any client schema extensions
+  --includes=includes                        Glob of files to search for GraphQL operations
 
   --key=key                                  The API key for the Apollo Engine service
 
@@ -199,8 +197,7 @@ OPTIONS
 
   --header=header                        Additional headers to send to server for introspectionQuery
 
-  --includes=includes                    Glob of files to search for GraphQL operations. This should be used to find queries
-                                         *and* any client schema extensions
+  --includes=includes                    Glob of files to search for GraphQL operations
 
   --key=key                              The API key for the Apollo Engine service
 
@@ -234,8 +231,7 @@ OPTIONS
 
   --header=header                        Additional headers to send to server for introspectionQuery
 
-  --includes=includes                    Glob of files to search for GraphQL operations. This should be used to find queries
-                                         *and* any client schema extensions
+  --includes=includes                    Glob of files to search for GraphQL operations
 
   --key=key                              The API key for the Apollo Engine service
 

--- a/packages/apollo/README.md
+++ b/packages/apollo/README.md
@@ -71,7 +71,8 @@ OPTIONS
 
   --header=header                        Additional headers to send to server for introspectionQuery
 
-  --includes=includes                    Glob of files to search for GraphQL operations
+  --includes=includes                    Glob of files to search for GraphQL operations. This should be used to find queries
+                                         *and* any client schema extensions
 
   --key=key                              The API key for the Apollo Engine service
 
@@ -125,7 +126,8 @@ OPTIONS
 
   --header=header                            Additional headers to send to server for introspectionQuery
 
-  --includes=includes                        Glob of files to search for GraphQL operations
+  --includes=includes                        Glob of files to search for GraphQL operations. This should be used to find
+                                             queries *and* any client schema extensions
 
   --key=key                                  The API key for the Apollo Engine service
 
@@ -197,7 +199,8 @@ OPTIONS
 
   --header=header                        Additional headers to send to server for introspectionQuery
 
-  --includes=includes                    Glob of files to search for GraphQL operations
+  --includes=includes                    Glob of files to search for GraphQL operations. This should be used to find queries
+                                         *and* any client schema extensions
 
   --key=key                              The API key for the Apollo Engine service
 
@@ -231,7 +234,8 @@ OPTIONS
 
   --header=header                        Additional headers to send to server for introspectionQuery
 
-  --includes=includes                    Glob of files to search for GraphQL operations
+  --includes=includes                    Glob of files to search for GraphQL operations. This should be used to find queries
+                                         *and* any client schema extensions
 
   --key=key                              The API key for the Apollo Engine service
 

--- a/packages/apollo/src/Command.ts
+++ b/packages/apollo/src/Command.ts
@@ -242,7 +242,8 @@ export abstract class ClientCommand extends ProjectCommand {
       description: "Deprecated in favor of the includes flag"
     }),
     includes: flags.string({
-      description: "Glob of files to search for GraphQL operations. This should be used to find queries *and* any client schema extensions"
+      description:
+        "Glob of files to search for GraphQL operations. This should be used to find queries *and* any client schema extensions"
     }),
     excludes: flags.string({
       description:

--- a/packages/apollo/src/Command.ts
+++ b/packages/apollo/src/Command.ts
@@ -242,7 +242,7 @@ export abstract class ClientCommand extends ProjectCommand {
       description: "Deprecated in favor of the includes flag"
     }),
     includes: flags.string({
-      description: "Glob of files to search for GraphQL operations"
+      description: "Glob of files to search for GraphQL operations. This should be used to find queries *and* any client schema extensions"
     }),
     excludes: flags.string({
       description:


### PR DESCRIPTION
I updated the CLI docs and apollo readme to note that they are now
specified in the --includes glob.

Fixes #786.