### PR TITLE
Update core-js usage and prevent future updates from renovate.

### DIFF
--- a/packages/apollo-env/src/polyfills/array.ts
+++ b/packages/apollo-env/src/polyfills/array.ts
@@ -1,4 +1,5 @@
-import "core-js/proposals/array-flat-and-flat-map";
+import "core-js/features/array/flat";
+import "core-js/features/array/flat-map";
 
 declare global {
   interface Array<T> {

--- a/renovate.json
+++ b/renovate.json
@@ -7,7 +7,13 @@
     },
     {
       "packageNames": ["@oclif/config"],
-      "rangeStrategy": "pin"
+      "rangeStrategy": "pin",
+      "allowedVersions": ["=1.12.0"]
+    },
+    {
+      "packageNames": ["core-js"],
+      "rangeStrategy": "pin",
+      "allowedVersions": ["=3.0.0-beta.13"]
     }
   ]
 }


### PR DESCRIPTION
Migrate `core-js/proposals/array-flat-and-flat-map` to `core-js/features/array/{flat|flat-map}`

For reference (from core-js README):
```
core-js(-pure)/es|stable|features/array/flat
core-js(-pure)/es|stable|features/array/flat-map
```

Prevent renovate from updating core-js or @oclif/config via `allowedVersions`.

<!--
  Thanks for filing a pull request on Apollo Tooling!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [ ] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [ ] Make sure all of the significant new logic is covered by tests
- [ ] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests and linter rules pass

\*Make sure changelog entries note which project(s) has been affected. See older entries for examples on what this looks like.
