### PR TITLE
Resolve VS Code + package.json performance concern

### DIFF
--- a/packages/apollo-language-server/src/config.ts
+++ b/packages/apollo-language-server/src/config.ts
@@ -288,6 +288,12 @@ export const loadConfig = async ({
     ApolloConfigFormat
   >;
 
+  if (loadedConfig && loadedConfig.filepath.endsWith("package.json")) {
+    console.warn(
+      'The "apollo" package.json configuration key will no longer be supported in Apollo v3. Please use the apollo.config.js file for Apollo project configuration. For more information, see: https://bit.ly/2ByILPj'
+    );
+  }
+
   if (requireConfig && !loadedConfig) {
     throw new Error(
       `No Apollo config found for project. For more information, please refer to:

--- a/packages/apollo-language-server/src/server.ts
+++ b/packages/apollo-language-server/src/server.ts
@@ -6,8 +6,7 @@ import {
   ProposedFeatures,
   TextDocuments,
   FileChangeType,
-  ServerCapabilities,
-  WorkspaceFolder
+  ServerCapabilities
 } from "vscode-languageserver";
 import { QuickPickItem } from "vscode";
 import { GraphQLWorkspace } from "./workspace";
@@ -127,11 +126,7 @@ documents.onDidChangeContent(params => {
 
 connection.onDidChangeWatchedFiles(params => {
   for (const { uri, type } of params.changes) {
-    if (
-      uri.endsWith("apollo.config.js") ||
-      uri.endsWith("package.json") ||
-      uri.endsWith(".env")
-    ) {
+    if (uri.endsWith("apollo.config.js") || uri.endsWith(".env")) {
       workspace.reloadProjectForConfig(uri);
     }
 

--- a/packages/apollo-language-server/src/workspace.ts
+++ b/packages/apollo-language-server/src/workspace.ts
@@ -113,21 +113,6 @@ export class GraphQLWorkspace {
       ignore: "**/node_modules/**"
     });
 
-    apolloConfigFiles.push(
-      ...fg
-        .sync("**/package.json", {
-          cwd: URI.parse(folder.uri).fsPath,
-          absolute: true,
-          ignore: "**/node_modules/**"
-        })
-        // Every package.json file _potentially_ has an apollo config, but we can filter out
-        // the ones that don't before we even call loadConfig and send cosmiconfig looking.
-        .filter(packageFile => {
-          const { apollo } = require(packageFile);
-          return Boolean(apollo);
-        })
-    );
-
     // only have unique possible folders
     const apolloConfigFolders = new Set<string>(apolloConfigFiles.map(dirname));
 

--- a/packages/apollo/README.md
+++ b/packages/apollo/README.md
@@ -458,7 +458,9 @@ _See code: [src/commands/service/push.ts](https://github.com/apollographql/apoll
 
 # Configuration
 
-The Apollo CLI and VS Code extension can be configured with an Apollo Config file. Apollo configuration is stored as a plain object and can be either specified under the `apollo` key in your `package.json` or as a separate `apollo.config.js` file which exports the config data.
+The Apollo CLI and VS Code extension can be configured with an Apollo config file. Apollo configuration is stored as a plain object in an `apollo.config.js` file which exports the configuration. For more information about configuring an Apollo project, see: https://bit.ly/2ByILPj.
+
+> Note: the use of the `apollo` key in the project's package.json file for configuration is deprecated, and will no longer be supported in Apollo v3
 
 You'll need to set up your Apollo configuration for all the features of the Apollo CLI and VS Code extension to work correctly. For full details on how to do that, [visit our docs](https://www.apollographql.com/docs/references/apollo-config.html). A basic configuration (`apollo.config.js` style) looks something like this:
 

--- a/packages/vscode-apollo/src/languageServerClient.ts
+++ b/packages/vscode-apollo/src/languageServerClient.ts
@@ -49,7 +49,6 @@ export function getLanguageServerClient(
     ],
     synchronize: {
       fileEvents: [
-        workspace.createFileSystemWatcher("**/package.json"),
         workspace.createFileSystemWatcher("**/.env"),
         workspace.createFileSystemWatcher("**/*.{graphql,js,ts,jsx,tsx,py}")
       ]


### PR DESCRIPTION
Remove support for package.json Apollo configuration from vscode extension. For monorepos, supporting this type of configuration causes performance issues during a large file change (git branch change, etc.)

Add documentation and notices around deprecation of package.json support altogether.

<!--
  Thanks for filing a pull request on Apollo Tooling!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [ ] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [ ] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass

\*Make sure changelog entries note which project(s) has been affected. See older entries for examples on what this looks like.
