### PR TITLE
fix(vscode-apollo): Comments not being highlighted correctly

### DIFF
--- a/packages/vscode-apollo/syntaxes/graphql.json
+++ b/packages/vscode-apollo/syntaxes/graphql.json
@@ -267,7 +267,7 @@
     },
     "graphql-variable-assignment": {
       "begin": "\\s(=)",
-      "end": "(?=.)",
+      "end": "(?=[\n.])",
       "applyEndPatternLast": 1,
       "beginCaptures": {
         "1": { "name": "punctuation.assignment.graphql" }


### PR DESCRIPTION
Given the following:
```
launches(
  """
  The number of results to show. Must be >= 1.
  """
  pageSize: Int = 20
[Completely blank line; no whitespace characters aside from \n]
  """
  If you add a cursor here, it will only return results _after_ this cursor
  """
  after: String = "hello nurse"
): LaunchConnection!
```

The second comment would be detected and highlighted as a string, not a comment. My formatter removes any additional spaces at the end of lines, so this was a visual nuisance.

Changed from `(?=.)` to `(?=[\n.]` because `.` doesn't take line breaks into consideration.

Hopefully that's the correct place to change this; never created a textmate syntax before.