### PR TITLE
Remove legacy build artifacts from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,11 +17,7 @@ packages/*/package-lock.json
 
 lerna-debug.log
 
-packages/apollo-vscode/server
-packages/apollo-vscode/webview-content
-packages/vscode-apollo/server
-packages/vscode-apollo/webview-content
-**/*.vsix
+vscode-apollo-*.vsix
 
 .env
 


### PR DESCRIPTION
An old build artifact caused test failures. This wasn't immediately
clear because the .gitignore prevented these files from showing up in
the unstaged files. This removes those artifacts to make the fix more
obvious.