### PR TITLE
Fix edge case for empty operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Upcoming
 
+- `apollo-language-server`
+  - Fix edge case for empty operations [#959](https://github.com/apollographql/apollo-tooling/pull/959)
+
 ## `apollo@2.4.1`
 
 - `apollo` 2.4.1

--- a/packages/apollo-language-server/src/project/client.ts
+++ b/packages/apollo-language-server/src/project/client.ts
@@ -350,13 +350,17 @@ export class GraphQLClientProject extends GraphQLProject {
     const filtered = Object.create(null);
     for (const operationName in current) {
       const document = current[operationName];
+
       let serviceOnly: DocumentNode = removeDirectiveAnnotatedFields(
         removeDirectives(document, clientOnlyDirectives as string[]),
         clientSchemaDirectives as string[]
       );
+
       if (addTypename)
         serviceOnly = withTypenameFieldAddedWhereNeeded(serviceOnly);
-      if (serviceOnly.definitions.length) {
+      // In the case we've made a document empty by filtering client directives,
+      // we don't want to include that in the result we pass on.
+      if (serviceOnly.definitions.filter(Boolean).length) {
         filtered[operationName] = serviceOnly;
       }
     }


### PR DESCRIPTION
Filter out 'undefined' definitions before checking the length

It's possible to leave a whole query behind when removing fields by directive. In that case, we want to exclude it altogether. In the current state, definitions can === [undefined], giving a length of 1 and passing this check. By filtering for truthy values only, we won't include empty operations in the result of this function.

<!--
  Thanks for filing a pull request on Apollo Tooling!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [ ] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [ ] Make sure all of the significant new logic is covered by tests
- [ ] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests and linter rules pass

\*Make sure changelog entries note which project(s) has been affected. See older entries for examples on what this looks like.
