### PR TITLE
Support status bar command and service stats logging

### DIFF
--- a/packages/apollo-language-server/src/config.ts
+++ b/packages/apollo-language-server/src/config.ts
@@ -153,13 +153,14 @@ export type ConfigResult<Config> = {
 // take a config with multiple project types and return
 // an array of individual types
 export const projectsFromConfig = (
-  config: ApolloConfigFormat
+  config: ApolloConfigFormat,
+  configURI?: URI
 ): Array<ClientConfig | ServiceConfig> => {
   const configs = [];
   const { client, service, ...rest } = config;
   // XXX use casting detection
-  if (client) configs.push(new ClientConfig(config));
-  if (service) configs.push(new ServiceConfig(config));
+  if (client) configs.push(new ClientConfig(config, configURI));
+  if (service) configs.push(new ServiceConfig(config, configURI));
   return configs;
 };
 
@@ -205,7 +206,7 @@ export class ApolloConfig {
   }
 
   get projects() {
-    return projectsFromConfig(this.rawConfig);
+    return projectsFromConfig(this.rawConfig, this.configURI);
   }
 
   set tag(tag: string) {

--- a/packages/apollo-language-server/src/config.ts
+++ b/packages/apollo-language-server/src/config.ts
@@ -1,7 +1,7 @@
 import * as cosmiconfig from "cosmiconfig";
 import { LoaderEntry } from "cosmiconfig";
 import TypeScriptLoader from "@endemolshinegroup/cosmiconfig-typescript-loader";
-import { resolve } from "path";
+import { resolve, dirname } from "path";
 import { readFileSync, existsSync } from "fs";
 import { merge } from "lodash/fp";
 
@@ -203,6 +203,12 @@ export class ApolloConfig {
     this.name = getServiceName(rawConfig);
     this.client = rawConfig.client;
     this.service = rawConfig.service;
+  }
+
+  get configDirURI() {
+    return this.configURI && this.configURI.fsPath.includes(".js")
+      ? URI.parse(dirname(this.configURI.fsPath))
+      : this.configURI;
   }
 
   get projects() {

--- a/packages/apollo-language-server/src/fileSet.ts
+++ b/packages/apollo-language-server/src/fileSet.ts
@@ -45,12 +45,18 @@ export class FileSet {
   allFiles(): string[] {
     return this.includes
       .flatMap(include =>
-        glob.sync(include, { cwd: this.rootPath, absolute: true })
+        glob.sync(include, {
+          cwd: this.configPath || this.rootPath,
+          absolute: true
+        })
       )
       .filter(
         filePath =>
           !this.excludes.some(exclude =>
-            minimatch(relative(this.rootPath, filePath), exclude)
+            minimatch(
+              relative(this.configPath || this.rootPath, filePath),
+              exclude
+            )
           )
       );
   }

--- a/packages/apollo-language-server/src/fileSet.ts
+++ b/packages/apollo-language-server/src/fileSet.ts
@@ -1,18 +1,22 @@
-import { relative } from "path";
+import { relative, dirname } from "path";
 import minimatch = require("minimatch");
 import * as glob from "glob";
 import { invariant } from "@apollographql/apollo-tools";
+import URI from "vscode-uri";
 
 export class FileSet {
+  private configPath?: string;
   private rootPath: string;
   private includes: string[];
   private excludes: string[];
 
   constructor({
+    configPath,
     rootPath,
     includes,
     excludes
   }: {
+    configPath?: string;
     rootPath: string;
     includes: string[];
     excludes: string[];
@@ -21,14 +25,17 @@ export class FileSet {
     invariant(includes, `Must provide "includes".`);
     invariant(excludes, `Must provide "excludes".`);
 
+    this.configPath = configPath;
     this.rootPath = rootPath;
     this.includes = includes;
     this.excludes = excludes;
   }
 
-  includesFile(filePath: string): boolean {
-    filePath = relative(this.rootPath, filePath);
-
+  includesFile(filePath: string, configDir?: URI): boolean {
+    // if we're given a path to the config file, we should match the
+    // "includes" glob relative to that dir. This allows us to run this command
+    // from a "root" dir above the root of the project, like when at the root of a monorepo
+    filePath = relative(configDir ? configDir.path : this.rootPath, filePath);
     return (
       this.includes.some(include => minimatch(filePath, include)) &&
       !this.excludes.some(exclude => minimatch(filePath, exclude))

--- a/packages/apollo-language-server/src/fileSet.ts
+++ b/packages/apollo-language-server/src/fileSet.ts
@@ -1,22 +1,19 @@
-import { relative, dirname } from "path";
+import { relative } from "path";
 import minimatch = require("minimatch");
 import * as glob from "glob";
 import { invariant } from "@apollographql/apollo-tools";
 import URI from "vscode-uri";
 
 export class FileSet {
-  private configDirURI?: URI;
   private rootURI: URI;
   private includes: string[];
   private excludes: string[];
 
   constructor({
-    configURI,
     rootURI,
     includes,
     excludes
   }: {
-    configURI?: URI;
     rootURI: URI;
     includes: string[];
     excludes: string[];
@@ -25,24 +22,14 @@ export class FileSet {
     invariant(includes, `Must provide "includes".`);
     invariant(excludes, `Must provide "excludes".`);
 
-    // the URI of the folder _containing_ the apollo.config.js
-    this.configDirURI =
-      configURI && configURI.fsPath.includes(".js")
-        ? URI.parse(dirname(configURI.fsPath))
-        : configURI;
     this.rootURI = rootURI;
     this.includes = includes;
     this.excludes = excludes;
   }
 
-  includesFile(filePath: string, configDirURI?: URI): boolean {
-    // if we're given a path to the config file, we should match the
-    // "includes" glob relative to that dir. This allows us to run this command
-    // from a "root" dir above the root of the project, like when at the root of a monorepo
-    filePath = relative(
-      configDirURI ? configDirURI.path : this.rootURI.fsPath,
-      filePath
-    );
+  includesFile(filePath: string): boolean {
+    filePath = relative(this.rootURI.fsPath, filePath);
+
     return (
       this.includes.some(include => minimatch(filePath, include)) &&
       !this.excludes.some(exclude => minimatch(filePath, exclude))
@@ -52,25 +39,12 @@ export class FileSet {
   allFiles(): string[] {
     return this.includes
       .flatMap(include =>
-        glob.sync(include, {
-          cwd: this.configDirURI
-            ? this.configDirURI.fsPath
-            : this.rootURI.fsPath,
-          absolute: true
-        })
+        glob.sync(include, { cwd: this.rootURI.fsPath, absolute: true })
       )
       .filter(
         filePath =>
           !this.excludes.some(exclude =>
-            minimatch(
-              relative(
-                this.configDirURI
-                  ? this.configDirURI.fsPath
-                  : this.rootURI.fsPath,
-                filePath
-              ),
-              exclude
-            )
+            minimatch(relative(this.rootURI.fsPath, filePath), exclude)
           )
       );
   }

--- a/packages/apollo-language-server/src/languageProvider.ts
+++ b/packages/apollo-language-server/src/languageProvider.ts
@@ -93,6 +93,15 @@ function symbolForFieldDefinition(
 export class GraphQLLanguageProvider {
   constructor(public workspace: GraphQLWorkspace) {}
 
+  async provideStats(uri?: DocumentUri) {
+    if (this.workspace.projects.length && uri) {
+      const project = this.workspace.projectForFile(uri);
+      return project ? project.getProjectStats() : { loaded: false };
+    }
+
+    return { loaded: false };
+  }
+
   async provideCompletionItems(
     uri: DocumentUri,
     position: Position,

--- a/packages/apollo-language-server/src/project/base.ts
+++ b/packages/apollo-language-server/src/project/base.ts
@@ -1,6 +1,6 @@
 import { extname } from "path";
 import { readFileSync } from "fs";
-import Uri from "vscode-uri";
+import URI from "vscode-uri";
 
 import {
   TypeSystemDefinitionNode,
@@ -48,6 +48,22 @@ export interface GraphQLProjectConfig {
   fileSet: FileSet;
   loadingHandler: LoadingHandler;
 }
+
+export interface TypeStats {
+  service?: number;
+  client?: number;
+  total?: number;
+}
+
+export interface ProjectStats {
+  type: string;
+  loaded: boolean;
+  serviceId?: string;
+  types?: TypeStats;
+  tag?: string;
+  lastFetch?: number;
+}
+
 export abstract class GraphQLProject implements GraphQLSchemaProvider {
   public schemaProvider: GraphQLSchemaProvider;
   protected _onDiagnostics?: NotificationHandler<PublishDiagnosticsParams>;
@@ -64,6 +80,8 @@ export abstract class GraphQLProject implements GraphQLSchemaProvider {
   public schema?: GraphQLSchema;
   private fileSet: FileSet;
   protected loadingHandler: LoadingHandler;
+
+  protected lastLoadDate?: number;
 
   constructor({
     config,
@@ -106,6 +124,8 @@ export abstract class GraphQLProject implements GraphQLSchemaProvider {
 
   protected abstract initialize(): Promise<void>[];
 
+  abstract getProjectStats(): ProjectStats;
+
   get isReady(): boolean {
     return this._isReady;
   }
@@ -124,10 +144,12 @@ export abstract class GraphQLProject implements GraphQLSchemaProvider {
   }
 
   public resolveSchema(config: SchemaResolveConfig): Promise<GraphQLSchema> {
+    this.lastLoadDate = +new Date();
     return this.schemaProvider.resolveSchema(config);
   }
 
   public onSchemaChange(handler: NotificationHandler<GraphQLSchema>) {
+    this.lastLoadDate = +new Date();
     return this.schemaProvider.onSchemaChange(handler);
   }
 
@@ -136,7 +158,10 @@ export abstract class GraphQLProject implements GraphQLSchemaProvider {
   }
 
   includesFile(uri: DocumentUri) {
-    return this.fileSet.includesFile(Uri.parse(uri).fsPath);
+    return this.fileSet.includesFile(
+      URI.parse(uri).fsPath,
+      this.config.configURI
+    );
   }
 
   async scanAllIncludedFiles() {
@@ -144,7 +169,7 @@ export abstract class GraphQLProject implements GraphQLSchemaProvider {
       `Loading queries for ${this.displayName}`,
       (async () => {
         for (const filePath of this.fileSet.allFiles()) {
-          const uri = Uri.file(filePath).toString();
+          const uri = URI.file(filePath).toString();
 
           // If we already have query documents for this file, that means it was either
           // opened or changed before we got a chance to read it.
@@ -157,7 +182,7 @@ export abstract class GraphQLProject implements GraphQLSchemaProvider {
   }
 
   fileDidChange(uri: DocumentUri) {
-    const filePath = Uri.parse(uri).fsPath;
+    const filePath = URI.parse(uri).fsPath;
     const extension = extname(filePath);
     const languageId = fileAssociations[extension];
 

--- a/packages/apollo-language-server/src/project/base.ts
+++ b/packages/apollo-language-server/src/project/base.ts
@@ -158,10 +158,7 @@ export abstract class GraphQLProject implements GraphQLSchemaProvider {
   }
 
   includesFile(uri: DocumentUri) {
-    return this.fileSet.includesFile(
-      URI.parse(uri).fsPath,
-      this.config.configURI
-    );
+    return this.fileSet.includesFile(URI.parse(uri).fsPath);
   }
 
   async scanAllIncludedFiles() {

--- a/packages/apollo-language-server/src/project/client.ts
+++ b/packages/apollo-language-server/src/project/client.ts
@@ -91,8 +91,9 @@ export class GraphQLClientProject extends GraphQLProject {
     clientIdentity
   }: GraphQLClientProjectConfig) {
     const fileSet = new FileSet({
-      configURI: config.configURI,
-      rootURI: rootURI,
+      // the URI of the folder _containing_ the apollo.config.js is the true project's root.
+      // if a config doesn't have a uri associated, we can assume the `rootURI` is the project's root.
+      rootURI: config.configDirURI || rootURI,
       includes: config.client.includes,
       excludes: config.client.excludes
     });

--- a/packages/apollo-language-server/src/project/client.ts
+++ b/packages/apollo-language-server/src/project/client.ts
@@ -91,8 +91,8 @@ export class GraphQLClientProject extends GraphQLProject {
     clientIdentity
   }: GraphQLClientProjectConfig) {
     const fileSet = new FileSet({
-      configPath: config.configURI ? config.configURI.fsPath : undefined,
-      rootPath: rootURI.fsPath,
+      configURI: config.configURI,
+      rootURI: rootURI,
       includes: config.client.includes,
       excludes: config.client.excludes
     });

--- a/packages/apollo-language-server/src/project/service.ts
+++ b/packages/apollo-language-server/src/project/service.ts
@@ -25,7 +25,7 @@ export class GraphQLServiceProject extends GraphQLProject {
     loadingHandler
   }: GraphQLServiceProjectConfig) {
     const fileSet = new FileSet({
-      rootURI: rootURI,
+      rootURI: config.configDirURI || rootURI,
       includes: config.service.includes,
       excludes: config.service.excludes
     });

--- a/packages/apollo-language-server/src/project/service.ts
+++ b/packages/apollo-language-server/src/project/service.ts
@@ -43,4 +43,8 @@ export class GraphQLServiceProject extends GraphQLProject {
   }
 
   validate() {}
+
+  getProjectStats() {
+    return { loaded: true, type: "service" };
+  }
 }

--- a/packages/apollo-language-server/src/project/service.ts
+++ b/packages/apollo-language-server/src/project/service.ts
@@ -25,7 +25,7 @@ export class GraphQLServiceProject extends GraphQLProject {
     loadingHandler
   }: GraphQLServiceProjectConfig) {
     const fileSet = new FileSet({
-      rootPath: rootURI.fsPath,
+      rootURI: rootURI,
       includes: config.service.includes,
       excludes: config.service.excludes
     });

--- a/packages/apollo-language-server/src/server.ts
+++ b/packages/apollo-language-server/src/server.ts
@@ -212,5 +212,10 @@ connection.onNotification(
   (selection: QuickPickItem) => workspace.updateSchemaTag(selection)
 );
 
+connection.onNotification("apollographql/getStats", async ({ uri }) => {
+  const status = await languageProvider.provideStats(uri);
+  connection.sendNotification("apollographql/statsLoaded", status);
+});
+
 // Listen on the connection
 connection.listen();

--- a/packages/apollo-language-server/src/workspace.ts
+++ b/packages/apollo-language-server/src/workspace.ts
@@ -3,7 +3,6 @@ import {
   NotificationHandler,
   PublishDiagnosticsParams
 } from "vscode-languageserver";
-import Uri from "vscode-uri";
 import { QuickPickItem } from "vscode";
 
 import { GraphQLProject, DocumentUri } from "./project/base";
@@ -54,13 +53,13 @@ export class GraphQLWorkspace {
       ? new GraphQLClientProject({
           config,
           loadingHandler: this.LanguageServerLoadingHandler,
-          rootURI: URI.file(folder.uri),
+          rootURI: URI.parse(folder.uri),
           clientIdentity
         })
       : new GraphQLServiceProject({
           config: config as ServiceConfig,
           loadingHandler: this.LanguageServerLoadingHandler,
-          rootURI: URI.file(folder.uri),
+          rootURI: URI.parse(folder.uri),
           clientIdentity
         });
 
@@ -98,14 +97,14 @@ export class GraphQLWorkspace {
 
     */
     const apolloConfigFiles: string[] = fg.sync("**/apollo.config.@(js|ts)", {
-      cwd: Uri.parse(folder.uri).fsPath,
+      cwd: URI.parse(folder.uri).fsPath,
       absolute: true,
       ignore: "**/node_modules/**"
     });
 
     apolloConfigFiles.push(
       ...fg.sync("**/package.json", {
-        cwd: Uri.parse(folder.uri).fsPath,
+        cwd: URI.parse(folder.uri).fsPath,
         absolute: true,
         ignore: "**/node_modules/**"
       })

--- a/packages/apollo/src/commands/client/codegen.ts
+++ b/packages/apollo/src/commands/client/codegen.ts
@@ -4,13 +4,11 @@ import * as path from "path";
 import { Kind, DocumentNode } from "graphql";
 import * as tty from "tty";
 import { Gaze } from "gaze";
-
-import Uri from "vscode-uri";
+import URI from "vscode-uri";
 
 import { TargetType, default as generate } from "../../generate";
 
 import { ClientCommand } from "../../Command";
-import URI from "vscode-uri";
 
 const waitForKey = async () => {
   console.log("Press any key to stop.");
@@ -218,7 +216,7 @@ export default class Generate extends ClientCommand {
       const watcher = new Gaze(this.project.config.client.includes);
       watcher.on("all", (event, file) => {
         // console.log("\nChange detected, generating types...");
-        this.project.fileDidChange(Uri.file(file).toString());
+        this.project.fileDidChange(URI.file(file).toString());
       });
       if (tty.isatty((process.stdin as any).fd)) {
         await waitForKey();

--- a/packages/apollo/src/generate.ts
+++ b/packages/apollo/src/generate.ts
@@ -1,7 +1,7 @@
 import { fs } from "apollo-codegen-core/lib/localfs";
 import * as path from "path";
 import { GraphQLSchema, DocumentNode, print } from "graphql";
-import Uri from "vscode-uri";
+import URI from "vscode-uri";
 
 import {
   compileToIR,
@@ -42,7 +42,7 @@ export type GenerationOptions = CompilerOptions &
   };
 
 function toPath(uri: string): string {
-  return Uri.parse(uri).path;
+  return URI.parse(uri).path;
 }
 
 export default function generate(

--- a/packages/vscode-apollo/package.json
+++ b/packages/vscode-apollo/package.json
@@ -113,6 +113,11 @@
         "command": "apollographql/reloadService",
         "title": "Reload schema",
         "category": "Apollo"
+      },
+      {
+        "command": "apollographql/showStatus",
+        "title": "Show Status",
+        "category": "Apollo"
       }
     ]
   }

--- a/packages/vscode-apollo/src/statusBar.ts
+++ b/packages/vscode-apollo/src/statusBar.ts
@@ -10,7 +10,8 @@ export default class ApolloStatusBar {
     this.statusBarItem.text = ApolloStatusBar.loadingStateText;
     this.statusBarItem.show();
 
-    // this.statusBarItem.command = "apollographql/showOutputChannel";
+    this.statusBarItem.command = "apollographql/showStats";
+    // context.subscriptions.push(this.statusBarItem);
   }
 
   public showLoadedState({

--- a/packages/vscode-apollo/src/utils.ts
+++ b/packages/vscode-apollo/src/utils.ts
@@ -1,0 +1,82 @@
+import { LanguageClient } from "vscode-languageclient";
+
+export const timeSince = (date: number) => {
+  const seconds = Math.floor((+new Date() - date) / 1000);
+  if (!seconds) return;
+  let interval = Math.floor(seconds / 86400);
+  if (interval >= 1) return `${interval}d`;
+
+  interval = Math.floor(seconds / 3600);
+  if (interval >= 1) return `${interval}h`;
+
+  interval = Math.floor(seconds / 60);
+  if (interval >= 1) return `${interval}m`;
+
+  return `${Math.floor(seconds)}s`;
+};
+
+export const printNoFileOpenMessage = (
+  client: LanguageClient,
+  extVersion: string
+) => {
+  client.outputChannel.appendLine("------------------------------");
+  client.outputChannel.appendLine(`🚀 Apollo GraphQL v${extVersion}`);
+  client.outputChannel.appendLine("------------------------------");
+};
+
+export interface TypeStats {
+  service?: number;
+  client?: number;
+  total?: number;
+}
+
+export interface ProjectStats {
+  type: string;
+  loaded: boolean;
+  serviceId?: string;
+  types?: TypeStats;
+  tag?: string;
+  lastFetch?: number;
+}
+
+export const printStatsToClientOutputChannel = (
+  client: LanguageClient,
+  stats: ProjectStats,
+  extVersion: string
+) => {
+  client.outputChannel.appendLine("------------------------------");
+  client.outputChannel.appendLine(`🚀 Apollo GraphQL v${extVersion}`);
+  client.outputChannel.appendLine("------------------------------");
+
+  if (!stats || !stats.loaded) {
+    client.outputChannel.appendLine(
+      "❌ Service stats could not be loaded. This may be because you're missing an apollo.config.js file " +
+        "or it is misconfigured. For more information about configuring Apollo projects, " +
+        "see the guide here (https://bit.ly/2ByILPj)."
+    );
+    return;
+  }
+
+  // we don't support logging of stats for service projects currently
+  if (stats.type === "service") {
+    return;
+  } else if (stats.type === "client") {
+    client.outputChannel.appendLine("✅ Service Loaded!");
+    client.outputChannel.appendLine(`🆔 Service ID: ${stats.serviceId}`);
+    client.outputChannel.appendLine(`🏷 Schema Tag: ${stats.tag}`);
+
+    if (stats.types)
+      client.outputChannel.appendLine(
+        `📈 Number of Types: ${stats.types.total} (${
+          stats.types.client
+        } client ${stats.types.client === 1 ? "type" : "types"})`
+      );
+
+    if (stats.lastFetch && timeSince(stats.lastFetch)) {
+      client.outputChannel.appendLine(
+        `🗓 Last Fetched ${timeSince(stats.lastFetch)} Ago`
+      );
+    }
+    client.outputChannel.appendLine("------------------------------");
+  }
+};


### PR DESCRIPTION
## Goals
- [x] Add an action to the action bar item at the bottom of the VSCode editor that opens up the output for the Apollo extension and prints out basic service info
- [x] Add support on the language server for reporting that service info
- [x] Supports multiple projects open in the workspace (like in a monorepo). Stats printed are for the project associated with the open file. If no file is open, it just prints extension version

**Client projects when loaded successfully:**
<img width="353" alt="screen shot 2019-01-10 at 4 34 45 pm" src="https://user-images.githubusercontent.com/9259509/50998667-28c4b080-14f6-11e9-9ee7-8cca0ba7e05a.png">

**Error when projects can't load stats (either because of misconfiguration or other language server/extension errors):**
<img width="925" alt="screen shot 2019-01-10 at 4 35 20 pm" src="https://user-images.githubusercontent.com/9259509/50998698-3bd78080-14f6-11e9-9b0a-41b8d6313b7a.png">

Note: Service projects currently aren't supported for stats, so clicking the status bar icon just prints the extension version and opens the output pane