### PR TITLE
Internally track URI of project config files

### DIFF
--- a/packages/apollo-language-server/src/config.ts
+++ b/packages/apollo-language-server/src/config.ts
@@ -12,6 +12,7 @@ import {
   StatsWindowSize,
   ServiceIDAndTag
 } from "./engine";
+import URI from "vscode-uri";
 
 export interface EngineStatsWindow {
   to: number;
@@ -194,7 +195,7 @@ export class ApolloConfig {
   public client?: ClientConfigFormat;
   private _tag?: string;
 
-  constructor(public rawConfig: ApolloConfigFormat) {
+  constructor(public rawConfig: ApolloConfigFormat, public configURI?: URI) {
     this.isService = !!rawConfig.service;
     this.isClient = !!rawConfig.client;
     this.engine = rawConfig.engine!;
@@ -267,7 +268,7 @@ export const loadConfig = async ({
   configPath,
   name,
   type
-}: LoadConfigSettings): Promise<ConfigResult<ApolloConfig>> => {
+}: LoadConfigSettings): Promise<ApolloConfig> => {
   const explorer = cosmiconfig(MODULE_NAME, {
     searchPlaces: getSearchPlaces(configPath),
     loaders
@@ -339,5 +340,5 @@ export const loadConfig = async ({
 
   config = merge({ engine: DefaultEngineConfig }, config);
 
-  return { config: new ApolloConfig(config), filepath, isEmpty };
+  return new ApolloConfig(config, URI.file(resolve(filepath)));
 };

--- a/packages/apollo-language-server/src/project/client.ts
+++ b/packages/apollo-language-server/src/project/client.ts
@@ -1,4 +1,4 @@
-import { GraphQLProject, DocumentUri } from "./base";
+import { GraphQLProject } from "./base";
 import {
   GraphQLSchema,
   GraphQLError,
@@ -15,14 +15,11 @@ import {
   OperationDefinitionNode,
   extendSchema,
   DocumentNode,
-  GraphQLType,
   FieldNode,
-  ASTNode,
   ObjectTypeDefinitionNode
 } from "graphql";
 
 import { NotificationHandler, DiagnosticSeverity } from "vscode-languageserver";
-import Uri from "vscode-uri";
 
 import { rangeForASTNode } from "../utilities/source";
 import { formatMS } from "../format";
@@ -42,6 +39,7 @@ import {
   DiagnosticSet,
   diagnosticsFromError
 } from "../diagnostics";
+import URI from "vscode-uri";
 
 function schemaHasASTNodes(schema: GraphQLSchema): boolean {
   const queryType = schema && schema.getQueryType();
@@ -71,11 +69,11 @@ export function isClientProject(
 export interface GraphQLClientProjectConfig {
   clientIdentity?: ClientIdentity;
   config: ClientConfig;
-  rootURI: DocumentUri;
+  rootURI: URI;
   loadingHandler: LoadingHandler;
 }
 export class GraphQLClientProject extends GraphQLProject {
-  public rootURI: DocumentUri;
+  public rootURI: URI;
   public serviceID?: string;
   public config!: ClientConfig;
 
@@ -93,7 +91,7 @@ export class GraphQLClientProject extends GraphQLProject {
     clientIdentity
   }: GraphQLClientProjectConfig) {
     const fileSet = new FileSet({
-      rootPath: Uri.parse(rootURI).fsPath,
+      rootPath: rootURI.fsPath,
       includes: config.client.includes,
       excludes: config.client.excludes
     });

--- a/packages/apollo-language-server/src/project/service.ts
+++ b/packages/apollo-language-server/src/project/service.ts
@@ -1,9 +1,9 @@
-import { GraphQLProject, DocumentUri } from "./base";
+import { GraphQLProject } from "./base";
 import { LoadingHandler } from "../loadingHandler";
 import { FileSet } from "../fileSet";
 import { ServiceConfig } from "../config";
 import { ClientIdentity } from "../engine";
-import Uri from "vscode-uri";
+import URI from "vscode-uri";
 
 export function isServiceProject(
   project: GraphQLProject
@@ -14,7 +14,7 @@ export function isServiceProject(
 export interface GraphQLServiceProjectConfig {
   clientIdentity?: ClientIdentity;
   config: ServiceConfig;
-  rootURI: DocumentUri;
+  rootURI: URI;
   loadingHandler: LoadingHandler;
 }
 export class GraphQLServiceProject extends GraphQLProject {
@@ -25,7 +25,7 @@ export class GraphQLServiceProject extends GraphQLProject {
     loadingHandler
   }: GraphQLServiceProjectConfig) {
     const fileSet = new FileSet({
-      rootPath: Uri.parse(rootURI).fsPath,
+      rootPath: rootURI.fsPath,
       includes: config.service.includes,
       excludes: config.service.excludes
     });

--- a/packages/apollo-language-server/src/workspace.ts
+++ b/packages/apollo-language-server/src/workspace.ts
@@ -13,14 +13,13 @@ import {
   loadConfig,
   ApolloConfig,
   isClientConfig,
-  ApolloConfigFormat,
-  ClientConfig,
   ServiceConfig
 } from "./config";
 import { LanguageServerLoadingHandler } from "./loadingHandler";
 import { ServiceID, SchemaTag, ClientIdentity } from "./engine";
 import { GraphQLClientProject, isClientProject } from "./project/client";
 import { GraphQLServiceProject } from "./project/service";
+import URI from "vscode-uri";
 
 export interface WorkspaceConfig {
   clientIdentity?: ClientIdentity;
@@ -55,13 +54,13 @@ export class GraphQLWorkspace {
       ? new GraphQLClientProject({
           config,
           loadingHandler: this.LanguageServerLoadingHandler,
-          rootURI: folder.uri,
+          rootURI: URI.file(folder.uri),
           clientIdentity
         })
       : new GraphQLServiceProject({
           config: config as ServiceConfig,
           loadingHandler: this.LanguageServerLoadingHandler,
-          rootURI: folder.uri,
+          rootURI: URI.file(folder.uri),
           clientIdentity
         });
 
@@ -123,8 +122,7 @@ export class GraphQLWorkspace {
         `Loading Apollo Config in folder ${configFolder}`,
         (async () => {
           try {
-            const config = await loadConfig({ configPath: configFolder });
-            return config && config.config;
+            return await loadConfig({ configPath: configFolder });
           } catch (e) {
             console.error(e);
             return null;


### PR DESCRIPTION
Multiple streams of work can use this, so breaking out this chunk of work.

The `ApolloConfig` data model should track the URI of its related config file to make that information available when it's needed.
* Add the URI to the data model
* Pass the URI in on construction during `loadConfig`
* Some cleanup / simplification based on things that aren't in use