### PR TITLE
Bump the apollo-engine-reporting version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Upcoming
 
+- `apollo`
+  - Bump the apollo-engine-reporting version [#950](https://github.com/apollographql/apollo-tooling/pull/950)
+
 ## `apollo@2.4.0`, `apollo-language-server@1.4.0`, `vscode-apollo@1.4.1`
 
 - `apollo` 2.4.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -2443,7 +2443,7 @@
       "requires": {
         "@apollographql/apollo-tools": "file:packages/apollo-tools",
         "@oclif/command": "^1.4.21",
-        "@oclif/config": "^1.6.17",
+        "@oclif/config": "1.12.0",
         "@oclif/plugin-autocomplete": "^0.1.0",
         "@oclif/plugin-help": "^1.2.11",
         "@oclif/plugin-not-found": "^1.0.9",
@@ -2454,7 +2454,7 @@
         "apollo-codegen-scala": "file:packages/apollo-codegen-scala",
         "apollo-codegen-swift": "file:packages/apollo-codegen-swift",
         "apollo-codegen-typescript": "file:packages/apollo-codegen-typescript",
-        "apollo-engine-reporting": "0.0.2",
+        "apollo-engine-reporting": "0.2.1",
         "apollo-env": "file:packages/apollo-env",
         "apollo-language-server": "file:packages/apollo-language-server",
         "chalk": "^2.4.1",

--- a/packages/apollo/package.json
+++ b/packages/apollo/package.json
@@ -44,7 +44,7 @@
     "apollo-codegen-scala": "file:../apollo-codegen-scala",
     "apollo-codegen-swift": "file:../apollo-codegen-swift",
     "apollo-codegen-typescript": "file:../apollo-codegen-typescript",
-    "apollo-engine-reporting": "0.0.2",
+    "apollo-engine-reporting": "0.2.1",
     "apollo-env": "file:../apollo-env",
     "apollo-language-server": "file:../apollo-language-server",
     "chalk": "^2.4.1",


### PR DESCRIPTION
The `apollo-engine-reporting` package previously was causing unresolved peer deps within the `apollo` package. This blocks the upgrade path for some of our users, and is something we should resolve anyway :)
