### PR TITLE
[AT-10] Add helpful errors / messaging around config files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@
   - Improve client:check output [#934](https://github.com/apollographql/apollo-tooling/pull/934)
 - `apollo-language-server`
   - Replace checkOperations mutation with new validateOperations mutation [#934](https://github.com/apollographql/apollo-tooling/pull/934)
+  - Include config files into a project's fileSet [#897](https://github.com/apollographql/apollo-tooling/pull/897)
+  - Add hook into workspace for communicating out when configs are loaded or when errors are found [#897](https://github.com/apollographql/apollo-tooling/pull/897)
+  - Add fn to workspace for reloading a project with a given config URI [#897](https://github.com/apollographql/apollo-tooling/pull/897)
+  - Reload project when config file is changed [#897](https://github.com/apollographql/apollo-tooling/pull/897)
+  - Update error handling from within the server (send as message). This message can be listened for and handled by the consumer [#897](https://github.com/apollographql/apollo-tooling/pull/897)
+- `vscode-apollo`
+  - Update statusBar to reflect new possible "warning" states [#897](https://github.com/apollographql/apollo-tooling/pull/897)
 
 ## `apollo@2.3.1`
 

--- a/packages/apollo-language-server/src/config.ts
+++ b/packages/apollo-language-server/src/config.ts
@@ -4,7 +4,6 @@ import TypeScriptLoader from "@endemolshinegroup/cosmiconfig-typescript-loader";
 import { resolve, dirname } from "path";
 import { readFileSync, existsSync } from "fs";
 import { merge } from "lodash/fp";
-
 import {
   ServiceID,
   ServiceSpecifier,
@@ -139,6 +138,8 @@ export interface LoadConfigSettings {
   // config loading only works on node so we default to
   // process.cwd()
   configPath?: string;
+  configFileName?: string;
+  requireConfig?: boolean;
   name?: string;
   type?: "service" | "client";
 }
@@ -273,17 +274,26 @@ const getServiceFromKey = (key: string | undefined): string | undefined => {
 // XXX load .env files automatically
 export const loadConfig = async ({
   configPath,
+  configFileName,
+  requireConfig = false,
   name,
   type
 }: LoadConfigSettings): Promise<ApolloConfig> => {
   const explorer = cosmiconfig(MODULE_NAME, {
-    searchPlaces: getSearchPlaces(configPath),
+    searchPlaces: getSearchPlaces(configFileName),
     loaders
   });
 
   let loadedConfig = (await explorer.search(configPath)) as ConfigResult<
     ApolloConfigFormat
   >;
+
+  if (requireConfig && !loadedConfig) {
+    throw new Error(
+      `No Apollo config found for project. For more information, please refer to:
+      https://bit.ly/2ByILPj`
+    );
+  }
 
   // add API to the env
   let engineConfig = {},
@@ -328,7 +338,7 @@ export const loadConfig = async ({
     resolvedType = "service";
   } else {
     throw new Error(
-      "Unable to resolve project type. Please add either a client or service config. For more information, please refer to https://www.apollographql.com/docs/references/apollo-config.html"
+      "Unable to resolve project type. Please add either a client or service config. For more information, please refer to https://bit.ly/2ByILPj"
     );
   }
 

--- a/packages/apollo-language-server/src/config.ts
+++ b/packages/apollo-language-server/src/config.ts
@@ -349,24 +349,24 @@ export const loadConfig = async ({
     loadedConfig = {
       isEmpty: false,
       filepath: configPath || process.cwd(),
-      config:
-        resolvedType === "client"
+      config: {
+        ...(loadedConfig && loadedConfig.config),
+        ...(resolvedType === "client"
           ? {
-              ...(loadedConfig ? loadedConfig.config : {}),
               client: {
                 ...DefaultConfigBase,
-                ...(loadedConfig ? loadedConfig.config.client : {}),
+                ...(loadedConfig && loadedConfig.config.client),
                 service: resolvedName
               }
             }
           : {
-              ...(loadedConfig ? loadedConfig.config : {}),
               service: {
                 ...DefaultConfigBase,
-                ...(loadedConfig ? loadedConfig.config.service : {}),
+                ...(loadedConfig && loadedConfig.config.service),
                 name: resolvedName
               }
-            }
+            })
+      }
     };
   }
 

--- a/packages/apollo-language-server/src/project/base.ts
+++ b/packages/apollo-language-server/src/project/base.ts
@@ -125,7 +125,6 @@ export abstract class GraphQLProject implements GraphQLSchemaProvider {
   protected abstract initialize(): Promise<void>[];
 
   abstract getProjectStats(): ProjectStats;
-  abstract updateConfig(config: ApolloConfig): Promise<void>[];
 
   get isReady(): boolean {
     return this._isReady;
@@ -142,6 +141,11 @@ export abstract class GraphQLProject implements GraphQLSchemaProvider {
 
   get whenReady(): Promise<void> {
     return this.readyPromise;
+  }
+
+  public updateConfig(config: ApolloConfig) {
+    this.config = config;
+    return this.initialize();
   }
 
   public resolveSchema(config: SchemaResolveConfig): Promise<GraphQLSchema> {

--- a/packages/apollo-language-server/src/project/base.ts
+++ b/packages/apollo-language-server/src/project/base.ts
@@ -125,6 +125,7 @@ export abstract class GraphQLProject implements GraphQLSchemaProvider {
   protected abstract initialize(): Promise<void>[];
 
   abstract getProjectStats(): ProjectStats;
+  abstract updateConfig(config: ApolloConfig): Promise<void>[];
 
   get isReady(): boolean {
     return this._isReady;

--- a/packages/apollo-language-server/src/project/client.ts
+++ b/packages/apollo-language-server/src/project/client.ts
@@ -94,7 +94,7 @@ export class GraphQLClientProject extends GraphQLProject {
       // the URI of the folder _containing_ the apollo.config.js is the true project's root.
       // if a config doesn't have a uri associated, we can assume the `rootURI` is the project's root.
       rootURI: config.configDirURI || rootURI,
-      includes: config.client.includes,
+      includes: [...config.client.includes, ".env", "apollo.config.js"],
       excludes: config.client.excludes
     });
 

--- a/packages/apollo-language-server/src/project/client.ts
+++ b/packages/apollo-language-server/src/project/client.ts
@@ -140,6 +140,11 @@ export class GraphQLClientProject extends GraphQLProject {
     };
   }
 
+  updateConfig(config: ClientConfig) {
+    this.config = config;
+    return this.initialize();
+  }
+
   onDecorations(handler: (any: any) => void) {
     this._onDecorations = handler;
   }

--- a/packages/apollo-language-server/src/project/client.ts
+++ b/packages/apollo-language-server/src/project/client.ts
@@ -140,11 +140,6 @@ export class GraphQLClientProject extends GraphQLProject {
     };
   }
 
-  updateConfig(config: ClientConfig) {
-    this.config = config;
-    return this.initialize();
-  }
-
   onDecorations(handler: (any: any) => void) {
     this._onDecorations = handler;
   }

--- a/packages/apollo-language-server/src/project/service.ts
+++ b/packages/apollo-language-server/src/project/service.ts
@@ -26,7 +26,7 @@ export class GraphQLServiceProject extends GraphQLProject {
   }: GraphQLServiceProjectConfig) {
     const fileSet = new FileSet({
       rootURI: config.configDirURI || rootURI,
-      includes: config.service.includes,
+      includes: [...config.service.includes, ".env", "apollo.config.js"],
       excludes: config.service.excludes
     });
 

--- a/packages/apollo-language-server/src/project/service.ts
+++ b/packages/apollo-language-server/src/project/service.ts
@@ -42,11 +42,6 @@ export class GraphQLServiceProject extends GraphQLProject {
     return [];
   }
 
-  updateConfig(config: ServiceConfig) {
-    this.config = config;
-    return this.initialize();
-  }
-
   validate() {}
 
   getProjectStats() {

--- a/packages/apollo-language-server/src/project/service.ts
+++ b/packages/apollo-language-server/src/project/service.ts
@@ -42,6 +42,11 @@ export class GraphQLServiceProject extends GraphQLProject {
     return [];
   }
 
+  updateConfig(config: ServiceConfig) {
+    this.config = config;
+    return this.initialize();
+  }
+
   validate() {}
 
   getProjectStats() {

--- a/packages/apollo-language-server/src/schema/providers/index.ts
+++ b/packages/apollo-language-server/src/schema/providers/index.ts
@@ -49,5 +49,7 @@ export function schemaProviderFromConfig(
     }
   }
 
-  throw new Error("No provider was created for config");
+  throw new Error(
+    "No schema provider was created, because the project type was unable to be resolved from your config. Please add either a client or service config. For more information, please refer to https://bit.ly/2ByILPj"
+  );
 }

--- a/packages/apollo-language-server/src/server.ts
+++ b/packages/apollo-language-server/src/server.ts
@@ -108,48 +108,25 @@ documents.onDidChangeContent(params => {
 });
 
 connection.onDidChangeWatchedFiles(params => {
-  for (const change of params.changes) {
-    const uri = change.uri;
-
-    // FIXME: Re-enable updating projects when config files change.
-
-    // const filePath = Uri.parse(change.uri).fsPath;
-    // if (
-    //   filePath.endsWith("apollo.config.js") ||
-    //   filePath.endsWith("package.json")
-    // ) {
-    //   const projectForConfig = Array.from(
-    //     workspace.projectsByFolderUri.values()
-    //   )
-    //     .flatMap(arr => arr)
-    //     .find(proj => {
-    //       return proj.configFile === filePath;
-    //     });
-
-    //   if (projectForConfig) {
-    //     const newConfig = findAndLoadConfig(
-    //       dirname(projectForConfig.configFile),
-    //       false,
-    //       true
-    //     );
-
-    //     if (newConfig) {
-    //       projectForConfig.updateConfig(newConfig);
-    //     }
-    //   }
-    // }
+  for (const { uri, type } of params.changes) {
+    if (
+      uri.endsWith("apollo.config.js") ||
+      uri.endsWith("package.json") ||
+      uri.endsWith(".env")
+    ) {
+      workspace.reloadProjectForConfig(uri);
+    }
 
     // Don't respond to changes in files that are currently open,
     // because we'll get content change notifications instead
-
-    if (change.type === FileChangeType.Changed) {
+    if (type === FileChangeType.Changed) {
       continue;
     }
 
     const project = workspace.projectForFile(uri);
     if (!project) continue;
 
-    switch (change.type) {
+    switch (type) {
       case FileChangeType.Created:
         project.fileDidChange(uri);
         break;

--- a/packages/apollo-language-server/src/server.ts
+++ b/packages/apollo-language-server/src/server.ts
@@ -6,7 +6,8 @@ import {
   ProposedFeatures,
   TextDocuments,
   FileChangeType,
-  ServerCapabilities
+  ServerCapabilities,
+  WorkspaceFolder
 } from "vscode-languageserver";
 import { QuickPickItem } from "vscode";
 import { GraphQLWorkspace } from "./workspace";
@@ -16,6 +17,12 @@ import { LanguageServerLoadingHandler } from "./loadingHandler";
 const connection = createConnection(ProposedFeatures.all);
 
 let hasWorkspaceFolderCapability = false;
+
+// Awaitable promise for sending messages before the connection is initialized
+let initializeConnection: () => void;
+const whenConnectionInitialized: Promise<void> = new Promise(
+  resolve => (initializeConnection = resolve)
+);
 
 const workspace = new GraphQLWorkspace(
   new LanguageServerLoadingHandler(connection),
@@ -43,13 +50,23 @@ workspace.onSchemaTags(params => {
   );
 });
 
-connection.onInitialize(async params => {
-  let capabilities = params.capabilities;
+workspace.onConfigFilesFound(async params => {
+  await whenConnectionInitialized;
+
+  connection.sendNotification(
+    "apollographql/configFilesFound",
+    params instanceof Error
+      ? // Can't stringify Errors, just results in "{}"
+        JSON.stringify({ message: params.message, stack: params.stack })
+      : JSON.stringify(params)
+  );
+});
+
+connection.onInitialize(async ({ capabilities, workspaceFolders }) => {
   hasWorkspaceFolderCapability = !!(
     capabilities.workspace && capabilities.workspace.workspaceFolders
   );
 
-  const workspaceFolders = params.workspaceFolders;
   if (workspaceFolders) {
     // We wait until all projects are added, because after `initialize` returns we can get additional requests
     // like `textDocument/codeLens`, and that way these can await `GraphQLProject#whenReady` to make sure
@@ -82,6 +99,7 @@ connection.onInitialize(async params => {
 });
 
 connection.onInitialized(async () => {
+  initializeConnection();
   if (hasWorkspaceFolderCapability) {
     connection.workspace.onDidChangeWorkspaceFolders(async event => {
       await Promise.all([

--- a/packages/apollo-language-server/src/workspace.ts
+++ b/packages/apollo-language-server/src/workspace.ts
@@ -4,7 +4,6 @@ import {
   PublishDiagnosticsParams
 } from "vscode-languageserver";
 import { QuickPickItem } from "vscode";
-
 import { GraphQLProject, DocumentUri } from "./project/base";
 import { dirname } from "path";
 import * as fg from "glob";
@@ -23,10 +22,12 @@ import URI from "vscode-uri";
 export interface WorkspaceConfig {
   clientIdentity?: ClientIdentity;
 }
+
 export class GraphQLWorkspace {
   private _onDiagnostics?: NotificationHandler<PublishDiagnosticsParams>;
-  private _onDecorations?: (any: any) => void;
+  private _onDecorations?: NotificationHandler<any>;
   private _onSchemaTags?: NotificationHandler<[ServiceID, SchemaTag[]]>;
+  private _onConfigFilesFound?: NotificationHandler<ApolloConfig[]>;
 
   private projectsByFolderUri: Map<string, GraphQLProject[]> = new Map();
 
@@ -39,7 +40,7 @@ export class GraphQLWorkspace {
     this._onDiagnostics = handler;
   }
 
-  onDecorations(handler: (any: any) => void) {
+  onDecorations(handler: NotificationHandler<any>) {
     this._onDecorations = handler;
   }
 
@@ -118,9 +119,7 @@ export class GraphQLWorkspace {
     );
 
     // only have unique possible folders
-    const apolloConfigFolders = new Set<string>(
-      apolloConfigFiles.map(f => dirname(f))
-    );
+    const apolloConfigFolders = new Set<string>(apolloConfigFiles.map(dirname));
 
     // go from possible folders to known array of configs
     const projectConfigs = Array.from(apolloConfigFolders).map(configFolder =>

--- a/packages/apollo-language-server/src/workspace.ts
+++ b/packages/apollo-language-server/src/workspace.ts
@@ -48,7 +48,13 @@ export class GraphQLWorkspace {
     this._onSchemaTags = handler;
   }
 
-  private createProject(config: ApolloConfig, folder: WorkspaceFolder) {
+  private createProject({
+    config,
+    folder
+  }: {
+    config: ApolloConfig;
+    folder: WorkspaceFolder;
+  }) {
     const { clientIdentity } = this.config;
     const project = isClientConfig(config)
       ? new GraphQLClientProject({

--- a/packages/apollo-language-server/src/workspace.ts
+++ b/packages/apollo-language-server/src/workspace.ts
@@ -133,17 +133,7 @@ export class GraphQLWorkspace {
 
     // go from possible folders to known array of configs
     const projectConfigs = Array.from(apolloConfigFolders).map(configFolder =>
-      this.LanguageServerLoadingHandler.handle<ApolloConfig | null>(
-        `Loading Apollo Config in folder ${configFolder}`,
-        (async () => {
-          try {
-            return await loadConfig({ configPath: configFolder });
-          } catch (e) {
-            console.error(e);
-            return null;
-          }
-        })()
-      )
+      loadConfig({ configPath: configFolder, requireConfig: true })
     );
 
     let foundConfigs: ApolloConfig[] | Error = [];

--- a/packages/apollo/src/Command.ts
+++ b/packages/apollo/src/Command.ts
@@ -107,21 +107,23 @@ export abstract class ProjectCommand extends Command {
 
     const config = await this.createConfig(flags);
     this.createService(config, flags);
-    (this.ctx.config = config),
-      // make sure this the first item in the task list
-      this.tasks.push({
-        title: "Loading Apollo Project",
-        task: async ctx => {
-          await this.project.whenReady;
-          ctx = { ...ctx, ...this.ctx };
-        }
-      });
+    this.ctx.config = config;
+
+    // make sure this the first item in the task list
+    this.tasks.push({
+      title: "Loading Apollo Project",
+      task: async ctx => {
+        await this.project.whenReady;
+        ctx = { ...ctx, ...this.ctx };
+      }
+    });
   }
 
   protected async createConfig(flags: Flags) {
     const service = flags.key ? getServiceFromKey(flags.key) : undefined;
     const config = await loadConfig({
       configPath: flags.config && parse(resolve(flags.config)).dir,
+      configFileName: flags.config,
       name: service,
       type: this.type
     });
@@ -206,6 +208,10 @@ export abstract class ProjectCommand extends Command {
         rootURI,
         clientIdentity
       });
+    } else {
+      throw new Error(
+        "Unable to resolve project type. Please add either a client or service config. For more information, please refer to https://bit.ly/2ByILPj"
+      );
     }
 
     this.ctx.project = this.project;

--- a/packages/vscode-apollo/package.json
+++ b/packages/vscode-apollo/package.json
@@ -40,7 +40,7 @@
   ],
   "icon": "images/icon-apollo-teal-400x400.png",
   "activationEvents": [
-    "workspaceContains:**/apollo.config.js"
+    "workspaceContains:**/package.json"
   ],
   "contributes": {
     "configuration": {

--- a/packages/vscode-apollo/src/__tests__/statusBar.test.ts
+++ b/packages/vscode-apollo/src/__tests__/statusBar.test.ts
@@ -2,7 +2,7 @@ import StatusBar from "../statusBar";
 
 describe("statusBar", () => {
   it("only shows loaded state when it's supposed to", () => {
-    const statusBar = new StatusBar();
+    const statusBar = new StatusBar({ hasActiveTextEditor: true });
 
     expect(statusBar.statusBarItem.text).toEqual(StatusBar.loadingStateText);
     statusBar.showLoadedState({ hasActiveTextEditor: true });

--- a/packages/vscode-apollo/src/extension.ts
+++ b/packages/vscode-apollo/src/extension.ts
@@ -19,7 +19,7 @@ import {
   printStatsToClientOutputChannel
 } from "./utils";
 
-const { version } = require("./package.json");
+const { version } = require("../package.json");
 
 let client: LanguageClient;
 let clientDisposable: Disposable;

--- a/packages/vscode-apollo/src/languageServerClient.ts
+++ b/packages/vscode-apollo/src/languageServerClient.ts
@@ -1,0 +1,66 @@
+import {
+  ServerOptions,
+  TransportKind,
+  LanguageClientOptions,
+  LanguageClient
+} from "vscode-languageclient";
+import { workspace, OutputChannel } from "vscode";
+
+const { version, referenceID } = require("../package.json");
+
+export function getLanguageServerClient(
+  serverModule: string,
+  outputChannel: OutputChannel
+) {
+  const env = {
+    APOLLO_CLIENT_NAME: "Apollo VS Code",
+    APOLLO_CLIENT_VERSION: version,
+    APOLLO_CLIENT_REFERENCE_ID: referenceID
+  };
+
+  const debugOptions = {
+    execArgv: ["--nolazy", "--inspect=6009"],
+    env
+  };
+
+  const serverOptions: ServerOptions = {
+    run: {
+      module: serverModule,
+      transport: TransportKind.ipc,
+      options: {
+        env
+      }
+    },
+    debug: {
+      module: serverModule,
+      transport: TransportKind.ipc,
+      options: debugOptions
+    }
+  };
+
+  const clientOptions: LanguageClientOptions = {
+    documentSelector: [
+      "graphql",
+      "javascript",
+      "typescript",
+      "javascriptreact",
+      "typescriptreact",
+      "python"
+    ],
+    synchronize: {
+      fileEvents: [
+        workspace.createFileSystemWatcher("**/package.json"),
+        workspace.createFileSystemWatcher("**/.env"),
+        workspace.createFileSystemWatcher("**/*.{graphql,js,ts,jsx,tsx,py}")
+      ]
+    },
+    outputChannel
+  };
+
+  return new LanguageClient(
+    "apollographql",
+    "Apollo GraphQL",
+    serverOptions,
+    clientOptions
+  );
+}

--- a/packages/vscode-apollo/src/statusBar.ts
+++ b/packages/vscode-apollo/src/statusBar.ts
@@ -1,31 +1,64 @@
 import { window, StatusBarAlignment } from "vscode";
 
+interface LoadingInput {
+  hasActiveTextEditor: boolean;
+}
+
+interface StateChangeInput extends LoadingInput {
+  text: string;
+  tooltip?: string;
+}
+
 export default class ApolloStatusBar {
   public statusBarItem = window.createStatusBarItem(StatusBarAlignment.Right);
 
   static loadingStateText = "Apollo GraphQL $(rss)";
   static loadedStateText = "ApolloGraphQL $(rocket)";
+  static warningText = "Apollo GraphQL $(alert)";
 
-  constructor() {
-    this.statusBarItem.text = ApolloStatusBar.loadingStateText;
-    this.statusBarItem.show();
-
+  constructor({ hasActiveTextEditor }: LoadingInput) {
+    this.showLoadingState({ hasActiveTextEditor });
     this.statusBarItem.command = "apollographql/showStats";
-    // context.subscriptions.push(this.statusBarItem);
   }
 
-  public showLoadedState({
-    hasActiveTextEditor
-  }: {
-    hasActiveTextEditor: boolean;
-  }) {
+  protected changeState({
+    hasActiveTextEditor,
+    text,
+    tooltip
+  }: StateChangeInput) {
     if (!hasActiveTextEditor) {
       this.statusBarItem.hide();
       return;
     }
 
-    this.statusBarItem.text = ApolloStatusBar.loadedStateText;
+    this.statusBarItem.text = text;
+    this.statusBarItem.tooltip = tooltip;
     this.statusBarItem.show();
+  }
+
+  public showLoadingState({ hasActiveTextEditor }: LoadingInput) {
+    this.changeState({
+      hasActiveTextEditor,
+      text: ApolloStatusBar.loadingStateText
+    });
+  }
+
+  public showLoadedState({ hasActiveTextEditor }: LoadingInput) {
+    this.changeState({
+      hasActiveTextEditor,
+      text: ApolloStatusBar.loadedStateText
+    });
+  }
+
+  public showWarningState({
+    hasActiveTextEditor,
+    tooltip
+  }: LoadingInput & { tooltip: string }) {
+    this.changeState({
+      hasActiveTextEditor,
+      text: ApolloStatusBar.warningText,
+      tooltip
+    });
   }
 
   public dispose() {


### PR DESCRIPTION
This PR adds new warning states and communication within the extension in order to help users resolve config issues more easily and know when there's a problem.

![noconfig](https://user-images.githubusercontent.com/29644393/51344306-2d84e980-1a4d-11e9-928a-eaec151f3627.png)

Also included with this PR is a bit of a shift in how errors are handled. After speaking with James about it, we both agreed that this would be a scalable approach that will work well with clients consuming the language server or using its parts programmatically.
* Internals of the language server should throw errors, as opposed to catching them and logging at any point.
* The server itself should catch these errors at the top level and message them out via the connection, so they can be consumed by any client listening on that connection.
* Clients using the language server parts programmatically should catch and handle these errors in an appropriate manner based on the requirements of the client.