### PR TITLE
Support tagName flag

### DIFF
--- a/packages/apollo/src/Command.ts
+++ b/packages/apollo/src/Command.ts
@@ -35,6 +35,16 @@ export interface Flags {
   skipSSLValidation?: boolean;
 }
 
+export interface ClientCommandFlags extends Flags {
+  includes?: string;
+  queries?: string;
+  excludes?: string;
+  tagName?: string;
+  clientName?: string;
+  clientReferenceId?: string;
+  clientVersion?: string;
+}
+
 const headersArrayToObject = (
   arr?: string[]
 ): Record<string, string> | undefined => {
@@ -249,13 +259,17 @@ export abstract class ClientCommand extends ProjectCommand {
     excludes: flags.string({
       description:
         "Glob of files to exclude for GraphQL operations. Caveat: this doesn't currently work in watch mode"
+    }),
+    tagName: flags.string({
+      description:
+        "Name of the template literal tag used to identify template literals containing GraphQL queries in Javascript/Typescript code"
     })
   };
   public project!: GraphQLClientProject;
   constructor(argv, config) {
     super(argv, config);
     this.type = "client";
-    this.configMap = (flags: any) => {
+    this.configMap = (flags: ClientCommandFlags) => {
       const config = {
         client: {
           name: flags.clientName,
@@ -276,6 +290,10 @@ export abstract class ClientCommand extends ProjectCommand {
 
       if (flags.excludes) {
         config.client.excludes = [flags.excludes];
+      }
+
+      if (flags.tagName) {
+        config.client.tagName = flags.tagName;
       }
 
       return config;

--- a/packages/apollo/src/commands/client/__tests__/__snapshots__/generate.test.ts.snap
+++ b/packages/apollo/src/commands/client/__tests__/__snapshots__/generate.test.ts.snap
@@ -1,5 +1,33 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`client:codegen extracts queries with a custom tagName provided as a flag 1`] = `
+"/* tslint:disable */
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL query operation: SimpleQuery
+// ====================================================
+
+export interface SimpleQuery {
+  hello: string;
+}
+"
+`;
+
+exports[`client:codegen extracts queries with a custom tagName provided in the config 1`] = `
+"/* tslint:disable */
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL query operation: SimpleQuery
+// ====================================================
+
+export interface SimpleQuery {
+  hello: string;
+}
+"
+`;
+
 exports[`client:codegen generates operation IDs for swift files when flag is set 1`] = `
 "{
   \\"4de1e386589b0853a102a87a3f21ca25266116517e59c1e8be9442e2571f00bc\\": {

--- a/packages/apollo/src/commands/client/__tests__/generate.test.ts
+++ b/packages/apollo/src/commands/client/__tests__/generate.test.ts
@@ -587,6 +587,64 @@ describe("client:codegen", () => {
         ).toMatchSnapshot();
       }
     );
+
+  test
+    .fs({
+      "schema.json": fullSchemaJsonString,
+      "components/component.tsx": `
+        const query = customGraphQLTag\`
+          query SimpleQuery {
+            hello
+          }
+        \`;
+      `,
+      "apollo.config.js": `
+        module.exports = {
+          client: {
+            includes: ["./**/*.tsx"],
+            service: { name: "my-service-name", localSchemaFile: "./schema.json" }
+          }
+        }
+    `
+    })
+    .command([
+      "client:codegen",
+      "--target=typescript",
+      "--tagName=customGraphQLTag",
+      "--outputFlat"
+    ])
+    .it("extracts queries with a custom tagName provided as a flag", () => {
+      expect(
+        fs.readFileSync("__generated__/SimpleQuery.ts").toString()
+      ).toMatchSnapshot();
+    });
+
+  test
+    .fs({
+      "schema.json": fullSchemaJsonString,
+      "components/component.tsx": `
+        const query = customGraphQLTag\`
+          query SimpleQuery {
+            hello
+          }
+        \`;
+      `,
+      "apollo.config.js": `
+        module.exports = {
+          client: {
+            includes: ["./**/*.tsx"],
+            service: { name: "my-service-name", localSchemaFile: "./schema.json" },
+            tagName: 'customGraphQLTag'
+          }
+        }
+    `
+    })
+    .command(["client:codegen", "--target=typescript", "--outputFlat"])
+    .it("extracts queries with a custom tagName provided in the config", () => {
+      expect(
+        fs.readFileSync("__generated__/SimpleQuery.ts").toString()
+      ).toMatchSnapshot();
+    });
 });
 
 describe("error handling", () => {

--- a/packages/apollo/src/commands/client/codegen.ts
+++ b/packages/apollo/src/commands/client/codegen.ts
@@ -61,11 +61,6 @@ export default class Generate extends ClientCommand {
     mergeInFieldsFromFragmentSpreads: flags.boolean({
       description: "Merge fragment fields onto its enclosing type"
     }),
-    tagName: flags.string({
-      description:
-        "Name of the template literal tag used to identify template literals containing GraphQL queries in Javascript/Typescript code",
-      default: "gql"
-    }),
 
     // swift
     namespace: flags.string({


### PR DESCRIPTION
This PR re-adds support for providing a custom tagName for `client:codegen`.

Also included:
* Some addition to types
* Tests for `tagName` as a flag and in the config

Fixes: #723 
