### PR TITLE
Improve Scala codegen to make results feel more like case classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Upcoming
+- `apollo-codegen-scala`
+  - Generate additional case-class like APIs for data containers [#943](https://github.com/apollographql/apollo-tooling/pull/943)
 
 ## `apollo@2.4.3`
 

--- a/packages/apollo-codegen-scala/src/__tests__/__snapshots__/codeGeneration.ts.snap
+++ b/packages/apollo-codegen-scala/src/__tests__/__snapshots__/codeGeneration.ts.snap
@@ -13,31 +13,71 @@ exports[`Scala code generation #classDeclarationForOperation() should generate a
 
 
   @scala.scalajs.js.native trait Variables extends scala.scalajs.js.Object {
-    val episode: com.apollographql.scalajs.OptionalInput[String]
+    val episode: com.apollographql.scalajs.OptionalValue[String]
   }
 
   object Variables {
-    def apply(episode: com.apollographql.scalajs.OptionalInput[String] = com.apollographql.scalajs.OptionalInput.empty) =  {
+    def apply(episode: com.apollographql.scalajs.OptionalValue[String] = com.apollographql.scalajs.OptionalValue.empty) = {
       scala.scalajs.js.Dynamic.literal(episode = episode).asInstanceOf[Variables]
+    }
+
+    def unapply(value: Variables) = {
+      Some((value.episode))
+    }
+
+    implicit class CopyExtensions(private val orig: Variables) extends AnyVal {
+      def copy(episode: com.apollographql.scalajs.OptionalValue[String] = orig.episode) = {
+        scala.scalajs.js.Dynamic.literal(episode = episode).asInstanceOf[Variables]
+      }
     }
   }
 
   @scala.scalajs.js.native trait Data extends scala.scalajs.js.Object {
-    val createReview: com.apollographql.scalajs.OptionalResult[Data.CreateReview]
+    val createReview: com.apollographql.scalajs.OptionalValue[Data.CreateReview]
   }
 
   object Data {
+    def apply(createReview: com.apollographql.scalajs.OptionalValue[Data.CreateReview] = com.apollographql.scalajs.OptionalValue.empty) = {
+      scala.scalajs.js.Dynamic.literal(createReview = createReview).asInstanceOf[Data]
+    }
+
+    def unapply(value: Data) = {
+      Some((value.createReview))
+    }
+
+    implicit class CopyExtensions(private val orig: Data) extends AnyVal {
+      def copy(createReview: com.apollographql.scalajs.OptionalValue[Data.CreateReview] = orig.createReview) = {
+        scala.scalajs.js.Dynamic.literal(createReview = createReview).asInstanceOf[Data]
+      }
+    }
+
     val possibleTypes = scala.collection.Set(\\"Mutation\\")
+
     implicit class ViewExtensions(private val orig: Data) extends AnyVal {
     }
 
     @scala.scalajs.js.native trait CreateReview extends scala.scalajs.js.Object {
       val stars: Int
-      val commentary: com.apollographql.scalajs.OptionalResult[String]
+      val commentary: com.apollographql.scalajs.OptionalValue[String]
     }
 
     object CreateReview {
+      def apply(stars: Int, commentary: com.apollographql.scalajs.OptionalValue[String] = com.apollographql.scalajs.OptionalValue.empty) = {
+        scala.scalajs.js.Dynamic.literal(stars = stars, commentary = commentary).asInstanceOf[CreateReview]
+      }
+
+      def unapply(value: CreateReview) = {
+        Some((value.stars, value.commentary))
+      }
+
+      implicit class CopyExtensions(private val orig: CreateReview) extends AnyVal {
+        def copy(stars: Int = orig.stars, commentary: com.apollographql.scalajs.OptionalValue[String] = orig.commentary) = {
+          scala.scalajs.js.Dynamic.literal(stars = stars, commentary = commentary).asInstanceOf[CreateReview]
+        }
+      }
+
       val possibleTypes = scala.collection.Set(\\"Review\\")
+
       implicit class ViewExtensions(private val orig: CreateReview) extends AnyVal {
       }
     }
@@ -60,21 +100,51 @@ exports[`Scala code generation #classDeclarationForOperation() should generate a
   type Variables = Unit
 
   @scala.scalajs.js.native trait Data extends scala.scalajs.js.Object {
-    val hero: com.apollographql.scalajs.OptionalResult[Data.Hero]
+    val hero: com.apollographql.scalajs.OptionalValue[Data.Hero]
   }
 
   object Data {
+    def apply(hero: com.apollographql.scalajs.OptionalValue[Data.Hero] = com.apollographql.scalajs.OptionalValue.empty) = {
+      scala.scalajs.js.Dynamic.literal(hero = hero).asInstanceOf[Data]
+    }
+
+    def unapply(value: Data) = {
+      Some((value.hero))
+    }
+
+    implicit class CopyExtensions(private val orig: Data) extends AnyVal {
+      def copy(hero: com.apollographql.scalajs.OptionalValue[Data.Hero] = orig.hero) = {
+        scala.scalajs.js.Dynamic.literal(hero = hero).asInstanceOf[Data]
+      }
+    }
+
     val possibleTypes = scala.collection.Set(\\"Query\\")
+
     implicit class ViewExtensions(private val orig: Data) extends AnyVal {
     }
 
     @scala.scalajs.js.native trait Hero extends scala.scalajs.js.Object with HeroDetails {
       val name: String
-      val friends: com.apollographql.scalajs.OptionalResult[scala.scalajs.js.Array[com.apollographql.scalajs.OptionalResult[Hero.Friend]]]
+      val friends: com.apollographql.scalajs.OptionalValue[scala.scalajs.js.Array[com.apollographql.scalajs.OptionalValue[Hero.Friend]]]
     }
 
     object Hero {
+      def apply(name: String, friends: com.apollographql.scalajs.OptionalValue[scala.scalajs.js.Array[com.apollographql.scalajs.OptionalValue[Hero.Friend]]] = com.apollographql.scalajs.OptionalValue.empty) = {
+        scala.scalajs.js.Dynamic.literal(name = name, friends = friends).asInstanceOf[Hero]
+      }
+
+      def unapply(value: Hero) = {
+        Some((value.name, value.friends))
+      }
+
+      implicit class CopyExtensions(private val orig: Hero) extends AnyVal {
+        def copy(name: String = orig.name, friends: com.apollographql.scalajs.OptionalValue[scala.scalajs.js.Array[com.apollographql.scalajs.OptionalValue[Hero.Friend]]] = orig.friends) = {
+          scala.scalajs.js.Dynamic.literal(name = name, friends = friends).asInstanceOf[Hero]
+        }
+      }
+
       val possibleTypes = scala.collection.Set(\\"Human\\", \\"Droid\\")
+
       implicit class ViewExtensions(private val orig: Hero) extends AnyVal {
       }
 
@@ -83,7 +153,22 @@ exports[`Scala code generation #classDeclarationForOperation() should generate a
       }
 
       object Friend {
+        def apply(name: String) = {
+          scala.scalajs.js.Dynamic.literal(name = name).asInstanceOf[Friend]
+        }
+
+        def unapply(value: Friend) = {
+          Some((value.name))
+        }
+
+        implicit class CopyExtensions(private val orig: Friend) extends AnyVal {
+          def copy(name: String = orig.name) = {
+            scala.scalajs.js.Dynamic.literal(name = name).asInstanceOf[Friend]
+          }
+        }
+
         val possibleTypes = scala.collection.Set(\\"Human\\", \\"Droid\\")
+
         implicit class ViewExtensions(private val orig: Friend) extends AnyVal {
         }
       }
@@ -93,11 +178,26 @@ exports[`Scala code generation #classDeclarationForOperation() should generate a
 
 @scala.scalajs.js.native trait HeroDetails extends scala.scalajs.js.Object {
   val name: String
-  val friends: com.apollographql.scalajs.OptionalResult[scala.scalajs.js.Array[com.apollographql.scalajs.OptionalResult[HeroDetails.Friend]]]
+  val friends: com.apollographql.scalajs.OptionalValue[scala.scalajs.js.Array[com.apollographql.scalajs.OptionalValue[HeroDetails.Friend]]]
 }
 
 object HeroDetails {
+  def apply(name: String, friends: com.apollographql.scalajs.OptionalValue[scala.scalajs.js.Array[com.apollographql.scalajs.OptionalValue[HeroDetails.Friend]]] = com.apollographql.scalajs.OptionalValue.empty) = {
+    scala.scalajs.js.Dynamic.literal(name = name, friends = friends).asInstanceOf[HeroDetails]
+  }
+
+  def unapply(value: HeroDetails) = {
+    Some((value.name, value.friends))
+  }
+
+  implicit class CopyExtensions(private val orig: HeroDetails) extends AnyVal {
+    def copy(name: String = orig.name, friends: com.apollographql.scalajs.OptionalValue[scala.scalajs.js.Array[com.apollographql.scalajs.OptionalValue[HeroDetails.Friend]]] = orig.friends) = {
+      scala.scalajs.js.Dynamic.literal(name = name, friends = friends).asInstanceOf[HeroDetails]
+    }
+  }
+
   val possibleTypes = scala.collection.Set(\\"Human\\", \\"Droid\\")
+
   implicit class ViewExtensions(private val orig: HeroDetails) extends AnyVal {
   }
 
@@ -106,7 +206,22 @@ object HeroDetails {
   }
 
   object Friend {
+    def apply(name: String) = {
+      scala.scalajs.js.Dynamic.literal(name = name).asInstanceOf[Friend]
+    }
+
+    def unapply(value: Friend) = {
+      Some((value.name))
+    }
+
+    implicit class CopyExtensions(private val orig: Friend) extends AnyVal {
+      def copy(name: String = orig.name) = {
+        scala.scalajs.js.Dynamic.literal(name = name).asInstanceOf[Friend]
+      }
+    }
+
     val possibleTypes = scala.collection.Set(\\"Human\\", \\"Droid\\")
+
     implicit class ViewExtensions(private val orig: Friend) extends AnyVal {
     }
   }
@@ -137,15 +252,27 @@ exports[`Scala code generation #classDeclarationForOperation() should generate a
   type Variables = Unit
 
   @scala.scalajs.js.native trait Data extends scala.scalajs.js.Object {
-    val hero: com.apollographql.scalajs.OptionalResult[Data.Hero]
+    val hero: com.apollographql.scalajs.OptionalValue[Data.Hero]
   }
 
   object Data {
-    val possibleTypes = scala.collection.Set(\\"Query\\")
-    implicit class ViewExtensions(private val orig: Data) extends AnyVal {
+    def apply(hero: com.apollographql.scalajs.OptionalValue[Data.Hero] = com.apollographql.scalajs.OptionalValue.empty) = {
+      scala.scalajs.js.Dynamic.literal(hero = hero).asInstanceOf[Data]
     }
 
-    @scala.scalajs.js.native trait Hero extends scala.scalajs.js.Object {
+    def unapply(value: Data) = {
+      Some((value.hero))
+    }
+
+    implicit class CopyExtensions(private val orig: Data) extends AnyVal {
+      def copy(hero: com.apollographql.scalajs.OptionalValue[Data.Hero] = orig.hero) = {
+        scala.scalajs.js.Dynamic.literal(hero = hero).asInstanceOf[Data]
+      }
+    }
+
+    val possibleTypes = scala.collection.Set(\\"Query\\")
+
+    implicit class ViewExtensions(private val orig: Data) extends AnyVal {
     }
 
     @scala.scalajs.js.native trait AsDroid extends scala.scalajs.js.Object with Hero with HeroDetails {
@@ -153,13 +280,46 @@ exports[`Scala code generation #classDeclarationForOperation() should generate a
     }
 
     object AsDroid {
+      def apply(name: String) = {
+        scala.scalajs.js.Dynamic.literal(name = name).asInstanceOf[AsDroid]
+      }
+
+      def unapply(value: AsDroid) = {
+        Some((value.name))
+      }
+
+      implicit class CopyExtensions(private val orig: AsDroid) extends AnyVal {
+        def copy(name: String = orig.name) = {
+          scala.scalajs.js.Dynamic.literal(name = name).asInstanceOf[AsDroid]
+        }
+      }
+
       val possibleTypes = scala.collection.Set(\\"Droid\\")
+
       implicit class ViewExtensions(private val orig: AsDroid) extends AnyVal {
       }
     }
 
+    @scala.scalajs.js.native trait Hero extends scala.scalajs.js.Object {
+    }
+
     object Hero {
+      def apply() = {
+        scala.scalajs.js.Dynamic.literal().asInstanceOf[Hero]
+      }
+
+      def unapply(value: Hero) = {
+        Some(())
+      }
+
+      implicit class CopyExtensions(private val orig: Hero) extends AnyVal {
+        def copy() = {
+          scala.scalajs.js.Dynamic.literal().asInstanceOf[Hero]
+        }
+      }
+
       val possibleTypes = scala.collection.Set(\\"Human\\", \\"Droid\\")
+
       implicit class ViewExtensions(private val orig: Hero) extends AnyVal {
         def asDroid: Option[AsDroid] = {
           if (AsDroid.possibleTypes.contains(orig.asInstanceOf[scala.scalajs.js.Dynamic].__typename.asInstanceOf[String])) Some(orig.asInstanceOf[AsDroid]) else None
@@ -185,29 +345,74 @@ exports[`Scala code generation #classDeclarationForOperation() should generate a
   type Variables = Unit
 
   @scala.scalajs.js.native trait Data extends scala.scalajs.js.Object {
-    val hero: com.apollographql.scalajs.OptionalResult[Data.Hero]
+    val hero: com.apollographql.scalajs.OptionalValue[Data.Hero]
   }
 
   object Data {
+    def apply(hero: com.apollographql.scalajs.OptionalValue[Data.Hero] = com.apollographql.scalajs.OptionalValue.empty) = {
+      scala.scalajs.js.Dynamic.literal(hero = hero).asInstanceOf[Data]
+    }
+
+    def unapply(value: Data) = {
+      Some((value.hero))
+    }
+
+    implicit class CopyExtensions(private val orig: Data) extends AnyVal {
+      def copy(hero: com.apollographql.scalajs.OptionalValue[Data.Hero] = orig.hero) = {
+        scala.scalajs.js.Dynamic.literal(hero = hero).asInstanceOf[Data]
+      }
+    }
+
     val possibleTypes = scala.collection.Set(\\"Query\\")
+
     implicit class ViewExtensions(private val orig: Data) extends AnyVal {
+    }
+
+    @scala.scalajs.js.native trait AsDroid extends scala.scalajs.js.Object with Hero with DroidDetails {
+      val primaryFunction: com.apollographql.scalajs.OptionalValue[String]
+    }
+
+    object AsDroid {
+      def apply(primaryFunction: com.apollographql.scalajs.OptionalValue[String] = com.apollographql.scalajs.OptionalValue.empty) = {
+        scala.scalajs.js.Dynamic.literal(primaryFunction = primaryFunction).asInstanceOf[AsDroid]
+      }
+
+      def unapply(value: AsDroid) = {
+        Some((value.primaryFunction))
+      }
+
+      implicit class CopyExtensions(private val orig: AsDroid) extends AnyVal {
+        def copy(primaryFunction: com.apollographql.scalajs.OptionalValue[String] = orig.primaryFunction) = {
+          scala.scalajs.js.Dynamic.literal(primaryFunction = primaryFunction).asInstanceOf[AsDroid]
+        }
+      }
+
+      val possibleTypes = scala.collection.Set(\\"Droid\\")
+
+      implicit class ViewExtensions(private val orig: AsDroid) extends AnyVal {
+      }
     }
 
     @scala.scalajs.js.native trait Hero extends scala.scalajs.js.Object {
     }
 
-    @scala.scalajs.js.native trait AsDroid extends scala.scalajs.js.Object with Hero with DroidDetails {
-      val primaryFunction: com.apollographql.scalajs.OptionalResult[String]
-    }
-
-    object AsDroid {
-      val possibleTypes = scala.collection.Set(\\"Droid\\")
-      implicit class ViewExtensions(private val orig: AsDroid) extends AnyVal {
-      }
-    }
-
     object Hero {
+      def apply() = {
+        scala.scalajs.js.Dynamic.literal().asInstanceOf[Hero]
+      }
+
+      def unapply(value: Hero) = {
+        Some(())
+      }
+
+      implicit class CopyExtensions(private val orig: Hero) extends AnyVal {
+        def copy() = {
+          scala.scalajs.js.Dynamic.literal().asInstanceOf[Hero]
+        }
+      }
+
       val possibleTypes = scala.collection.Set(\\"Human\\", \\"Droid\\")
+
       implicit class ViewExtensions(private val orig: Hero) extends AnyVal {
         def asDroid: Option[AsDroid] = {
           if (AsDroid.possibleTypes.contains(orig.asInstanceOf[scala.scalajs.js.Dynamic].__typename.asInstanceOf[String])) Some(orig.asInstanceOf[AsDroid]) else None
@@ -236,11 +441,26 @@ exports[`Scala code generation #classDeclarationForOperation() should generate a
   type Variables = Unit
 
   @scala.scalajs.js.native trait Data extends scala.scalajs.js.Object {
-    val hero: com.apollographql.scalajs.OptionalResult[Data.Hero]
+    val hero: com.apollographql.scalajs.OptionalValue[Data.Hero]
   }
 
   object Data {
+    def apply(hero: com.apollographql.scalajs.OptionalValue[Data.Hero] = com.apollographql.scalajs.OptionalValue.empty) = {
+      scala.scalajs.js.Dynamic.literal(hero = hero).asInstanceOf[Data]
+    }
+
+    def unapply(value: Data) = {
+      Some((value.hero))
+    }
+
+    implicit class CopyExtensions(private val orig: Data) extends AnyVal {
+      def copy(hero: com.apollographql.scalajs.OptionalValue[Data.Hero] = orig.hero) = {
+        scala.scalajs.js.Dynamic.literal(hero = hero).asInstanceOf[Data]
+      }
+    }
+
     val possibleTypes = scala.collection.Set(\\"Query\\")
+
     implicit class ViewExtensions(private val orig: Data) extends AnyVal {
     }
 
@@ -249,7 +469,22 @@ exports[`Scala code generation #classDeclarationForOperation() should generate a
     }
 
     object Hero {
+      def apply(name: String) = {
+        scala.scalajs.js.Dynamic.literal(name = name).asInstanceOf[Hero]
+      }
+
+      def unapply(value: Hero) = {
+        Some((value.name))
+      }
+
+      implicit class CopyExtensions(private val orig: Hero) extends AnyVal {
+        def copy(name: String = orig.name) = {
+          scala.scalajs.js.Dynamic.literal(name = name).asInstanceOf[Hero]
+        }
+      }
+
       val possibleTypes = scala.collection.Set(\\"Human\\", \\"Droid\\")
+
       implicit class ViewExtensions(private val orig: Hero) extends AnyVal {
       }
     }
@@ -269,21 +504,46 @@ exports[`Scala code generation #classDeclarationForOperation() should generate a
 
 
   @scala.scalajs.js.native trait Variables extends scala.scalajs.js.Object {
-    val episode: com.apollographql.scalajs.OptionalInput[String]
+    val episode: com.apollographql.scalajs.OptionalValue[String]
   }
 
   object Variables {
-    def apply(episode: com.apollographql.scalajs.OptionalInput[String] = com.apollographql.scalajs.OptionalInput.empty) =  {
+    def apply(episode: com.apollographql.scalajs.OptionalValue[String] = com.apollographql.scalajs.OptionalValue.empty) = {
       scala.scalajs.js.Dynamic.literal(episode = episode).asInstanceOf[Variables]
+    }
+
+    def unapply(value: Variables) = {
+      Some((value.episode))
+    }
+
+    implicit class CopyExtensions(private val orig: Variables) extends AnyVal {
+      def copy(episode: com.apollographql.scalajs.OptionalValue[String] = orig.episode) = {
+        scala.scalajs.js.Dynamic.literal(episode = episode).asInstanceOf[Variables]
+      }
     }
   }
 
   @scala.scalajs.js.native trait Data extends scala.scalajs.js.Object {
-    val hero: com.apollographql.scalajs.OptionalResult[Data.Hero]
+    val hero: com.apollographql.scalajs.OptionalValue[Data.Hero]
   }
 
   object Data {
+    def apply(hero: com.apollographql.scalajs.OptionalValue[Data.Hero] = com.apollographql.scalajs.OptionalValue.empty) = {
+      scala.scalajs.js.Dynamic.literal(hero = hero).asInstanceOf[Data]
+    }
+
+    def unapply(value: Data) = {
+      Some((value.hero))
+    }
+
+    implicit class CopyExtensions(private val orig: Data) extends AnyVal {
+      def copy(hero: com.apollographql.scalajs.OptionalValue[Data.Hero] = orig.hero) = {
+        scala.scalajs.js.Dynamic.literal(hero = hero).asInstanceOf[Data]
+      }
+    }
+
     val possibleTypes = scala.collection.Set(\\"Query\\")
+
     implicit class ViewExtensions(private val orig: Data) extends AnyVal {
     }
 
@@ -292,7 +552,22 @@ exports[`Scala code generation #classDeclarationForOperation() should generate a
     }
 
     object Hero {
+      def apply(name: String) = {
+        scala.scalajs.js.Dynamic.literal(name = name).asInstanceOf[Hero]
+      }
+
+      def unapply(value: Hero) = {
+        Some((value.name))
+      }
+
+      implicit class CopyExtensions(private val orig: Hero) extends AnyVal {
+        def copy(name: String = orig.name) = {
+          scala.scalajs.js.Dynamic.literal(name = name).asInstanceOf[Hero]
+        }
+      }
+
       val possibleTypes = scala.collection.Set(\\"Human\\", \\"Droid\\")
+
       implicit class ViewExtensions(private val orig: Hero) extends AnyVal {
       }
     }
@@ -317,11 +592,26 @@ exports[`Scala code generation #classDeclarationForOperation() when generateOper
   type Variables = Unit
 
   @scala.scalajs.js.native trait Data extends scala.scalajs.js.Object {
-    val hero: com.apollographql.scalajs.OptionalResult[Data.Hero]
+    val hero: com.apollographql.scalajs.OptionalValue[Data.Hero]
   }
 
   object Data {
+    def apply(hero: com.apollographql.scalajs.OptionalValue[Data.Hero] = com.apollographql.scalajs.OptionalValue.empty) = {
+      scala.scalajs.js.Dynamic.literal(hero = hero).asInstanceOf[Data]
+    }
+
+    def unapply(value: Data) = {
+      Some((value.hero))
+    }
+
+    implicit class CopyExtensions(private val orig: Data) extends AnyVal {
+      def copy(hero: com.apollographql.scalajs.OptionalValue[Data.Hero] = orig.hero) = {
+        scala.scalajs.js.Dynamic.literal(hero = hero).asInstanceOf[Data]
+      }
+    }
+
     val possibleTypes = scala.collection.Set(\\"Query\\")
+
     implicit class ViewExtensions(private val orig: Data) extends AnyVal {
     }
 
@@ -330,7 +620,22 @@ exports[`Scala code generation #classDeclarationForOperation() when generateOper
     }
 
     object Hero {
+      def apply(name: String) = {
+        scala.scalajs.js.Dynamic.literal(name = name).asInstanceOf[Hero]
+      }
+
+      def unapply(value: Hero) = {
+        Some((value.name))
+      }
+
+      implicit class CopyExtensions(private val orig: Hero) extends AnyVal {
+        def copy(name: String = orig.name) = {
+          scala.scalajs.js.Dynamic.literal(name = name).asInstanceOf[Hero]
+        }
+      }
+
       val possibleTypes = scala.collection.Set(\\"Human\\", \\"Droid\\")
+
       implicit class ViewExtensions(private val orig: Hero) extends AnyVal {
       }
     }
@@ -389,21 +694,46 @@ object HeroNameQuery extends com.apollographql.scalajs.GraphQLQuery {
 
 
   @scala.scalajs.js.native trait Variables extends scala.scalajs.js.Object {
-    val episode: com.apollographql.scalajs.OptionalInput[String]
+    val episode: com.apollographql.scalajs.OptionalValue[String]
   }
 
   object Variables {
-    def apply(episode: com.apollographql.scalajs.OptionalInput[String] = com.apollographql.scalajs.OptionalInput.empty) =  {
+    def apply(episode: com.apollographql.scalajs.OptionalValue[String] = com.apollographql.scalajs.OptionalValue.empty) = {
       scala.scalajs.js.Dynamic.literal(episode = episode).asInstanceOf[Variables]
+    }
+
+    def unapply(value: Variables) = {
+      Some((value.episode))
+    }
+
+    implicit class CopyExtensions(private val orig: Variables) extends AnyVal {
+      def copy(episode: com.apollographql.scalajs.OptionalValue[String] = orig.episode) = {
+        scala.scalajs.js.Dynamic.literal(episode = episode).asInstanceOf[Variables]
+      }
     }
   }
 
   @scala.scalajs.js.native trait Data extends scala.scalajs.js.Object {
-    val hero: com.apollographql.scalajs.OptionalResult[Data.Hero]
+    val hero: com.apollographql.scalajs.OptionalValue[Data.Hero]
   }
 
   object Data {
+    def apply(hero: com.apollographql.scalajs.OptionalValue[Data.Hero] = com.apollographql.scalajs.OptionalValue.empty) = {
+      scala.scalajs.js.Dynamic.literal(hero = hero).asInstanceOf[Data]
+    }
+
+    def unapply(value: Data) = {
+      Some((value.hero))
+    }
+
+    implicit class CopyExtensions(private val orig: Data) extends AnyVal {
+      def copy(hero: com.apollographql.scalajs.OptionalValue[Data.Hero] = orig.hero) = {
+        scala.scalajs.js.Dynamic.literal(hero = hero).asInstanceOf[Data]
+      }
+    }
+
     val possibleTypes = scala.collection.Set(\\"Query\\")
+
     implicit class ViewExtensions(private val orig: Data) extends AnyVal {
     }
 
@@ -412,7 +742,22 @@ object HeroNameQuery extends com.apollographql.scalajs.GraphQLQuery {
     }
 
     object Hero {
+      def apply(name: String) = {
+        scala.scalajs.js.Dynamic.literal(name = name).asInstanceOf[Hero]
+      }
+
+      def unapply(value: Hero) = {
+        Some((value.name))
+      }
+
+      implicit class CopyExtensions(private val orig: Hero) extends AnyVal {
+        def copy(name: String = orig.name) = {
+          scala.scalajs.js.Dynamic.literal(name = name).asInstanceOf[Hero]
+        }
+      }
+
       val possibleTypes = scala.collection.Set(\\"Human\\", \\"Droid\\")
+
       implicit class ViewExtensions(private val orig: Hero) extends AnyVal {
       }
     }
@@ -423,11 +768,26 @@ object HeroNameQuery extends com.apollographql.scalajs.GraphQLQuery {
 exports[`Scala code generation #traitDeclarationForFragment() should generate a trait declaration for a fragment that includes a fragment spread 1`] = `
 "@scala.scalajs.js.native trait HeroDetails extends scala.scalajs.js.Object with MoreHeroDetails {
   val name: String
-  val appearsIn: scala.scalajs.js.Array[com.apollographql.scalajs.OptionalResult[String]]
+  val appearsIn: scala.scalajs.js.Array[com.apollographql.scalajs.OptionalValue[String]]
 }
 
 object HeroDetails {
+  def apply(name: String, appearsIn: scala.scalajs.js.Array[com.apollographql.scalajs.OptionalValue[String]]) = {
+    scala.scalajs.js.Dynamic.literal(name = name, appearsIn = appearsIn).asInstanceOf[HeroDetails]
+  }
+
+  def unapply(value: HeroDetails) = {
+    Some((value.name, value.appearsIn))
+  }
+
+  implicit class CopyExtensions(private val orig: HeroDetails) extends AnyVal {
+    def copy(name: String = orig.name, appearsIn: scala.scalajs.js.Array[com.apollographql.scalajs.OptionalValue[String]] = orig.appearsIn) = {
+      scala.scalajs.js.Dynamic.literal(name = name, appearsIn = appearsIn).asInstanceOf[HeroDetails]
+    }
+  }
+
   val possibleTypes = scala.collection.Set(\\"Human\\", \\"Droid\\")
+
   implicit class ViewExtensions(private val orig: HeroDetails) extends AnyVal {
   }
   val fragmentString =
@@ -441,11 +801,26 @@ object HeroDetails {
 exports[`Scala code generation #traitDeclarationForFragment() should generate a trait declaration for a fragment with a concrete type condition 1`] = `
 "@scala.scalajs.js.native trait DroidDetails extends scala.scalajs.js.Object {
   val name: String
-  val primaryFunction: com.apollographql.scalajs.OptionalResult[String]
+  val primaryFunction: com.apollographql.scalajs.OptionalValue[String]
 }
 
 object DroidDetails {
+  def apply(name: String, primaryFunction: com.apollographql.scalajs.OptionalValue[String] = com.apollographql.scalajs.OptionalValue.empty) = {
+    scala.scalajs.js.Dynamic.literal(name = name, primaryFunction = primaryFunction).asInstanceOf[DroidDetails]
+  }
+
+  def unapply(value: DroidDetails) = {
+    Some((value.name, value.primaryFunction))
+  }
+
+  implicit class CopyExtensions(private val orig: DroidDetails) extends AnyVal {
+    def copy(name: String = orig.name, primaryFunction: com.apollographql.scalajs.OptionalValue[String] = orig.primaryFunction) = {
+      scala.scalajs.js.Dynamic.literal(name = name, primaryFunction = primaryFunction).asInstanceOf[DroidDetails]
+    }
+  }
+
   val possibleTypes = scala.collection.Set(\\"Droid\\")
+
   implicit class ViewExtensions(private val orig: DroidDetails) extends AnyVal {
   }
   val fragmentString =
@@ -459,11 +834,26 @@ object DroidDetails {
 exports[`Scala code generation #traitDeclarationForFragment() should generate a trait declaration for a fragment with a subselection 1`] = `
 "@scala.scalajs.js.native trait HeroDetails extends scala.scalajs.js.Object {
   val name: String
-  val friends: com.apollographql.scalajs.OptionalResult[scala.scalajs.js.Array[com.apollographql.scalajs.OptionalResult[HeroDetails.Friend]]]
+  val friends: com.apollographql.scalajs.OptionalValue[scala.scalajs.js.Array[com.apollographql.scalajs.OptionalValue[HeroDetails.Friend]]]
 }
 
 object HeroDetails {
+  def apply(name: String, friends: com.apollographql.scalajs.OptionalValue[scala.scalajs.js.Array[com.apollographql.scalajs.OptionalValue[HeroDetails.Friend]]] = com.apollographql.scalajs.OptionalValue.empty) = {
+    scala.scalajs.js.Dynamic.literal(name = name, friends = friends).asInstanceOf[HeroDetails]
+  }
+
+  def unapply(value: HeroDetails) = {
+    Some((value.name, value.friends))
+  }
+
+  implicit class CopyExtensions(private val orig: HeroDetails) extends AnyVal {
+    def copy(name: String = orig.name, friends: com.apollographql.scalajs.OptionalValue[scala.scalajs.js.Array[com.apollographql.scalajs.OptionalValue[HeroDetails.Friend]]] = orig.friends) = {
+      scala.scalajs.js.Dynamic.literal(name = name, friends = friends).asInstanceOf[HeroDetails]
+    }
+  }
+
   val possibleTypes = scala.collection.Set(\\"Human\\", \\"Droid\\")
+
   implicit class ViewExtensions(private val orig: HeroDetails) extends AnyVal {
   }
 
@@ -472,7 +862,22 @@ object HeroDetails {
   }
 
   object Friend {
+    def apply(name: String) = {
+      scala.scalajs.js.Dynamic.literal(name = name).asInstanceOf[Friend]
+    }
+
+    def unapply(value: Friend) = {
+      Some((value.name))
+    }
+
+    implicit class CopyExtensions(private val orig: Friend) extends AnyVal {
+      def copy(name: String = orig.name) = {
+        scala.scalajs.js.Dynamic.literal(name = name).asInstanceOf[Friend]
+      }
+    }
+
     val possibleTypes = scala.collection.Set(\\"Human\\", \\"Droid\\")
+
     implicit class ViewExtensions(private val orig: Friend) extends AnyVal {
     }
   }
@@ -489,11 +894,26 @@ object HeroDetails {
 exports[`Scala code generation #traitDeclarationForFragment() should generate a trait declaration for a fragment with an abstract type condition 1`] = `
 "@scala.scalajs.js.native trait HeroDetails extends scala.scalajs.js.Object {
   val name: String
-  val appearsIn: scala.scalajs.js.Array[com.apollographql.scalajs.OptionalResult[String]]
+  val appearsIn: scala.scalajs.js.Array[com.apollographql.scalajs.OptionalValue[String]]
 }
 
 object HeroDetails {
+  def apply(name: String, appearsIn: scala.scalajs.js.Array[com.apollographql.scalajs.OptionalValue[String]]) = {
+    scala.scalajs.js.Dynamic.literal(name = name, appearsIn = appearsIn).asInstanceOf[HeroDetails]
+  }
+
+  def unapply(value: HeroDetails) = {
+    Some((value.name, value.appearsIn))
+  }
+
+  implicit class CopyExtensions(private val orig: HeroDetails) extends AnyVal {
+    def copy(name: String = orig.name, appearsIn: scala.scalajs.js.Array[com.apollographql.scalajs.OptionalValue[String]] = orig.appearsIn) = {
+      scala.scalajs.js.Dynamic.literal(name = name, appearsIn = appearsIn).asInstanceOf[HeroDetails]
+    }
+  }
+
   val possibleTypes = scala.collection.Set(\\"Human\\", \\"Droid\\")
+
   implicit class ViewExtensions(private val orig: HeroDetails) extends AnyVal {
   }
   val fragmentString =
@@ -506,11 +926,26 @@ object HeroDetails {
 
 exports[`Scala code generation #traitDeclarationForSelectionSet() should escape reserved keywords in a trait declaration for a selection set 1`] = `
 "@scala.scalajs.js.native trait Hero extends scala.scalajs.js.Object {
-  val private: com.apollographql.scalajs.OptionalResult[String]
+  val private: com.apollographql.scalajs.OptionalValue[String]
 }
 
 object Hero {
+  def apply(private: com.apollographql.scalajs.OptionalValue[String] = com.apollographql.scalajs.OptionalValue.empty) = {
+    scala.scalajs.js.Dynamic.literal(private = private).asInstanceOf[Hero]
+  }
+
+  def unapply(value: Hero) = {
+    Some((value.private))
+  }
+
+  implicit class CopyExtensions(private val orig: Hero) extends AnyVal {
+    def copy(private: com.apollographql.scalajs.OptionalValue[String] = orig.private) = {
+      scala.scalajs.js.Dynamic.literal(private = private).asInstanceOf[Hero]
+    }
+  }
+
   val possibleTypes = scala.collection.Set(\\"Human\\", \\"Droid\\")
+
   implicit class ViewExtensions(private val orig: Hero) extends AnyVal {
   }
 }"
@@ -518,20 +953,50 @@ object Hero {
 
 exports[`Scala code generation #traitDeclarationForSelectionSet() should generate a nested trait declaration for a selection set with subselections 1`] = `
 "@scala.scalajs.js.native trait Hero extends scala.scalajs.js.Object {
-  val friends: com.apollographql.scalajs.OptionalResult[scala.scalajs.js.Array[com.apollographql.scalajs.OptionalResult[Hero.Friend]]]
+  val friends: com.apollographql.scalajs.OptionalValue[scala.scalajs.js.Array[com.apollographql.scalajs.OptionalValue[Hero.Friend]]]
 }
 
 object Hero {
+  def apply(friends: com.apollographql.scalajs.OptionalValue[scala.scalajs.js.Array[com.apollographql.scalajs.OptionalValue[Hero.Friend]]] = com.apollographql.scalajs.OptionalValue.empty) = {
+    scala.scalajs.js.Dynamic.literal(friends = friends).asInstanceOf[Hero]
+  }
+
+  def unapply(value: Hero) = {
+    Some((value.friends))
+  }
+
+  implicit class CopyExtensions(private val orig: Hero) extends AnyVal {
+    def copy(friends: com.apollographql.scalajs.OptionalValue[scala.scalajs.js.Array[com.apollographql.scalajs.OptionalValue[Hero.Friend]]] = orig.friends) = {
+      scala.scalajs.js.Dynamic.literal(friends = friends).asInstanceOf[Hero]
+    }
+  }
+
   val possibleTypes = scala.collection.Set(\\"Human\\", \\"Droid\\")
+
   implicit class ViewExtensions(private val orig: Hero) extends AnyVal {
   }
 
   @scala.scalajs.js.native trait Friend extends scala.scalajs.js.Object {
-    val name: com.apollographql.scalajs.OptionalResult[String]
+    val name: com.apollographql.scalajs.OptionalValue[String]
   }
 
   object Friend {
+    def apply(name: com.apollographql.scalajs.OptionalValue[String] = com.apollographql.scalajs.OptionalValue.empty) = {
+      scala.scalajs.js.Dynamic.literal(name = name).asInstanceOf[Friend]
+    }
+
+    def unapply(value: Friend) = {
+      Some((value.name))
+    }
+
+    implicit class CopyExtensions(private val orig: Friend) extends AnyVal {
+      def copy(name: com.apollographql.scalajs.OptionalValue[String] = orig.name) = {
+        scala.scalajs.js.Dynamic.literal(name = name).asInstanceOf[Friend]
+      }
+    }
+
     val possibleTypes = scala.collection.Set(\\"Human\\", \\"Droid\\")
+
     implicit class ViewExtensions(private val orig: Friend) extends AnyVal {
     }
   }
@@ -539,20 +1004,50 @@ object Hero {
 `;
 
 exports[`Scala code generation #traitDeclarationForSelectionSet() should generate a trait declaration for a fragment spread nested in an inline fragment 1`] = `
-"@scala.scalajs.js.native trait Hero extends scala.scalajs.js.Object {
-}
-
-@scala.scalajs.js.native trait AsDroid extends scala.scalajs.js.Object with Hero with HeroDetails {
+"@scala.scalajs.js.native trait AsDroid extends scala.scalajs.js.Object with Hero with HeroDetails {
 }
 
 object AsDroid {
+  def apply() = {
+    scala.scalajs.js.Dynamic.literal().asInstanceOf[AsDroid]
+  }
+
+  def unapply(value: AsDroid) = {
+    Some(())
+  }
+
+  implicit class CopyExtensions(private val orig: AsDroid) extends AnyVal {
+    def copy() = {
+      scala.scalajs.js.Dynamic.literal().asInstanceOf[AsDroid]
+    }
+  }
+
   val possibleTypes = scala.collection.Set(\\"Droid\\")
+
   implicit class ViewExtensions(private val orig: AsDroid) extends AnyVal {
   }
 }
 
+@scala.scalajs.js.native trait Hero extends scala.scalajs.js.Object {
+}
+
 object Hero {
+  def apply() = {
+    scala.scalajs.js.Dynamic.literal().asInstanceOf[Hero]
+  }
+
+  def unapply(value: Hero) = {
+    Some(())
+  }
+
+  implicit class CopyExtensions(private val orig: Hero) extends AnyVal {
+    def copy() = {
+      scala.scalajs.js.Dynamic.literal().asInstanceOf[Hero]
+    }
+  }
+
   val possibleTypes = scala.collection.Set(\\"Human\\", \\"Droid\\")
+
   implicit class ViewExtensions(private val orig: Hero) extends AnyVal {
     def asDroid: Option[AsDroid] = {
       if (AsDroid.possibleTypes.contains(orig.asInstanceOf[scala.scalajs.js.Dynamic].__typename.asInstanceOf[String])) Some(orig.asInstanceOf[AsDroid]) else None
@@ -563,11 +1058,26 @@ object Hero {
 
 exports[`Scala code generation #traitDeclarationForSelectionSet() should generate a trait declaration for a selection set 1`] = `
 "@scala.scalajs.js.native trait Hero extends scala.scalajs.js.Object {
-  val name: com.apollographql.scalajs.OptionalResult[String]
+  val name: com.apollographql.scalajs.OptionalValue[String]
 }
 
 object Hero {
+  def apply(name: com.apollographql.scalajs.OptionalValue[String] = com.apollographql.scalajs.OptionalValue.empty) = {
+    scala.scalajs.js.Dynamic.literal(name = name).asInstanceOf[Hero]
+  }
+
+  def unapply(value: Hero) = {
+    Some((value.name))
+  }
+
+  implicit class CopyExtensions(private val orig: Hero) extends AnyVal {
+    def copy(name: com.apollographql.scalajs.OptionalValue[String] = orig.name) = {
+      scala.scalajs.js.Dynamic.literal(name = name).asInstanceOf[Hero]
+    }
+  }
+
   val possibleTypes = scala.collection.Set(\\"Human\\", \\"Droid\\")
+
   implicit class ViewExtensions(private val orig: Hero) extends AnyVal {
   }
 }"
@@ -575,11 +1085,26 @@ object Hero {
 
 exports[`Scala code generation #traitDeclarationForSelectionSet() should generate a trait declaration for a selection set with a fragment spread that matches the parent type 1`] = `
 "@scala.scalajs.js.native trait Hero extends scala.scalajs.js.Object with HeroDetails {
-  val name: com.apollographql.scalajs.OptionalResult[String]
+  val name: com.apollographql.scalajs.OptionalValue[String]
 }
 
 object Hero {
+  def apply(name: com.apollographql.scalajs.OptionalValue[String] = com.apollographql.scalajs.OptionalValue.empty) = {
+    scala.scalajs.js.Dynamic.literal(name = name).asInstanceOf[Hero]
+  }
+
+  def unapply(value: Hero) = {
+    Some((value.name))
+  }
+
+  implicit class CopyExtensions(private val orig: Hero) extends AnyVal {
+    def copy(name: com.apollographql.scalajs.OptionalValue[String] = orig.name) = {
+      scala.scalajs.js.Dynamic.literal(name = name).asInstanceOf[Hero]
+    }
+  }
+
   val possibleTypes = scala.collection.Set(\\"Human\\", \\"Droid\\")
+
   implicit class ViewExtensions(private val orig: Hero) extends AnyVal {
   }
 }"
@@ -587,11 +1112,26 @@ object Hero {
 
 exports[`Scala code generation #traitDeclarationForSelectionSet() should generate a trait declaration for a selection set with a fragment spread with a more specific type condition 1`] = `
 "@scala.scalajs.js.native trait Hero extends scala.scalajs.js.Object {
-  val name: com.apollographql.scalajs.OptionalResult[String]
+  val name: com.apollographql.scalajs.OptionalValue[String]
 }
 
 object Hero {
+  def apply(name: com.apollographql.scalajs.OptionalValue[String] = com.apollographql.scalajs.OptionalValue.empty) = {
+    scala.scalajs.js.Dynamic.literal(name = name).asInstanceOf[Hero]
+  }
+
+  def unapply(value: Hero) = {
+    Some((value.name))
+  }
+
+  implicit class CopyExtensions(private val orig: Hero) extends AnyVal {
+    def copy(name: com.apollographql.scalajs.OptionalValue[String] = orig.name) = {
+      scala.scalajs.js.Dynamic.literal(name = name).asInstanceOf[Hero]
+    }
+  }
+
   val possibleTypes = scala.collection.Set(\\"Human\\", \\"Droid\\")
+
   implicit class ViewExtensions(private val orig: Hero) extends AnyVal {
     def asDroidDetails: Option[DroidDetails] = {
       if (DroidDetails.possibleTypes.contains(orig.asInstanceOf[scala.scalajs.js.Dynamic].__typename.asInstanceOf[String])) Some(orig.asInstanceOf[DroidDetails]) else None
@@ -601,23 +1141,53 @@ object Hero {
 `;
 
 exports[`Scala code generation #traitDeclarationForSelectionSet() should generate a trait declaration for a selection set with an inline fragment 1`] = `
-"@scala.scalajs.js.native trait Hero extends scala.scalajs.js.Object {
+"@scala.scalajs.js.native trait AsDroid extends scala.scalajs.js.Object with Hero {
   val name: String
-}
-
-@scala.scalajs.js.native trait AsDroid extends scala.scalajs.js.Object with Hero {
-  val name: String
-  val primaryFunction: com.apollographql.scalajs.OptionalResult[String]
+  val primaryFunction: com.apollographql.scalajs.OptionalValue[String]
 }
 
 object AsDroid {
+  def apply(name: String, primaryFunction: com.apollographql.scalajs.OptionalValue[String] = com.apollographql.scalajs.OptionalValue.empty) = {
+    scala.scalajs.js.Dynamic.literal(name = name, primaryFunction = primaryFunction).asInstanceOf[AsDroid]
+  }
+
+  def unapply(value: AsDroid) = {
+    Some((value.name, value.primaryFunction))
+  }
+
+  implicit class CopyExtensions(private val orig: AsDroid) extends AnyVal {
+    def copy(name: String = orig.name, primaryFunction: com.apollographql.scalajs.OptionalValue[String] = orig.primaryFunction) = {
+      scala.scalajs.js.Dynamic.literal(name = name, primaryFunction = primaryFunction).asInstanceOf[AsDroid]
+    }
+  }
+
   val possibleTypes = scala.collection.Set(\\"Droid\\")
+
   implicit class ViewExtensions(private val orig: AsDroid) extends AnyVal {
   }
 }
 
+@scala.scalajs.js.native trait Hero extends scala.scalajs.js.Object {
+  val name: String
+}
+
 object Hero {
+  def apply(name: String) = {
+    scala.scalajs.js.Dynamic.literal(name = name).asInstanceOf[Hero]
+  }
+
+  def unapply(value: Hero) = {
+    Some((value.name))
+  }
+
+  implicit class CopyExtensions(private val orig: Hero) extends AnyVal {
+    def copy(name: String = orig.name) = {
+      scala.scalajs.js.Dynamic.literal(name = name).asInstanceOf[Hero]
+    }
+  }
+
   val possibleTypes = scala.collection.Set(\\"Human\\", \\"Droid\\")
+
   implicit class ViewExtensions(private val orig: Hero) extends AnyVal {
     def asDroid: Option[AsDroid] = {
       if (AsDroid.possibleTypes.contains(orig.asInstanceOf[scala.scalajs.js.Dynamic].__typename.asInstanceOf[String])) Some(orig.asInstanceOf[AsDroid]) else None
@@ -640,13 +1210,23 @@ exports[`Scala code generation #typeDeclarationForGraphQLType() should generate 
  */
 @scala.scalajs.js.native trait ReviewInput extends scala.scalajs.js.Object {
   val stars: Int
-  val commentary: com.apollographql.scalajs.OptionalInput[String]
-  val favoriteColor: com.apollographql.scalajs.OptionalInput[ColorInput]
+  val commentary: com.apollographql.scalajs.OptionalValue[String]
+  val favoriteColor: com.apollographql.scalajs.OptionalValue[ColorInput]
 }
 
 object ReviewInput {
-  def apply(stars: Int, commentary: com.apollographql.scalajs.OptionalInput[String] = com.apollographql.scalajs.OptionalInput.empty, favoriteColor: com.apollographql.scalajs.OptionalInput[ColorInput] = com.apollographql.scalajs.OptionalInput.empty) =  {
+  def apply(stars: Int, commentary: com.apollographql.scalajs.OptionalValue[String] = com.apollographql.scalajs.OptionalValue.empty, favoriteColor: com.apollographql.scalajs.OptionalValue[ColorInput] = com.apollographql.scalajs.OptionalValue.empty) = {
     scala.scalajs.js.Dynamic.literal(stars = stars, commentary = commentary, favoriteColor = favoriteColor).asInstanceOf[ReviewInput]
+  }
+
+  def unapply(value: ReviewInput) = {
+    Some((value.stars, value.commentary, value.favoriteColor))
+  }
+
+  implicit class CopyExtensions(private val orig: ReviewInput) extends AnyVal {
+    def copy(stars: Int = orig.stars, commentary: com.apollographql.scalajs.OptionalValue[String] = orig.commentary, favoriteColor: com.apollographql.scalajs.OptionalValue[ColorInput] = orig.favoriteColor) = {
+      scala.scalajs.js.Dynamic.literal(stars = stars, commentary = commentary, favoriteColor = favoriteColor).asInstanceOf[ReviewInput]
+    }
   }
 }"
 `;

--- a/packages/apollo-codegen-scala/src/__tests__/types.ts
+++ b/packages/apollo-codegen-scala/src/__tests__/types.ts
@@ -20,7 +20,7 @@ describe("Scala code generation: Types", function() {
   describe("#typeNameFromGraphQLType()", function() {
     test("should return OptionalResult[String] for GraphQLString", function() {
       expect(typeNameFromGraphQLType({ options: {} }, GraphQLString)).toBe(
-        "com.apollographql.scalajs.OptionalResult[String]"
+        "com.apollographql.scalajs.OptionalValue[String]"
       );
     });
 
@@ -37,7 +37,7 @@ describe("Scala code generation: Types", function() {
       expect(
         typeNameFromGraphQLType({ options: {} }, new GraphQLList(GraphQLString))
       ).toBe(
-        "com.apollographql.scalajs.OptionalResult[scala.scalajs.js.Array[com.apollographql.scalajs.OptionalResult[String]]]"
+        "com.apollographql.scalajs.OptionalValue[scala.scalajs.js.Array[com.apollographql.scalajs.OptionalValue[String]]]"
       );
     });
 
@@ -48,7 +48,7 @@ describe("Scala code generation: Types", function() {
           new GraphQLNonNull(new GraphQLList(GraphQLString))
         )
       ).toBe(
-        "scala.scalajs.js.Array[com.apollographql.scalajs.OptionalResult[String]]"
+        "scala.scalajs.js.Array[com.apollographql.scalajs.OptionalValue[String]]"
       );
     });
 
@@ -59,7 +59,7 @@ describe("Scala code generation: Types", function() {
           new GraphQLList(new GraphQLNonNull(GraphQLString))
         )
       ).toBe(
-        "com.apollographql.scalajs.OptionalResult[scala.scalajs.js.Array[String]]"
+        "com.apollographql.scalajs.OptionalValue[scala.scalajs.js.Array[String]]"
       );
     });
 
@@ -79,7 +79,7 @@ describe("Scala code generation: Types", function() {
           new GraphQLList(new GraphQLList(GraphQLString))
         )
       ).toBe(
-        "com.apollographql.scalajs.OptionalResult[scala.scalajs.js.Array[com.apollographql.scalajs.OptionalResult[scala.scalajs.js.Array[com.apollographql.scalajs.OptionalResult[String]]]]]"
+        "com.apollographql.scalajs.OptionalValue[scala.scalajs.js.Array[com.apollographql.scalajs.OptionalValue[scala.scalajs.js.Array[com.apollographql.scalajs.OptionalValue[String]]]]]"
       );
     });
 
@@ -90,31 +90,31 @@ describe("Scala code generation: Types", function() {
           new GraphQLList(new GraphQLNonNull(new GraphQLList(GraphQLString)))
         )
       ).toBe(
-        "com.apollographql.scalajs.OptionalResult[scala.scalajs.js.Array[scala.scalajs.js.Array[com.apollographql.scalajs.OptionalResult[String]]]]"
+        "com.apollographql.scalajs.OptionalValue[scala.scalajs.js.Array[scala.scalajs.js.Array[com.apollographql.scalajs.OptionalValue[String]]]]"
       );
     });
 
     test("should return OptionalResult[Int] for GraphQLInt", function() {
       expect(typeNameFromGraphQLType({ options: {} }, GraphQLInt)).toBe(
-        "com.apollographql.scalajs.OptionalResult[Int]"
+        "com.apollographql.scalajs.OptionalValue[Int]"
       );
     });
 
     test("should return OptionalResult[Double] for GraphQLFloat", function() {
       expect(typeNameFromGraphQLType({ options: {} }, GraphQLFloat)).toBe(
-        "com.apollographql.scalajs.OptionalResult[Double]"
+        "com.apollographql.scalajs.OptionalValue[Double]"
       );
     });
 
     test("should return OptionalResult[Boolean] for GraphQLBoolean", function() {
       expect(typeNameFromGraphQLType({ options: {} }, GraphQLBoolean)).toBe(
-        "com.apollographql.scalajs.OptionalResult[Boolean]"
+        "com.apollographql.scalajs.OptionalValue[Boolean]"
       );
     });
 
     test("should return OptionalResult[String] for GraphQLID", function() {
       expect(typeNameFromGraphQLType({ options: {} }, GraphQLID)).toBe(
-        "com.apollographql.scalajs.OptionalResult[String]"
+        "com.apollographql.scalajs.OptionalValue[String]"
       );
     });
 
@@ -124,7 +124,7 @@ describe("Scala code generation: Types", function() {
           { options: {} },
           new GraphQLScalarType({ name: "CustomScalarType", serialize: String })
         )
-      ).toBe("com.apollographql.scalajs.OptionalResult[String]");
+      ).toBe("com.apollographql.scalajs.OptionalValue[String]");
     });
 
     test("should return a passed through custom scalar type with the passthroughCustomScalars OptionalResult", function() {
@@ -135,7 +135,7 @@ describe("Scala code generation: Types", function() {
           },
           new GraphQLScalarType({ name: "CustomScalarType", serialize: String })
         )
-      ).toBe("com.apollographql.scalajs.OptionalResult[CustomScalarType]");
+      ).toBe("com.apollographql.scalajs.OptionalValue[CustomScalarType]");
     });
 
     test("should return a passed through custom scalar type with a prefix with the customScalarsPrefix OptionalResult", function() {
@@ -149,7 +149,7 @@ describe("Scala code generation: Types", function() {
           },
           new GraphQLScalarType({ name: "CustomScalarType", serialize: String })
         )
-      ).toBe("com.apollographql.scalajs.OptionalResult[MyCustomScalarType]");
+      ).toBe("com.apollographql.scalajs.OptionalValue[MyCustomScalarType]");
     });
   });
 });

--- a/packages/apollo-codegen-scala/src/language.ts
+++ b/packages/apollo-codegen-scala/src/language.ts
@@ -31,7 +31,6 @@ export function packageDeclaration(
 ) {
   generator.printNewlineIfNeeded();
   generator.printOnNewline(`package ${pkg}`);
-  generator.popScope();
 }
 
 export function objectDeclaration(
@@ -120,12 +119,12 @@ export function methodDeclaration(
     .join(", ");
 
   generator.printOnNewline(
-    `def ${methodName}(${paramsSection})` + (closure ? " = " : "")
+    `def ${methodName}(${paramsSection})` + (closure ? " =" : "")
   );
+
   if (closure) {
     generator.withinBlock(closure);
   }
-  generator.popScope();
 }
 
 export function propertyDeclaration(

--- a/packages/apollo-codegen-scala/src/types.ts
+++ b/packages/apollo-codegen-scala/src/types.ts
@@ -85,9 +85,7 @@ export function typeNameFromGraphQLType(
   }
 
   return isOptional
-    ? isInputObject
-      ? `com.apollographql.scalajs.OptionalInput[${typeName}]`
-      : `com.apollographql.scalajs.OptionalResult[${typeName}]`
+    ? `com.apollographql.scalajs.OptionalValue[${typeName}]`
     : typeName;
 }
 

--- a/packages/apollo/src/commands/client/__tests__/__snapshots__/generate.test.ts.snap
+++ b/packages/apollo/src/commands/client/__tests__/__snapshots__/generate.test.ts.snap
@@ -287,7 +287,22 @@ object SimpleQueryQuery extends com.apollographql.scalajs.GraphQLQuery {
   }
 
   object Data {
+    def apply(hello: String) = {
+      scala.scalajs.js.Dynamic.literal(hello = hello).asInstanceOf[Data]
+    }
+
+    def unapply(value: Data) = {
+      Some((value.hello))
+    }
+
+    implicit class CopyExtensions(private val orig: Data) extends AnyVal {
+      def copy(hello: String = orig.hello) = {
+        scala.scalajs.js.Dynamic.literal(hello = hello).asInstanceOf[Data]
+      }
+    }
+
     val possibleTypes = scala.collection.Set(\\"Query\\")
+
     implicit class ViewExtensions(private val orig: Data) extends AnyVal {
     }
   }


### PR DESCRIPTION
The change to use traits left some codebases pretty source incompatible, as they depended on APIs that are automatically generated for case classes. This adjusts the codegen to generate similar APIs so that query results have the feel of being case classes without the performance overhead.