### PR TITLE
Fix order of .env loading

### DIFF
--- a/packages/apollo/src/Command.ts
+++ b/packages/apollo/src/Command.ts
@@ -118,10 +118,7 @@ export abstract class ProjectCommand extends Command {
   }
 
   protected async createConfig(flags: Flags) {
-    let service;
-    if (process.env.ENGINE_API_KEY)
-      service = getServiceFromKey(process.env.ENGINE_API_KEY);
-    if (flags.key) service = getServiceFromKey(flags.key);
+    const service = flags.key ? getServiceFromKey(flags.key) : undefined;
     const loadedConfig = await loadConfig({
       configPath: flags.config,
       name: service,


### PR DESCRIPTION
This PR resolves an issue for configless approaches.

A simple reproduction can be achieved by:
```
// .env
ENGINE_API_KEY=...

$ npx apollo service:push --endpoint=<...>

  ✔ Loading Apollo Project
  ✖ Uploading service to Engine
    → No service found to link to Engine
```

**Cause**
This is because the `name` was being required before loading the env variables, causing an error to be thrown.

**Solution**
Load the env config earlier in the configuration process so the service name can be inferred if it isn't provided.
