### PR TITLE
Add gitLoc to git.branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,10 @@
 
 ## `apollo@2.4.0`, `apollo-language-server@1.4.0`, `vscode-apollo@1.4.1`
 
-- `apollo tooling`
-  - Fix a bug where tagging a build will cause the tool to not be able to figure out where the git repo is [#944](https://github.com/apollographql/apollo-tooling/pull/944)
 - `apollo` 2.4.0
   - Fix configuration loading and schema tag support [#925](https://github.com/apollographql/apollo-tooling/pull/925)
   - Improve client:check output [#934](https://github.com/apollographql/apollo-tooling/pull/934)
+  - Fix a bug where tagging a build will cause the tool to not be able to figure out where the git repo is [#944](https://github.com/apollographql/apollo-tooling/pull/944)
 - `apollo-language-server` 1.4.0
   - Replace checkOperations mutation with new validateOperations mutation [#934](https://github.com/apollographql/apollo-tooling/pull/934)
   - Include config files into a project's fileSet [#897](https://github.com/apollographql/apollo-tooling/pull/897)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## `apollo@2.4.0`, `apollo-language-server@1.4.0`, `vscode-apollo@1.4.1`
 
+- `apollo tooling`
+  - Fix a bug where tagging a build will cause the tool to not be able to figure out where the git repo is [#944](https://github.com/apollographql/apollo-tooling/pull/944)
 - `apollo` 2.4.0
   - Fix configuration loading and schema tag support [#925](https://github.com/apollographql/apollo-tooling/pull/925)
   - Improve client:check output [#934](https://github.com/apollographql/apollo-tooling/pull/934)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,13 @@
 # Changelog
 
 ## Upcoming
+- Fix a bug where tagging a build will cause the tool to not be able to figure out where the git repo is [#944](https://github.com/apollographql/apollo-tooling/pull/944)
 
 ## `apollo@2.4.0`, `apollo-language-server@1.4.0`, `vscode-apollo@1.4.1`
 
 - `apollo` 2.4.0
   - Fix configuration loading and schema tag support [#925](https://github.com/apollographql/apollo-tooling/pull/925)
   - Improve client:check output [#934](https://github.com/apollographql/apollo-tooling/pull/934)
-  - Fix a bug where tagging a build will cause the tool to not be able to figure out where the git repo is [#944](https://github.com/apollographql/apollo-tooling/pull/944)
 - `apollo-language-server` 1.4.0
   - Replace checkOperations mutation with new validateOperations mutation [#934](https://github.com/apollographql/apollo-tooling/pull/934)
   - Include config files into a project's fileSet [#897](https://github.com/apollographql/apollo-tooling/pull/897)

--- a/packages/apollo/src/git.ts
+++ b/packages/apollo/src/git.ts
@@ -81,7 +81,7 @@ export const gitInfo = async (): Promise<GitContext | undefined> => {
     // See https://github.com/pvdlg/env-ci#caveats for a detailed list of when
     // branch can be undefined
     if (!branch) {
-      branch = git.branch();
+      branch = git.branch([gitLoc]);
     }
   }
 


### PR DESCRIPTION
With out git loc in the branch call, apollo will fail on schema pushes with the following error: 

```bash
  ✔ Loading Apollo Project
  ✖ Uploading service to Engine
    → [git-rev-sync] no git repository found
Error: [git-rev-sync] no git repository found
    at _getGitDirectory (/usr/local/lib/node_modules/apollo/node_modules/git-rev-sync/index.js:47:11)
    at _getGitDirectory (/usr/local/lib/node_modules/apollo/node_modules/git-rev-sync/index.js:75:10)
    at _getGitDirectory (/usr/local/lib/node_modules/apollo/node_modules/git-rev-sync/index.js:75:10)
    at _getGitDirectory (/usr/local/lib/node_modules/apollo/node_modules/git-rev-sync/index.js:75:10)
    at _getGitDirectory (/usr/local/lib/node_modules/apollo/node_modules/git-rev-sync/index.js:75:10)
    at _getGitDirectory (/usr/local/lib/node_modules/apollo/node_modules/git-rev-sync/index.js:75:10)
    at _getGitDirectory (/usr/local/lib/node_modules/apollo/node_modules/git-rev-sync/index.js:75:10)
    at _getGitDirectory (/usr/local/lib/node_modules/apollo/node_modules/git-rev-sync/index.js:75:10)
    at Object.branch (/usr/local/lib/node_modules/apollo/node_modules/git-rev-sync/index.js:79:16)
    at Object.exports.gitInfo (/usr/local/lib/node_modules/apollo/lib/git.js:60:26)
```
This happens when you tag a build in CircleCI because it sets branch to an empty variable.

<!--
  Thanks for filing a pull request on Apollo Tooling!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [x] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass

\*Make sure changelog entries note which project(s) has been affected. See older entries for examples on what this looks like.
