### PR TITLE
Remove apollo-server-core dep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1941,7 +1941,6 @@
         "apollo-engine-reporting": "0.2.2",
         "apollo-env": "file:packages/apollo-env",
         "apollo-language-server": "file:packages/apollo-language-server",
-        "apollo-server-core": "^2.3.4",
         "chalk": "^2.4.1",
         "cli-ux": "^4.3.0",
         "env-ci": "^3.0.0",

--- a/packages/apollo/package.json
+++ b/packages/apollo/package.json
@@ -47,7 +47,6 @@
     "apollo-engine-reporting": "0.2.2",
     "apollo-env": "file:../apollo-env",
     "apollo-language-server": "file:../apollo-language-server",
-    "apollo-server-core": "^2.3.4",
     "chalk": "^2.4.1",
     "cli-ux": "^4.3.0",
     "env-ci": "^3.0.0",


### PR DESCRIPTION
Now that `apollo-server-core` is being included in `apollo-engine-reporting` as expected, we can remove it from the listed dependencies.
