### PR TITLE
[client config] Allow exclusion of validation rules.

### DIFF
--- a/packages/apollo-language-server/src/config.ts
+++ b/packages/apollo-language-server/src/config.ts
@@ -76,6 +76,15 @@ export interface ClientConfigFormat extends ConfigBase {
   tagName?: string;
   // stats window config
   statsWindow?: StatsWindowSize;
+
+  /**
+   * Rules that should be excluded from the validation rules that are in the GraphQL specification.
+   *
+   * By default the `NoUnusedFragments` and `KnownDirectives` rules are excluded.
+   *
+   * @see https://github.com/graphql/graphql-js/blob/master/src/validation/specifiedRules.js
+   */
+  excludeValidationRules?: string[];
 }
 
 export const DefaultClientConfig = {

--- a/packages/apollo-language-server/src/diagnostics.ts
+++ b/packages/apollo-language-server/src/diagnostics.ts
@@ -21,7 +21,8 @@ import { DocumentUri } from "./project/base";
 export function collectExecutableDefinitionDiagnositics(
   schema: GraphQLSchema,
   queryDocument: GraphQLDocument,
-  fragments: { [fragmentName: string]: FragmentDefinitionNode } = {}
+  fragments: { [fragmentName: string]: FragmentDefinitionNode } = {},
+  excludeValidationRules?: string[]
 ): Diagnostic[] {
   const ast = queryDocument.ast;
   if (!ast) return queryDocument.syntaxErrors;
@@ -36,7 +37,8 @@ export function collectExecutableDefinitionDiagnositics(
   for (const error of getValidationErrors(
     schema,
     astWithExecutableDefinitions,
-    fragments
+    fragments,
+    excludeValidationRules
   )) {
     diagnostics.push(
       ...diagnosticsFromError(error, DiagnosticSeverity.Error, "Validation")

--- a/packages/apollo-language-server/src/errors/validation.ts
+++ b/packages/apollo-language-server/src/errors/validation.ts
@@ -20,17 +20,13 @@ import { ToolError, logError } from "./logger";
 export function getValidationErrors(
   schema: GraphQLSchema,
   document: DocumentNode,
-  fragments?: { [fragmentName: string]: FragmentDefinitionNode }
+  fragments?: { [fragmentName: string]: FragmentDefinitionNode },
+  excludeRules: string[] = ["NoUnusedFragments", "KnownDirectives"]
 ) {
-  const specifiedRulesToBeRemoved = [
-    NoUnusedFragmentsRule,
-    KnownDirectivesRule
-  ];
-
   const rules = [
     NoAnonymousQueries,
     NoTypenameAlias,
-    ...specifiedRules.filter(rule => !specifiedRulesToBeRemoved.includes(rule))
+    ...specifiedRules.filter(rule => !excludeRules.includes(rule.name))
   ];
 
   const typeInfo = new TypeInfo(schema);

--- a/packages/apollo-language-server/src/project/client.ts
+++ b/packages/apollo-language-server/src/project/client.ts
@@ -187,7 +187,8 @@ export class GraphQLClientProject extends GraphQLProject {
           collectExecutableDefinitionDiagnositics(
             this.schema,
             document,
-            fragments
+            fragments,
+            this.config.client.excludeValidationRules
           )
         );
       }


### PR DESCRIPTION
We’re enjoying the extension on our Relay project very much!

The only thing that’s not working well right now is in operation variables validation. Relay Modern has [the `@argumentDefinition` directive](https://facebook.github.io/relay/docs/en/fragment-container.html#argumentdefinitions), which defines ‘local’ variables. These don’t need to be declared at the root of the operation, which currently leads to the many false positives seen below.

This change makes it possible to define rules to exclude in your project config. Ours now looks like this:

```js
module.exports = {
  client: {
    service: {
      name: "local",
      localSchemaFile: "data/schema.graphql",
    },
    excludeValidationRules: [
      // Defaults of vscode-apollo. Not sure why, maybe we can play with this.
      "NoUnusedFragments",
      "KnownDirectives",
      // Added because Relay has ‘local’ variables (defined with the
      // `@argumentDefinitions` directive) and these don’t need to be defined on
      // the operation.
      "NoUndefinedVariables",
    ],
    includes: ["src/**/*.{ts,tsx,graphql}"],
    excludes: ["**/node_modules", "**/__tests__"],
    tagName: "graphql",
  },
}
```

<img width="1440" alt="screen shot 2018-12-01 at 00 29 47" src="https://user-images.githubusercontent.com/2320/49320268-0441e580-f501-11e8-9fed-8f690c13d192.png">