### PR TITLE
Update renovate config for apollo package

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,3 +1,9 @@
 {
-  "extends": ["apollo-open-source"]
+  "extends": ["apollo-open-source"],
+  "packageRules": [
+    {
+      "paths": ["packages/apollo/package.json"],
+      "rangeStrategy": "pin"
+    }
+  ]
 }


### PR DESCRIPTION
Pin all `apollo` deps via renovate config.

Based on recent experience with packages breaking underneath us, and the typical inherent usage of the CLI being via `npx`, we should pin all deps for the `apollo` package.

For reference, see example 3 in the link below. This decision is also recommended by renovate for our case:
https://renovatebot.com/docs/dependency-pinning/#so-whats-best