### PR TITLE
[WIP] Allow Typescript global types in global NS

### DIFF
--- a/packages/apollo-codegen-typescript/src/language.ts
+++ b/packages/apollo-codegen-typescript/src/language.ts
@@ -18,6 +18,7 @@ export type ObjectProperty = {
 
 export interface TypescriptCompilerOptions extends CompilerOptions {
   // Leaving this open for Typescript only compiler options
+  useTypescriptGlobalNS: boolean;
 }
 
 export default class TypescriptGenerator {

--- a/packages/apollo/README.md
+++ b/packages/apollo/README.md
@@ -96,11 +96,11 @@ ARGUMENTS
   OUTPUT
       Directory to which generated files will be written.
       - For TypeScript/Flow generators, this specifies a directory relative to each source file by default.
-      - For TypeScript/Flow generators with the "outputFlat" flag is set, and for the Swift generator, this specifies a 
+      - For TypeScript/Flow generators with the "outputFlat" flag is set, and for the Swift generator, this specifies a
       file or directory (absolute or relative to the current working directory) to which:
          - a file will be written for each query (if "output" is a directory)
          - all generated types will be written
-      - For all other types, this defines a file (absolute or relative to the current working directory) to which all 
+      - For all other types, this defines a file (absolute or relative to the current working directory) to which all
       generated types are written.
 
 OPTIONS
@@ -165,6 +165,8 @@ OPTIONS
   --useFlowExactObjects                      Use Flow exact objects for generated types [flow only]
 
   --useFlowReadOnlyTypes                     Use Flow read only types for generated types [flow only]
+
+  --useTypescriptGlobalNS                    Use Typescript global namespace [typescript only]
 
   --watch                                    Watch for file changes and reload codegen
 
@@ -307,15 +309,15 @@ DESCRIPTION
 
   Installation of a user-installed plugin will override a core plugin.
 
-  e.g. If you have a core plugin that has a 'hello' command, installing a user-installed plugin with a 'hello' command 
-  will override the core plugin implementation. This is useful if a user needs to update core plugin functionality in 
+  e.g. If you have a core plugin that has a 'hello' command, installing a user-installed plugin with a 'hello' command
+  will override the core plugin implementation. This is useful if a user needs to update core plugin functionality in
   the CLI without the need to patch and update the whole CLI.
 
 ALIASES
   $ apollo plugins:add
 
 EXAMPLES
-  $ apollo plugins:install myplugin 
+  $ apollo plugins:install myplugin
   $ apollo plugins:install https://github.com/someuser/someplugin
   $ apollo plugins:install someuser/someplugin
 ```
@@ -340,7 +342,7 @@ OPTIONS
 DESCRIPTION
   Installation of a linked plugin will override a user-installed or core plugin.
 
-  e.g. If you have a user-installed or core plugin that has a 'hello' command, installing a linked plugin with a 'hello' 
+  e.g. If you have a user-installed or core plugin that has a 'hello' command, installing a linked plugin with a 'hello'
   command will override the user-installed or core plugin implementation. This is useful for development work.
 
 EXAMPLE

--- a/packages/apollo/src/commands/client/codegen.ts
+++ b/packages/apollo/src/commands/client/codegen.ts
@@ -196,6 +196,7 @@ export default class Generate extends ClientCommand {
                       flags.mergeInFieldsFromFragmentSpreads,
                     useFlowExactObjects: flags.useFlowExactObjects,
                     useFlowReadOnlyTypes: flags.useFlowReadOnlyTypes,
+                    useTypescriptGlobalNS: flags.useTypescriptGlobalNS,
                     globalTypesFile: flags.globalTypesFile
                   }
                 );

--- a/packages/apollo/src/commands/client/codegen.ts
+++ b/packages/apollo/src/commands/client/codegen.ts
@@ -91,6 +91,9 @@ export default class Generate extends ClientCommand {
     globalTypesFile: flags.string({
       description:
         'By default, TypeScript will put a file named "globalTypes.ts" inside the "output" directory. Set "globalTypesFile" to specify a different path.'
+    }),
+    useTypescriptGlobalNS: flags.boolean({
+      description: "Use Typescript global namespace"
     })
   };
 

--- a/packages/apollo/src/generate.ts
+++ b/packages/apollo/src/generate.ts
@@ -24,6 +24,7 @@ import {
 import { generateSource as generateScalaSource } from "apollo-codegen-scala";
 
 import { FlowCompilerOptions } from "../../apollo-codegen-flow/lib/language";
+import { TypescriptCompilerOptions } from "../../apollo-codegen-typescript/lib/language";
 import { validateQueryDocument } from "apollo-language-server/lib/errors/validation";
 
 export type TargetType =
@@ -36,6 +37,7 @@ export type TargetType =
 
 export type GenerationOptions = CompilerOptions &
   LegacyCompilerOptions &
+  TypescriptCompilerOptions &
   FlowCompilerOptions & {
     globalTypesFile?: string;
     rootPath?: string;


### PR DESCRIPTION
This PR adds an option that allows users to define all the GQL enums in the global namespace so they don't have to import those types everywhere.

This was already possible for flow with their `[libs]` config, but TS requires the file itself to specify its scope. I've tested and have tried it, it works.

TODO: 

- [ ] Squash commits
- [ ] Add Tests