### PR TITLE
Pass correct headers to Client Project

### DIFF
--- a/packages/apollo/src/Command.ts
+++ b/packages/apollo/src/Command.ts
@@ -264,7 +264,7 @@ export abstract class ClientCommand extends ProjectCommand {
       if (flags.endpoint) {
         config.client.service = {
           url: flags.endpoint,
-          headers: headersArrayToObject(flags.headers)
+          headers: headersArrayToObject(flags.header)
         };
       }
 


### PR DESCRIPTION
There was a typo in the headers flag which caused the option to not be passed to the client config.