### PR TITLE
Pin core-js version in apollo-env

### DIFF
--- a/packages/apollo-env/package.json
+++ b/packages/apollo-env/package.json
@@ -20,7 +20,7 @@
     "node": ">=8"
   },
   "dependencies": {
-    "core-js": "^3.0.0-beta.3",
+    "core-js": "3.0.0-beta.3",
     "node-fetch": "^2.2.0"
   }
 }


### PR DESCRIPTION
The API was changed in 3.0.0-beta.12 ([released 2 hours ago](https://github.com/zloirock/core-js/releases)) causing this error in my application:

```
Error: Cannot find module 'core-js/proposals/array-flat-and-flat-map'
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:603:15)
    at Function.Module._load (internal/modules/cjs/loader.js:529:25)
    at Module.require (internal/modules/cjs/loader.js:657:17)
    at require (internal/modules/cjs/helpers.js:22:18)
    at Object.<anonymous> (/Users/ben/p/miles/node_modules/apollo-env/src/polyfills/array.ts:1:1)
    at Module._compile (internal/modules/cjs/loader.js:721:30)
    at Module._compile (/Users/ben/p/miles/example/node_modules/pirates/lib/index.js:83:24)
    at Module._extensions..js (internal/modules/cjs/loader.js:732:10)
    at Object.newLoader [as .js] (/Users/ben/p/miles/example/node_modules/pirates/lib/index.js:88:7)
    at Module.load (internal/modules/cjs/loader.js:620:32)
```

It seems sensible to pin to a specific beta version while the API is moving around. When 3.0.0 is released, then it could be switched back to `^3.0.0`.