### PR TITLE
Remove defaults from historic validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - `apollo`
   - Support validation parameters for service:check [#953](https://github.com/apollographql/apollo-tooling/pull/953)
+  - Leverage nullability of validation parameters [#1006](https://github.com/apollographql/apollo-tooling/pull/1006)
 - `apollo-language-server`
   - Better error handling in ApolloEngineClient [#953](https://github.com/apollographql/apollo-tooling/pull/953)
 - `vscode-apollo`

--- a/packages/apollo/src/commands/service/check.ts
+++ b/packages/apollo/src/commands/service/check.ts
@@ -47,18 +47,15 @@ export default class ServiceCheck extends ProjectCommand {
     }),
     validationPeriod: flags.string({
       description:
-        "The size of the time window with which to validate the schema against. You may provide a number (in seconds), or an ISO8601 format duration for more granularity (see: https://en.wikipedia.org/wiki/ISO_8601#Durations)",
-      default: "86400"
+        "The size of the time window with which to validate the schema against. You may provide a number (in seconds), or an ISO8601 format duration for more granularity (see: https://en.wikipedia.org/wiki/ISO_8601#Durations)"
     }),
     queryCountThreshold: flags.integer({
       description:
-        "Minimum number of requests within the requested time window for a query to be considered.",
-      default: 1
+        "Minimum number of requests within the requested time window for a query to be considered."
     }),
     queryCountThresholdPercentage: flags.integer({
       description:
-        "Number of requests within the requested time window for a query to be considered, relative to total request count. Expected values are between 0 and 0.05 (minimum 5% of total request volume)",
-      default: 0
+        "Number of requests within the requested time window for a query to be considered, relative to total request count. Expected values are between 0 and 0.05 (minimum 5% of total request volume)"
     })
   };
 
@@ -88,7 +85,7 @@ export default class ServiceCheck extends ProjectCommand {
               tag: flags.tag,
               gitContext: ctx.gitContext,
               frontend: flags.frontend || config.engine.frontend,
-              historicParameters
+              ...(historicParameters && { historicParameters })
             });
           }
         }

--- a/packages/apollo/src/utils/__tests__/validateHistoricParams.test.ts
+++ b/packages/apollo/src/utils/__tests__/validateHistoricParams.test.ts
@@ -47,6 +47,35 @@ describe("validateHistoricParams", () => {
       })
     ).toThrow(/--queryCountThresholdPercentage/);
   });
+
+  it("handles partial input", () => {
+    expect(validateHistoricParams({})).toEqual(null);
+
+    expect(
+      validateHistoricParams({
+        validationPeriod: "P1D"
+      })
+    ).toEqual({ to: -0, from: -86400 });
+
+    expect(
+      validateHistoricParams({
+        queryCountThreshold: 1
+      })
+    ).toEqual({ queryCountThreshold: 1 });
+
+    expect(
+      validateHistoricParams({
+        queryCountThresholdPercentage: 50
+      })
+    ).toEqual({ queryCountThresholdPercentage: 0.5 });
+
+    expect(
+      validateHistoricParams({
+        validationPeriod: "P1D",
+        queryCountThresholdPercentage: 50
+      })
+    ).toEqual({ to: -0, from: -86400, queryCountThresholdPercentage: 0.5 });
+  });
 });
 
 function getValidParams(validationPeriod: string) {

--- a/packages/apollo/src/utils/validateHistoricParams.ts
+++ b/packages/apollo/src/utils/validateHistoricParams.ts
@@ -5,46 +5,61 @@ export function validateHistoricParams({
   validationPeriod,
   queryCountThreshold,
   queryCountThresholdPercentage
-}: {
+}: Partial<{
   validationPeriod: string;
   queryCountThreshold: number;
   queryCountThresholdPercentage: number;
-}): HistoricQueryParameters {
-  // Validation period can be one of two things:
-  // 1) a number in seconds
-  // 2) an ISO 8601 formatted duration, i.e. "P1D", "P10DT1H", "PT6H"
-  const from = isNumeric(validationPeriod)
-    ? -1 * duration(Number(validationPeriod), "seconds").asSeconds()
-    : -1 * duration(validationPeriod).asSeconds();
-
-  if (from >= 0) {
-    throw new Error(
-      "Please provide a valid duration for the --validationPeriod flag. Valid durations are represented in ISO 8601, see: https://bit.ly/2DEJ3UN."
-    );
+}>): Partial<HistoricQueryParameters> | null {
+  if (
+    !validationPeriod &&
+    !queryCountThreshold &&
+    !queryCountThresholdPercentage
+  ) {
+    return null;
   }
 
-  if (!Number.isInteger(queryCountThreshold) || queryCountThreshold < 1) {
+  let from: number | null = null;
+  if (validationPeriod) {
+    // Validation period can be one of two things:
+    // 1) a number in seconds
+    // 2) an ISO 8601 formatted duration, i.e. "P1D", "P10DT1H", "PT6H"
+    from = isNumeric(validationPeriod)
+      ? -1 * duration(Number(validationPeriod), "seconds").asSeconds()
+      : -1 * duration(validationPeriod).asSeconds();
+
+    if (from >= 0) {
+      throw new Error(
+        "Please provide a valid duration for the --validationPeriod flag. Valid durations are represented in ISO 8601, see: https://bit.ly/2DEJ3UN."
+      );
+    }
+  }
+
+  if (
+    queryCountThreshold &&
+    (!Number.isInteger(queryCountThreshold) || queryCountThreshold < 1)
+  ) {
     throw new Error(
       "Please provide a valid number for the --queryCountThreshold flag. Valid numbers are integers in the range x >= 1."
     );
   }
 
-  if (
-    queryCountThresholdPercentage < 0 ||
-    queryCountThresholdPercentage > 100
-  ) {
-    throw new Error(
-      "Please provide a valid number for the --queryCountThresholdPercentage flag. Valid numbers are in the range 0 <= x <= 100."
-    );
+  let asPercentage: number | null = null;
+  if (queryCountThresholdPercentage) {
+    if (
+      queryCountThresholdPercentage < 0 ||
+      queryCountThresholdPercentage > 100
+    ) {
+      throw new Error(
+        "Please provide a valid number for the --queryCountThresholdPercentage flag. Valid numbers are in the range 0 <= x <= 100."
+      );
+    }
+    asPercentage = queryCountThresholdPercentage / 100;
   }
 
-  const asPercentage = queryCountThresholdPercentage / 100;
-
   return {
-    to: -0,
-    from,
-    queryCountThreshold,
-    queryCountThresholdPercentage: asPercentage
+    ...(from && { to: -0, from }),
+    ...(queryCountThreshold && { queryCountThreshold }),
+    ...(asPercentage && { queryCountThresholdPercentage: asPercentage })
   };
 }
 


### PR DESCRIPTION
Previous behavior leveraged the nullability of the checkSchema mutation. By removing defaults from the flags, we can expect the same behavior as before when no historic flags are provided.

*What's incorrect?*
Defaulting to one day for the period was an incorrect assumption on my part - this value can vary on the backend when it's not provided, depending on the user's plan. To account for this, we need the option to provide nothing in the way of historical params (as we were doing before).

<!--
  Thanks for filing a pull request on Apollo Tooling!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [x] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
