### PR TITLE
Add documentation and launch task for CLI active development

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,23 +111,12 @@ jobs:
             - ~/.npm
       - run: ENGINE_API_KEY=$CHECKS_API_KEY ./packages/apollo/bin/run client:check
 
-ignore_doc_branches: &ignore_doc_branches
-  filters:
-    branches:
-      # If 'docs' is found, with word boundaries on either side, skip.
-      ignore: /.*?\bdocs\b.*/
-
 workflows:
   version: 2
   Build and Test:
     jobs:
-      - Node.js 8:
-          <<: *ignore_doc_branches
-      - Node.js 10:
-          <<: *ignore_doc_branches
-      - VSCode:
-          <<: *ignore_doc_branches
-      - Linting:
-          <<: *ignore_doc_branches
-      - Query Check:
-          <<: *ignore_doc_branches
+      - Node.js 8
+      - Node.js 10
+      - VSCode
+      - Linting
+      - Query Check

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -43,6 +43,14 @@
       "protocol": "inspector",
       "port": 9001,
       "sourceMaps": true
+    },
+    {
+      "name": "Attach to CLI Debugger",
+      "type": "node",
+      "request": "attach",
+      "protocol": "inspector",
+      "port": 9002,
+      "sourceMaps": true
     }
   ]
 }

--- a/packages/apollo/README.md
+++ b/packages/apollo/README.md
@@ -607,6 +607,16 @@ It can also be helpful to print standard out during testing. To enable logging, 
 .stdout({ print: true })
 ```
 
+## Active Development / Debugging
+
+To simplify the development process, you may want to step through and debug commands whose behavior you're modifying. To do this, run the executable with node in debug mode like so, where `<command>` is a valid CLI command like `client:check` or `service:push`:
+
+```
+node --inspect-brk=9002 packages/apollo/bin/run <command>
+```
+
+If you're using VS Code, you can run the included "Attach to CLI Debugger" launch task and debug right from VS Code! Otherwise, you may use the (Chrome inspector)[https://nodejs.org/en/docs/guides/debugging-getting-started/] or other Node debugger of your choice.
+
 ## Publishing
 
 - Make sure you have a `GITHUB_AUTH` set in your environment variables. For more information on setting `GITHUB_AUTH`, check the [`lerna-changelog` documentation](https://github.com/lerna/lerna-changelog#github-token).


### PR DESCRIPTION
This PR is mostly a convenience for me, so I have a reference to copy/paste when I'm developing the CLI. But this totally makes sense to document and make easy for other contributors 😄 