### PR TITLE
Ability to download schema from engine within service projects

### DIFF
--- a/packages/apollo-language-server/src/schema/providers/engine.ts
+++ b/packages/apollo-language-server/src/schema/providers/engine.ts
@@ -34,26 +34,27 @@ export class EngineSchemaProvider implements GraphQLSchemaProvider {
 
   async resolveSchema(override: SchemaResolveConfig) {
     if (this.schema && (!override || !override.force)) return this.schema;
-    const { engine, client, service } = this.config;
-
+    const { engine } = this.config;
     let serviceName;
 
     if (isClientConfig(this.config)) {
-      if (typeof client!.service !== "string") {
+      const client = this.config.client;
+      if (typeof client.service !== "string") {
         throw new Error(
           `Service name not found for client, found ${client!.service}`
         );
       }
 
-      serviceName = client!.service as string;
+      serviceName = client.service as string;
     } else if (isServiceConfig(this.config)) {
-      if (typeof service!.name !== "string") {
+      const service = this.config.service;
+      if (typeof service.name !== "string") {
         throw new Error(
           `Service name not found for service, found ${service!.name}`
         );
       }
 
-      serviceName = service!.name;
+      serviceName = service.name;
     }
 
     // create engine client

--- a/packages/apollo-language-server/src/schema/providers/index.ts
+++ b/packages/apollo-language-server/src/schema/providers/index.ts
@@ -33,6 +33,10 @@ export function schemaProviderFromConfig(
     if (config.service.endpoint) {
       return new IntrospectionSchemaProvider(config.service.endpoint);
     }
+
+    if (config.service.name) {
+      return new EngineSchemaProvider(config);
+    }
   }
 
   if (isClientConfig(config)) {


### PR DESCRIPTION
## Issue

- You couldn't use `apollo service:download` from within a `service` (server) project.
- The schema provider looks up schemas differently for client and service projects, since their configs are different shapes.
  - originally, the schema provider only supported getting a schema from a local schema files or an endpoint. 
  - the default endpoint that would get used if neither a schema file/endpoint option was present was `http://locahost:4000` which caused some users to see connection errors to localhost:4000 while trying to run introspection.

## Fixes

- Removed default endpoint for service projects
- Added ability for the `EngineSchemaProvider` to accept a service config file, and use the `service.name` to fetch from Engine (same as `client.service`)
- ~Made the schema lookup by `service.name` the one with highest precedence, since using a `--key` should always overwrite local config files with endpoints.~