### PR TITLE
Add VS Code build step to azure pipelines CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -71,3 +71,29 @@ jobs:
       - script: |
           npm run azure
         displayName: "npm ci && test"
+
+  - job: Build_VSCode
+
+    pool:
+      vmImage: "ubuntu 16.04"
+
+    steps:
+      - task: NodeTool@0
+        inputs:
+          versionSpec: "10.x"
+        displayName: "Install Node.js"
+
+      - script: |
+          npm run package-extension
+        displayName: "package-extension"
+
+      - task: CopyFiles@2
+        inputs:
+          sourceFolder: "./packages/vscode-apollo"
+          contents: "*.vsix"
+          targetFolder: "$(Build.ArtifactStagingDirectory)"
+
+      - task: PublishArtifacts@1
+        inputs:
+          pathtoPublish: "$(Build.ArtifactStagingDirectory)"
+          artifactName: "vsix"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -93,7 +93,7 @@ jobs:
           contents: "*.vsix"
           targetFolder: "$(Build.ArtifactStagingDirectory)"
 
-      - task: PublishArtifacts@1
+      - task: PublishBuildArtifacts@1
         inputs:
           pathtoPublish: "$(Build.ArtifactStagingDirectory)"
           artifactName: "vsix"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -92,8 +92,10 @@ jobs:
           sourceFolder: "./packages/vscode-apollo"
           contents: "*.vsix"
           targetFolder: "$(Build.ArtifactStagingDirectory)"
+        condition: succeededOrFailed()
 
       - task: PublishBuildArtifacts@1
         inputs:
           pathtoPublish: "$(Build.ArtifactStagingDirectory)"
           artifactName: "vsix"
+        condition: succeededOrFailed()


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Tooling!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

To make releases easier and more accessible to others on the team (or for us to do from our phones without being at a computer), I explored the idea of building/releasing the vscode extension via azure pipelines.

**What I did**

- I added a single task to the build pipeline to package the extension (**which I feel we should've been doing anyway**).

- The task produces a build artifact of the `.vsix` file. This file can either be downloaded manually from the `summary` task of an azure build, or used by other pipelines (release pipelines)

<img width="1110" alt="screen shot 2019-02-03 at 10 52 16 pm" src="https://user-images.githubusercontent.com/9259509/52189474-cfa32080-2806-11e9-9dd4-5221bd0af83a.png">

- In azure, I set up a release pipeline that is triggered on each successful build. **The release pipeline is created, but not triggered for a deploy**. The release pipeline isn't deployed unless manually queued in the azure UI. I've attached a video on how to get to that release in the UI.

![feb-03-2019 22-54-39](https://user-images.githubusercontent.com/9259509/52189470-c87c1280-2806-11e9-8b6a-53923d47de61.gif)

- I haven't actually run the deployment (because I don't want to deploy needlessly). I'd love to try the release pipeline out on our next release and see how it works. Until then, it doesn't do anything until manually triggered, so there's really no risk of leaving it in.



TODO:

- [ ] ~Update CHANGELOG.md\* with your change (include reference to issue & this PR)~
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass

\*Make sure changelog entries note which project(s) has been affected. See older entries for examples on what this looks like.