### PR TITLE
[RFC] Add CLI parameter to pass additional Swift framework imports

### DIFF
--- a/packages/apollo-codegen-swift/src/codeGeneration.ts
+++ b/packages/apollo-codegen-swift/src/codeGeneration.ts
@@ -47,12 +47,17 @@ export interface Options {
   customScalarsPrefix?: string;
 }
 
+export interface SwiftGeneratorOptions {
+  importFrameworks?: string[];
+}
+
 export function generateSource(
   context: CompilerContext,
   outputIndividualFiles: boolean,
-  only?: string
+  only?: string,
+  options?: SwiftGeneratorOptions
 ): SwiftAPIGenerator {
-  const generator = new SwiftAPIGenerator(context);
+  const generator = new SwiftAPIGenerator(context, options);
 
   if (outputIndividualFiles) {
     generator.withinFile(`Types.graphql.swift`, () => {
@@ -122,11 +127,13 @@ export function generateSource(
 
 export class SwiftAPIGenerator extends SwiftGenerator<CompilerContext> {
   helpers: Helpers;
+  generatorOptions?: SwiftGeneratorOptions;
 
-  constructor(context: CompilerContext) {
+  constructor(context: CompilerContext, options?: SwiftGeneratorOptions) {
     super(context);
 
     this.helpers = new Helpers(context.options);
+    this.generatorOptions = options;
   }
 
   fileHeader() {
@@ -135,6 +142,12 @@ export class SwiftAPIGenerator extends SwiftGenerator<CompilerContext> {
     );
     this.printNewline();
     this.printOnNewline("import Apollo");
+
+    if (this.generatorOptions && this.generatorOptions.importFrameworks) {
+      this.generatorOptions.importFrameworks.forEach(framework => {
+        this.printOnNewline(`import ${framework}`);
+      });
+    }
   }
 
   classDeclarationForOperation(operation: Operation) {

--- a/packages/apollo/src/commands/codegen/generate.ts
+++ b/packages/apollo/src/commands/codegen/generate.ts
@@ -86,6 +86,11 @@ export default class Generate extends Command {
       description:
         "Parse all input files, but only output generated code for the specified file [Swift only]"
     }),
+    importFramework: flags.string({
+      multiple: true,
+      description:
+        "Framework imports to be added at the top of the generated Swift files [Swift only]"
+    }),
     tagName: flags.string({
       description:
         "Name of the template literal tag used to identify template literals containing GraphQL queries in Javascript/Typescript code",
@@ -232,7 +237,8 @@ export default class Generate extends Command {
                   flags.mergeInFieldsFromFragmentSpreads,
                 useFlowExactObjects: flags.useFlowExactObjects,
                 useFlowReadOnlyTypes: flags.useFlowReadOnlyTypes,
-                globalTypesFile: flags.globalTypesFile
+                globalTypesFile: flags.globalTypesFile,
+                importFrameworks: flags.importFramework
               }
             );
 

--- a/packages/apollo/src/generate.ts
+++ b/packages/apollo/src/generate.ts
@@ -26,6 +26,7 @@ import {
 import { generateSource as generateScalaSource } from "apollo-codegen-scala";
 import { GraphQLSchema } from "graphql";
 import { FlowCompilerOptions } from "../../apollo-codegen-flow/lib/language";
+import { SwiftGeneratorOptions } from "../../apollo-codegen-swift/lib/codeGeneration";
 
 export type TargetType =
   | "json"
@@ -40,6 +41,7 @@ export type TargetType =
 
 export type GenerationOptions = CompilerOptions &
   LegacyCompilerOptions &
+  SwiftGeneratorOptions &
   FlowCompilerOptions & {
     globalTypesFile?: string;
   };
@@ -71,7 +73,12 @@ export default function generate(
     const outputIndividualFiles =
       fs.existsSync(outputPath) && fs.statSync(outputPath).isDirectory();
 
-    const generator = generateSwiftSource(context, outputIndividualFiles, only);
+    const generator = generateSwiftSource(
+      context,
+      outputIndividualFiles,
+      only,
+      options
+    );
 
     if (outputIndividualFiles) {
       writeGeneratedFiles(generator.generatedFiles, outputPath);


### PR DESCRIPTION
**What:**
This PR exposes an `importFramework` parameter to the `client:codegen` command that allows developers to add framework imports to the code generated swift files. 

**Use Case:**
Currently, the only import that is added to generated Swift files is for Apollo, but we found that it would be useful to be able to import other frameworks in cases where custom scalars are defined in modules outside of where the code generated Swift file is being added

**Is there a workaround?**
The only workaround currently is to edit the code generated swift files after they are generated and add additional imports

Note: This PR is built against the `apollo@1.8.3` tag, since there seems to be an issue currently with running swift code generation in master