### PR TITLE
Clean up configuration code

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5988,7 +5988,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -6009,12 +6010,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6029,17 +6032,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6156,7 +6162,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6168,6 +6175,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6182,6 +6190,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -6189,12 +6198,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -6213,6 +6224,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6293,7 +6305,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6305,6 +6318,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6390,7 +6404,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -6426,6 +6441,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6445,6 +6461,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -6488,12 +6505,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/packages/apollo-language-server/src/config/__tests__/config.ts
+++ b/packages/apollo-language-server/src/config/__tests__/config.ts
@@ -1,0 +1,118 @@
+import {
+  ApolloConfig,
+  ApolloConfigFormat,
+  DefaultClientConfig,
+  DefaultServiceConfig
+} from "../";
+import URI from "vscode-uri";
+
+describe("ApolloConfig", () => {
+  describe("confifDirURI", () => {
+    it("properly parses dir paths for configDirURI", () => {
+      const uri = URI.parse("/test/dir/name");
+      const config = new ApolloConfig({ service: { name: "hai" } }, uri);
+      // can be either /test/dir/name or \\test\\dir\\name depending on platform
+      // this difference is fine :)
+      expect(config.configDirURI.fsPath).toMatch(
+        /\/test\/dir\/name|\\test\\dir\\name/
+      );
+    });
+    it("properly parses filepaths for configDirURI", () => {
+      const uri = URI.parse("/test/dir/name/apollo.config.js");
+      const config = new ApolloConfig({ service: { name: "hai" } }, uri);
+      // can be either /test/dir/name or \\test\\dir\\name depending on platform
+      // this difference is fine :)
+      expect(config.configDirURI.fsPath).toMatch(
+        /\/test\/dir\/name|\\test\\dir\\name/
+      );
+    });
+  });
+
+  describe("projects", () => {
+    it("creates a ClientConfig when client is present", () => {
+      const rawConfig: ApolloConfigFormat = {
+        client: { service: "my-service" }
+      };
+      const config = new ApolloConfig(rawConfig);
+      const projects = config.projects;
+      expect(projects).toHaveLength(1);
+      expect(projects[0].isClient).toBeTruthy();
+    });
+    it("creates a ClientConfig when client is present", () => {
+      const rawConfig: ApolloConfigFormat = { service: "my-service" };
+      const config = new ApolloConfig(rawConfig);
+      const projects = config.projects;
+
+      expect(projects).toHaveLength(1);
+      expect(projects[0].isService).toBeTruthy();
+    });
+    it("creates multiple configs when both client and service are present", () => {
+      const rawConfig: ApolloConfigFormat = {
+        client: { service: "my-service" },
+        service: "my-service"
+      };
+      const config = new ApolloConfig(rawConfig);
+      const projects = config.projects;
+
+      expect(projects).toHaveLength(2);
+      expect(projects.find(c => c.isClient)).toBeTruthy();
+      expect(projects.find(c => c.isService)).toBeTruthy();
+    });
+  });
+
+  describe("tag", () => {
+    it("gets default tag when none is set", () => {
+      const config = new ApolloConfig({ client: { service: "hai" } });
+      expect(config.tag).toEqual("current");
+    });
+
+    it("gets tag from service specifier", () => {
+      const config = new ApolloConfig({ client: { service: "hai@master" } });
+      expect(config.tag).toEqual("master");
+    });
+
+    it("can set and override tags", () => {
+      const config = new ApolloConfig({ client: { service: "hai@master" } });
+      config.tag = "new";
+      expect(config.tag).toEqual("new");
+    });
+  });
+
+  describe("setDefaults", () => {
+    it("can override engine defaults", () => {
+      const config = new ApolloConfig({});
+      const overrides = {
+        engine: {
+          endpoint: "https://test.apollographql.com/api/graphql",
+          frontend: "https://test.apollographql.com"
+        }
+      };
+      config.setDefaults(overrides);
+      expect(config.engine).toEqual(overrides.engine);
+    });
+
+    it("can override client defaults", () => {
+      const config = new ApolloConfig({});
+      const overrides = {
+        client: {
+          name: "my-client",
+          service: "my-service@master"
+        }
+      };
+      config.setDefaults(overrides);
+      expect(config.client).toEqual(overrides.client);
+    });
+
+    it("can override service defaults", () => {
+      const config = new ApolloConfig({});
+      const overrides = {
+        service: {
+          name: "my-service",
+          url: "localhost:9090"
+        }
+      };
+      config.setDefaults(overrides);
+      expect(config.service).toEqual(config.service);
+    });
+  });
+});

--- a/packages/apollo-language-server/src/config/__tests__/utils.ts
+++ b/packages/apollo-language-server/src/config/__tests__/utils.ts
@@ -1,0 +1,95 @@
+import {
+  ApolloConfig,
+  ApolloConfigFormat,
+  getServiceFromKey,
+  getServiceName,
+  isClientConfig,
+  isLocalServiceConfig,
+  isServiceConfig,
+  parseServiceSpecifier
+} from "../";
+
+describe("getServiceFromKey", () => {
+  it("returns undefined with no provided key", () => {
+    expect(getServiceFromKey()).toBeUndefined();
+  });
+
+  it("returns service name from service api key", () => {
+    const key = "service:bob-123:489fhseo4";
+    expect(getServiceFromKey(key)).toEqual("bob-123");
+  });
+
+  it("returns nothing if key is not a service key", () => {
+    const key = "not-a-service:bob-123:489fhseo4";
+    expect(getServiceFromKey(key)).toBeUndefined();
+  });
+
+  it("returns nothing if key is malformed", () => {
+    const key = "service/bob-123:489fhseo4";
+    expect(getServiceFromKey(key)).toBeUndefined();
+  });
+});
+
+describe("getServiceName", () => {
+  describe("client config", () => {
+    it("finds service name when client.service is a string", () => {
+      const rawConfig: ApolloConfigFormat = {
+        client: { service: "my-service" }
+      };
+      expect(getServiceName(rawConfig)).toEqual("my-service");
+
+      const rawConfigWithTag: ApolloConfigFormat = {
+        client: { service: "my-service@master" }
+      };
+      expect(getServiceName(rawConfigWithTag)).toEqual("my-service");
+    });
+
+    it("finds service name when client.service is an object", () => {
+      const rawConfig: ApolloConfigFormat = {
+        client: { service: { name: "my-service" } }
+      };
+      expect(getServiceName(rawConfig)).toEqual("my-service");
+    });
+  });
+  describe("service config", () => {
+    it("finds service name from raw service config", () => {
+      const rawConfig: ApolloConfigFormat = { service: { name: "my-service" } };
+      expect(getServiceName(rawConfig)).toEqual("my-service");
+    });
+  });
+});
+
+describe("isClientConfig", () => {
+  it("identifies client config properly", () => {
+    const config = new ApolloConfig({ client: { service: "hello" } });
+    expect(isClientConfig(config)).toBeTruthy();
+  });
+});
+
+describe("isLocalServiceConfig", () => {
+  it("properly identifies a client config that uses localSchemaFiles", () => {
+    const clientServiceConfig = { localSchemaFile: "okay" };
+    expect(isLocalServiceConfig(clientServiceConfig)).toBeTruthy();
+  });
+});
+
+describe("isServiceConfig", () => {
+  it("identifies service config properly", () => {
+    const config = new ApolloConfig({ service: "hello" });
+    expect(isServiceConfig(config)).toBeTruthy();
+  });
+});
+
+describe("parseServiceSpecifier", () => {
+  it("parses service identifier for service id and tag properly", () => {
+    const [id, tag] = parseServiceSpecifier("my-service@master");
+    expect(id).toEqual("my-service");
+    expect(tag).toEqual("master");
+
+    const [idFromSimpleName, tagFromSimpleName] = parseServiceSpecifier(
+      "my-service"
+    );
+    expect(idFromSimpleName).toEqual("my-service");
+    expect(tagFromSimpleName).toBeUndefined();
+  });
+});

--- a/packages/apollo-language-server/src/config/config.ts
+++ b/packages/apollo-language-server/src/config/config.ts
@@ -68,7 +68,6 @@ export interface ClientConfigFormat extends ConfigBase {
   clientOnlyDirectives?: string[];
   clientSchemaDirectives?: string[];
   addTypename?: boolean;
-
   tagName?: string;
   // stats window config
   statsWindow?: StatsWindowSize;

--- a/packages/apollo-language-server/src/config/config.ts
+++ b/packages/apollo-language-server/src/config/config.ts
@@ -10,7 +10,7 @@ import {
   ClientID,
   StatsWindowSize,
   ServiceIDAndTag
-} from "./engine";
+} from "../engine";
 import URI from "vscode-uri";
 
 export interface EngineStatsWindow {

--- a/packages/apollo-language-server/src/config/config.ts
+++ b/packages/apollo-language-server/src/config/config.ts
@@ -7,11 +7,7 @@ import {
   StatsWindowSize
 } from "../engine";
 import URI from "vscode-uri";
-import {
-  getServiceName,
-  projectsFromConfig,
-  parseServiceSpecificer
-} from "./utils";
+import { getServiceName, parseServiceSpecifier } from "./utils";
 
 export interface EngineStatsWindow {
   to: number;
@@ -135,7 +131,12 @@ export class ApolloConfig {
   }
 
   get projects() {
-    return projectsFromConfig(this.rawConfig, this.configURI);
+    const configs = [];
+    const { client, service } = this.rawConfig;
+    if (client) configs.push(new ClientConfig(this.rawConfig, this.configURI));
+    if (service)
+      configs.push(new ServiceConfig(this.rawConfig, this.configURI));
+    return configs;
   }
 
   set tag(tag: string) {
@@ -146,7 +147,7 @@ export class ApolloConfig {
     if (this._tag) return this._tag;
     let tag: string = "current";
     if (this.client && typeof this.client.service === "string") {
-      const specifierTag = parseServiceSpecificer(this.client
+      const specifierTag = parseServiceSpecifier(this.client
         .service as ServiceSpecifier)[1];
       if (specifierTag) tag = specifierTag;
     }

--- a/packages/apollo-language-server/src/config/config.ts
+++ b/packages/apollo-language-server/src/config/config.ts
@@ -1,17 +1,17 @@
-import * as cosmiconfig from "cosmiconfig";
-import { LoaderEntry } from "cosmiconfig";
-import TypeScriptLoader from "@endemolshinegroup/cosmiconfig-typescript-loader";
-import { resolve, dirname } from "path";
-import { readFileSync, existsSync } from "fs";
+import { dirname } from "path";
 import { merge } from "lodash/fp";
 import {
   ServiceID,
   ServiceSpecifier,
   ClientID,
-  StatsWindowSize,
-  ServiceIDAndTag
+  StatsWindowSize
 } from "../engine";
 import URI from "vscode-uri";
+import {
+  getServiceName,
+  projectsFromConfig,
+  parseServiceSpecificer
+} from "./utils";
 
 export interface EngineStatsWindow {
   to: number;
@@ -110,84 +110,6 @@ export type ApolloConfigFormat =
   | WithRequired<ConfigBaseFormat, "client">
   | WithRequired<ConfigBaseFormat, "service">;
 
-// config settings
-const MODULE_NAME = "apollo";
-const defaultSearchPlaces = [
-  "package.json",
-  `${MODULE_NAME}.config.js`,
-  `${MODULE_NAME}.config.ts`
-];
-
-// Based on order, a provided config file will take precedence over the defaults
-const getSearchPlaces = (configFile?: string) => [
-  ...(configFile ? [configFile] : []),
-  ...defaultSearchPlaces
-];
-
-const loaders = {
-  // XXX improve types for config
-  ".json": (cosmiconfig as any).loadJson as LoaderEntry,
-  ".js": (cosmiconfig as any).loadJs as LoaderEntry,
-  ".ts": {
-    async: TypeScriptLoader
-  }
-};
-
-export interface LoadConfigSettings {
-  // the current working directory to start looking for the config
-  // config loading only works on node so we default to
-  // process.cwd()
-  configPath?: string;
-  configFileName?: string;
-  requireConfig?: boolean;
-  name?: string;
-  type?: "service" | "client";
-}
-
-export type ConfigResult<Config> = {
-  config: Config;
-  filepath: string;
-  isEmpty?: boolean;
-} | null;
-
-// XXX change => to named functions
-// take a config with multiple project types and return
-// an array of individual types
-export const projectsFromConfig = (
-  config: ApolloConfigFormat,
-  configURI?: URI
-): Array<ClientConfig | ServiceConfig> => {
-  const configs = [];
-  const { client, service, ...rest } = config;
-  // XXX use casting detection
-  if (client) configs.push(new ClientConfig(config, configURI));
-  if (service) configs.push(new ServiceConfig(config, configURI));
-  return configs;
-};
-
-export const parseServiceSpecificer = (
-  specifier: ServiceSpecifier
-): ServiceIDAndTag => {
-  const [id, tag] = specifier.split("@").map(x => x.trim());
-  // typescript hinting
-  return [id, tag];
-};
-
-export const getServiceName = (
-  config: ApolloConfigFormat
-): string | undefined => {
-  if (config.service) return config.service.name;
-  if (config.client) {
-    if (typeof config.client.service === "string") {
-      return parseServiceSpecificer(config.client
-        .service as ServiceSpecifier)[0];
-    }
-    return config.client.service && config.client.service.name;
-  } else {
-    return undefined;
-  }
-};
-
 export class ApolloConfig {
   public isClient: boolean;
   public isService: boolean;
@@ -248,148 +170,3 @@ export class ClientConfig extends ApolloConfig {
 export class ServiceConfig extends ApolloConfig {
   public service!: ServiceConfigFormat;
 }
-
-export function isClientConfig(config: ApolloConfig): config is ClientConfig {
-  return config.isClient;
-}
-
-export function isLocalServiceConfig(
-  config: ClientServiceConfig
-): config is LocalServiceConfig {
-  return !!(config as LocalServiceConfig).localSchemaFile;
-}
-
-export function isServiceConfig(config: ApolloConfig): config is ServiceConfig {
-  return config.isService;
-}
-
-const getServiceFromKey = (key: string | undefined): string | undefined => {
-  if (key) {
-    const [type, service] = key.split(":");
-    if (type === "service") return service;
-  }
-  return;
-};
-
-// XXX load .env files automatically
-export const loadConfig = async ({
-  configPath,
-  configFileName,
-  requireConfig = false,
-  name,
-  type
-}: LoadConfigSettings): Promise<ApolloConfig> => {
-  const explorer = cosmiconfig(MODULE_NAME, {
-    searchPlaces: getSearchPlaces(configFileName),
-    loaders
-  });
-
-  let loadedConfig = (await explorer.search(configPath)) as ConfigResult<
-    ApolloConfigFormat
-  >;
-
-  if (loadedConfig && loadedConfig.filepath.endsWith("package.json")) {
-    console.warn(
-      'The "apollo" package.json configuration key will no longer be supported in Apollo v3. Please use the apollo.config.js file for Apollo project configuration. For more information, see: https://bit.ly/2ByILPj'
-    );
-  }
-
-  if (requireConfig && !loadedConfig) {
-    throw new Error(
-      `No Apollo config found for project. For more information, please refer to:
-      https://bit.ly/2ByILPj`
-    );
-  }
-
-  // add API to the env
-  let engineConfig = {},
-    nameFromKey;
-  const dotEnvPath = configPath
-    ? resolve(configPath, ".env")
-    : resolve(process.cwd(), ".env");
-
-  if (existsSync(dotEnvPath)) {
-    const env: { [key: string]: string } = require("dotenv").parse(
-      readFileSync(dotEnvPath)
-    );
-
-    if (env["ENGINE_API_KEY"]) {
-      engineConfig = { engine: { apiKey: env["ENGINE_API_KEY"] } };
-      nameFromKey = getServiceFromKey(env["ENGINE_API_KEY"]);
-    }
-  }
-
-  let resolvedName = name || nameFromKey;
-
-  // The CLI passes in a type when loading config. The editor extension
-  // does not. So we determine the type of the config here, and use it if
-  // the type wasn't explicitly passed in.
-  let resolvedType: "client" | "service";
-  if (type) {
-    resolvedType = type;
-    if (
-      loadedConfig &&
-      loadedConfig.config.client &&
-      typeof loadedConfig.config.client.service === "string"
-    ) {
-      resolvedName = loadedConfig.config.client.service;
-    }
-  } else if (loadedConfig && loadedConfig.config.client) {
-    resolvedType = "client";
-    resolvedName =
-      typeof loadedConfig.config.client.service === "string"
-        ? loadedConfig.config.client.service
-        : resolvedName;
-  } else if (loadedConfig && loadedConfig.config.service) {
-    resolvedType = "service";
-  } else {
-    throw new Error(
-      "Unable to resolve project type. Please add either a client or service config. For more information, please refer to https://bit.ly/2ByILPj"
-    );
-  }
-
-  // If there's a name passed in (from env/flag), it merges with the config file, to
-  // overwrite either the client's service (if a client project), or the service's name.
-  // if there's no config file, it uses the `DefaultConfigBase` to fill these in.
-  if (!loadedConfig || resolvedName) {
-    loadedConfig = {
-      isEmpty: false,
-      filepath: configPath || process.cwd(),
-      config: {
-        ...(loadedConfig && loadedConfig.config),
-        ...(resolvedType === "client"
-          ? {
-              client: {
-                ...DefaultConfigBase,
-                ...(loadedConfig && loadedConfig.config.client),
-                service: resolvedName
-              }
-            }
-          : {
-              service: {
-                ...DefaultConfigBase,
-                ...(loadedConfig && loadedConfig.config.service),
-                name: resolvedName
-              }
-            })
-      }
-    };
-  }
-
-  let { config, filepath, isEmpty } = loadedConfig;
-
-  if (isEmpty) {
-    throw new Error(
-      `Apollo config found at ${filepath} is empty. Please add either a client or service config`
-    );
-  }
-
-  // selectivly apply defaults when loading the config
-  if (config.client) config = merge({ client: DefaultClientConfig }, config);
-  if (config.service) config = merge({ service: DefaultServiceConfig }, config);
-  if (engineConfig) config = merge(engineConfig, config);
-
-  config = merge({ engine: DefaultEngineConfig }, config);
-
-  return new ApolloConfig(config, URI.file(resolve(filepath)));
-};

--- a/packages/apollo-language-server/src/config/index.ts
+++ b/packages/apollo-language-server/src/config/index.ts
@@ -1,0 +1,1 @@
+export * from "./config";

--- a/packages/apollo-language-server/src/config/index.ts
+++ b/packages/apollo-language-server/src/config/index.ts
@@ -1,1 +1,3 @@
+export * from "./utils";
 export * from "./config";
+export * from "./loadConfig";

--- a/packages/apollo-language-server/src/config/loadConfig.ts
+++ b/packages/apollo-language-server/src/config/loadConfig.ts
@@ -1,0 +1,179 @@
+import * as cosmiconfig from "cosmiconfig";
+import { LoaderEntry } from "cosmiconfig";
+import TypeScriptLoader from "@endemolshinegroup/cosmiconfig-typescript-loader";
+import { resolve } from "path";
+import { readFileSync, existsSync } from "fs";
+import { merge } from "lodash/fp";
+import {
+  ApolloConfig,
+  ApolloConfigFormat,
+  DefaultConfigBase,
+  DefaultClientConfig,
+  DefaultServiceConfig,
+  DefaultEngineConfig
+} from "./config";
+import { getServiceFromKey } from "./utils";
+import URI from "vscode-uri";
+
+// config settings
+const MODULE_NAME = "apollo";
+const defaultSearchPlaces = [
+  "package.json",
+  `${MODULE_NAME}.config.js`,
+  `${MODULE_NAME}.config.ts`
+];
+
+// Based on order, a provided config file will take precedence over the defaults
+const getSearchPlaces = (configFile?: string) => [
+  ...(configFile ? [configFile] : []),
+  ...defaultSearchPlaces
+];
+
+const loaders = {
+  // XXX improve types for config
+  ".json": (cosmiconfig as any).loadJson as LoaderEntry,
+  ".js": (cosmiconfig as any).loadJs as LoaderEntry,
+  ".ts": {
+    async: TypeScriptLoader
+  }
+};
+
+export interface LoadConfigSettings {
+  // the current working directory to start looking for the config
+  // config loading only works on node so we default to
+  // process.cwd()
+  configPath?: string;
+  configFileName?: string;
+  requireConfig?: boolean;
+  name?: string;
+  type?: "service" | "client";
+}
+
+export type ConfigResult<T> = {
+  config: T;
+  filepath: string;
+  isEmpty?: boolean;
+} | null;
+
+// XXX load .env files automatically
+export async function loadConfig({
+  configPath,
+  configFileName,
+  requireConfig = false,
+  name,
+  type
+}: LoadConfigSettings) {
+  const explorer = cosmiconfig(MODULE_NAME, {
+    searchPlaces: getSearchPlaces(configFileName),
+    loaders
+  });
+
+  let loadedConfig = (await explorer.search(configPath)) as ConfigResult<
+    ApolloConfigFormat
+  >;
+
+  if (loadedConfig && loadedConfig.filepath.endsWith("package.json")) {
+    console.warn(
+      'The "apollo" package.json configuration key will no longer be supported in Apollo v3. Please use the apollo.config.js file for Apollo project configuration. For more information, see: https://bit.ly/2ByILPj'
+    );
+  }
+
+  if (requireConfig && !loadedConfig) {
+    throw new Error(
+      `No Apollo config found for project. For more information, please refer to:
+      https://bit.ly/2ByILPj`
+    );
+  }
+
+  // add API to the env
+  let engineConfig = {},
+    nameFromKey;
+  const dotEnvPath = configPath
+    ? resolve(configPath, ".env")
+    : resolve(process.cwd(), ".env");
+
+  if (existsSync(dotEnvPath)) {
+    const env: { [key: string]: string } = require("dotenv").parse(
+      readFileSync(dotEnvPath)
+    );
+
+    if (env["ENGINE_API_KEY"]) {
+      engineConfig = { engine: { apiKey: env["ENGINE_API_KEY"] } };
+      nameFromKey = getServiceFromKey(env["ENGINE_API_KEY"]);
+    }
+  }
+
+  let resolvedName = name || nameFromKey;
+
+  // The CLI passes in a type when loading config. The editor extension
+  // does not. So we determine the type of the config here, and use it if
+  // the type wasn't explicitly passed in.
+  let resolvedType: "client" | "service";
+  if (type) {
+    resolvedType = type;
+    if (
+      loadedConfig &&
+      loadedConfig.config.client &&
+      typeof loadedConfig.config.client.service === "string"
+    ) {
+      resolvedName = loadedConfig.config.client.service;
+    }
+  } else if (loadedConfig && loadedConfig.config.client) {
+    resolvedType = "client";
+    resolvedName =
+      typeof loadedConfig.config.client.service === "string"
+        ? loadedConfig.config.client.service
+        : resolvedName;
+  } else if (loadedConfig && loadedConfig.config.service) {
+    resolvedType = "service";
+  } else {
+    throw new Error(
+      "Unable to resolve project type. Please add either a client or service config. For more information, please refer to https://bit.ly/2ByILPj"
+    );
+  }
+
+  // If there's a name passed in (from env/flag), it merges with the config file, to
+  // overwrite either the client's service (if a client project), or the service's name.
+  // if there's no config file, it uses the `DefaultConfigBase` to fill these in.
+  if (!loadedConfig || resolvedName) {
+    loadedConfig = {
+      isEmpty: false,
+      filepath: configPath || process.cwd(),
+      config: {
+        ...(loadedConfig && loadedConfig.config),
+        ...(resolvedType === "client"
+          ? {
+              client: {
+                ...DefaultConfigBase,
+                ...(loadedConfig && loadedConfig.config.client),
+                service: resolvedName
+              }
+            }
+          : {
+              service: {
+                ...DefaultConfigBase,
+                ...(loadedConfig && loadedConfig.config.service),
+                name: resolvedName
+              }
+            })
+      }
+    };
+  }
+
+  let { config, filepath, isEmpty } = loadedConfig;
+
+  if (isEmpty) {
+    throw new Error(
+      `Apollo config found at ${filepath} is empty. Please add either a client or service config`
+    );
+  }
+
+  // selectivly apply defaults when loading the config
+  if (config.client) config = merge({ client: DefaultClientConfig }, config);
+  if (config.service) config = merge({ service: DefaultServiceConfig }, config);
+  if (engineConfig) config = merge(engineConfig, config);
+
+  config = merge({ engine: DefaultEngineConfig }, config);
+
+  return new ApolloConfig(config, URI.file(resolve(filepath)));
+}

--- a/packages/apollo-language-server/src/config/utils.ts
+++ b/packages/apollo-language-server/src/config/utils.ts
@@ -35,7 +35,7 @@ export function getServiceName(config: ApolloConfigFormat) {
   if (config.service) return config.service.name;
   if (config.client) {
     if (typeof config.client.service === "string") {
-      return parseServiceSpecificer(config.client
+      return parseServiceSpecifier(config.client
         .service as ServiceSpecifier)[0];
     }
     return config.client.service && config.client.service.name;
@@ -44,20 +44,7 @@ export function getServiceName(config: ApolloConfigFormat) {
   }
 }
 
-export function parseServiceSpecificer(specifier: ServiceSpecifier) {
+export function parseServiceSpecifier(specifier: ServiceSpecifier) {
   const [id, tag] = specifier.split("@").map(x => x.trim());
   return [id, tag] as ServiceIDAndTag;
-}
-
-// take a config with multiple project types and return
-// an array of individual types
-export function projectsFromConfig(
-  config: ApolloConfigFormat,
-  configURI?: URI
-) {
-  const configs = [];
-  const { client, service } = config;
-  if (client) configs.push(new ClientConfig(config, configURI));
-  if (service) configs.push(new ServiceConfig(config, configURI));
-  return configs;
 }

--- a/packages/apollo-language-server/src/config/utils.ts
+++ b/packages/apollo-language-server/src/config/utils.ts
@@ -13,6 +13,7 @@ export function isClientConfig(config: ApolloConfig): config is ClientConfig {
   return config.isClient;
 }
 
+// checks the `config.client.service` object for a localSchemaFile
 export function isLocalServiceConfig(
   config: ClientServiceConfig
 ): config is LocalServiceConfig {

--- a/packages/apollo-language-server/src/config/utils.ts
+++ b/packages/apollo-language-server/src/config/utils.ts
@@ -1,0 +1,63 @@
+import {
+  ApolloConfig,
+  ClientConfig,
+  ClientServiceConfig,
+  LocalServiceConfig,
+  ServiceConfig,
+  ApolloConfigFormat
+} from "./config";
+import { ServiceSpecifier, ServiceIDAndTag } from "../engine";
+import URI from "vscode-uri";
+
+export function isClientConfig(config: ApolloConfig): config is ClientConfig {
+  return config.isClient;
+}
+
+export function isLocalServiceConfig(
+  config: ClientServiceConfig
+): config is LocalServiceConfig {
+  return !!(config as LocalServiceConfig).localSchemaFile;
+}
+
+export function isServiceConfig(config: ApolloConfig): config is ServiceConfig {
+  return config.isService;
+}
+
+export function getServiceFromKey(key: string | undefined) {
+  if (key) {
+    const [type, service] = key.split(":");
+    if (type === "service") return service;
+  }
+  return;
+}
+
+export function getServiceName(config: ApolloConfigFormat) {
+  if (config.service) return config.service.name;
+  if (config.client) {
+    if (typeof config.client.service === "string") {
+      return parseServiceSpecificer(config.client
+        .service as ServiceSpecifier)[0];
+    }
+    return config.client.service && config.client.service.name;
+  } else {
+    return undefined;
+  }
+}
+
+export function parseServiceSpecificer(specifier: ServiceSpecifier) {
+  const [id, tag] = specifier.split("@").map(x => x.trim());
+  return [id, tag] as ServiceIDAndTag;
+}
+
+// take a config with multiple project types and return
+// an array of individual types
+export function projectsFromConfig(
+  config: ApolloConfigFormat,
+  configURI?: URI
+) {
+  const configs = [];
+  const { client, service } = config;
+  if (client) configs.push(new ClientConfig(config, configURI));
+  if (service) configs.push(new ServiceConfig(config, configURI));
+  return configs;
+}

--- a/packages/apollo-language-server/src/engine/index.ts
+++ b/packages/apollo-language-server/src/engine/index.ts
@@ -2,7 +2,7 @@ import gql from "graphql-tag";
 import { GraphQLDataSource } from "./GraphQLDataSource";
 import { GraphQLRequest } from "apollo-link";
 
-import { DefaultEngineConfig } from "../config";
+import { DefaultEngineConfig, getServiceFromKey } from "../config";
 import { CHECK_SCHEMA, CheckSchemaVariables } from "./operations/checkSchema";
 import {
   UPLOAD_SCHEMA,
@@ -73,13 +73,6 @@ export function noServiceError(service: string | undefined, endpoint?: string) {
     service ? service : ""
   } from Engine at ${endpoint}. Please check your API key and service name`;
 }
-
-const getServiceFromKey = (key: string | undefined): string | undefined => {
-  if (!key) return "";
-  const [type, service] = key.split(":");
-  if (type === "service") return service;
-  return;
-};
 
 export class ApolloEngineClient extends GraphQLDataSource {
   constructor(

--- a/packages/apollo-language-server/src/schema/providers/engine.ts
+++ b/packages/apollo-language-server/src/schema/providers/engine.ts
@@ -6,7 +6,7 @@ import gql from "graphql-tag";
 import { GraphQLSchema, buildClientSchema } from "graphql";
 
 import { ApolloEngineClient, ClientIdentity } from "../../engine";
-import { ClientConfig, parseServiceSpecificer } from "../../config";
+import { ClientConfig, parseServiceSpecifier } from "../../config";
 import {
   GraphQLSchemaProvider,
   SchemaChangeUnsubscribeHandler,
@@ -44,7 +44,7 @@ export class EngineSchemaProvider implements GraphQLSchemaProvider {
       );
     }
 
-    const [id, tag = "current"] = parseServiceSpecificer(client.service);
+    const [id, tag = "current"] = parseServiceSpecifier(client.service);
     const { data, errors } = await this.client.execute({
       query: SCHEMA_QUERY,
       variables: {

--- a/packages/apollo/src/Command.ts
+++ b/packages/apollo/src/Command.ts
@@ -10,7 +10,8 @@ import {
   loadConfig,
   isClientConfig,
   isServiceConfig,
-  ApolloConfig
+  ApolloConfig,
+  getServiceFromKey
 } from "apollo-language-server";
 import { OclifLoadingHandler } from "./OclifLoadingHandler";
 import URI from "vscode-uri";
@@ -53,12 +54,6 @@ const headersArrayToObject = (
   return arr
     .map(val => JSON.parse(val))
     .reduce((pre, next) => ({ ...pre, ...next }), {});
-};
-
-const getServiceFromKey = (key): string | undefined => {
-  const [type, service] = key.split(":");
-  if (type === "service") return service;
-  return;
 };
 
 export abstract class ProjectCommand extends Command {

--- a/packages/apollo/src/commands/client/__tests__/generate.test.ts
+++ b/packages/apollo/src/commands/client/__tests__/generate.test.ts
@@ -68,7 +68,7 @@ const defaultConfig = `
 const defaultFiles = {
   "./schema.json": fullSchemaJsonString,
   "./queryOne.graphql": simpleQuery.toString(),
-  "./apollo.config.js": defaultConfig
+  "./my.config.js": defaultConfig
 };
 
 jest.setTimeout(25000);
@@ -79,7 +79,7 @@ describe("client:codegen", () => {
     .command([
       "client:codegen",
       "API.swift",
-      "--config=apollo.config.js",
+      "--config=my.config.js",
       "--target=swift"
     ])
     .it("writes swift types from local schema", () => {
@@ -90,7 +90,7 @@ describe("client:codegen", () => {
     .fs({
       "schema.graphql": graphQLSchema,
       "queryOne.graphql": simpleQuery.toString(),
-      "apollo.config.js": `
+      "my.config.js": `
         module.exports = {
           client: {
             includes: ["./queryOne.graphql"],
@@ -102,7 +102,7 @@ describe("client:codegen", () => {
     .command([
       "client:codegen",
       "API.swift",
-      "--config=apollo.config.js",
+      "--config=my.config.js",
       "--target=swift"
     ])
     .it("writes swift types from local schema in a graphql file", () => {
@@ -113,7 +113,7 @@ describe("client:codegen", () => {
     .fs({
       "schema.json": fullSchemaJsonString,
       "queryOne.graphql": simpleQuery.toString(),
-      "apollo.config.js": `
+      "my.config.js": `
         module.exports = {
           client: {
             includes: ["./queryOne.graphql"],
@@ -125,6 +125,7 @@ describe("client:codegen", () => {
     .command([
       "client:codegen",
       "API.swift",
+      "--config=my.config.js",
       "--target=swift",
       "--operationIdsPath=myOperationIDs.json"
     ])
@@ -141,10 +142,11 @@ describe("client:codegen", () => {
       "schema.json": fullSchemaJsonString,
       "queryOne.graphql": simpleQuery.toString(),
       "queryTwo.graphql": otherQuery.toString(),
-      "apollo.config.js": defaultConfig
+      "my.config.js": defaultConfig
     })
     .command([
       "client:codegen",
+      "--config=my.config.js",
       "--only=queryTwo.graphql",
       "--target=swift",
       "outDirectory"
@@ -160,9 +162,14 @@ describe("client:codegen", () => {
     .fs({
       "schema.json": fullSchemaJsonString,
       "queryOne.graphql": simpleQuery.toString(),
-      "apollo.config.js": defaultConfig
+      "my.config.js": defaultConfig
     })
-    .command(["client:codegen", "--target=scala", "API.scala"])
+    .command([
+      "client:codegen",
+      "--target=scala",
+      "API.scala",
+      "--config=my.config.js"
+    ])
     .it("writes types for scala", () => {
       expect(fs.readFileSync("API.scala").toString()).toMatchSnapshot();
     });
@@ -171,10 +178,11 @@ describe("client:codegen", () => {
     .fs({
       "schema.json": fullSchemaJsonString,
       "queryOne.graphql": simpleQuery.toString(),
-      "apollo.config.js": defaultConfig
+      "my.config.js": defaultConfig
     })
     .command([
       "client:codegen",
+      "--config=my.config.js",
       "--target=typescript",
       "--outputFlat",
       "API.ts"
@@ -188,10 +196,11 @@ describe("client:codegen", () => {
       "schema.json": fullSchemaJsonString,
       "clientSideSchema.graphql": clientSideSchema.toString(),
       "clientSideSchemaQuery.graphql": clientSideSchemaQuery.toString(),
-      "apollo.config.js": defaultConfig
+      "my.config.js": defaultConfig
     })
     .command([
       "client:codegen",
+      "--config=my.config.js",
       "--target=typescript",
       "--outputFlat",
       "__tmp__API.ts" // for some reason, this gets moved to root dir. naming __tmp__ to get .gitignore'd
@@ -208,7 +217,7 @@ describe("client:codegen", () => {
       "schema.json": fullSchemaJsonString,
       "clientSideSchemaTag.js": clientSideSchemaTag.toString(),
       "clientSideSchemaQuery.graphql": clientSideSchemaQuery.toString(),
-      "apollo.config.js": `
+      "my.config.js": `
         module.exports = {
           client: {
             includes: ["./**.graphql", "./**.js"], // include js file with schema in it
@@ -219,6 +228,7 @@ describe("client:codegen", () => {
     })
     .command([
       "client:codegen",
+      "--config=my.config.js",
       "--target=typescript",
       "--outputFlat",
       "__tmp__API.ts" // for some reason, this gets moved to root dir. naming __tmp__ to get .gitignore'd
@@ -269,7 +279,7 @@ describe("client:codegen", () => {
     .fs({
       "clientSideOnlySchema.graphql": clientSideOnlySchema.toString(),
       "clientSideOnlyQuery.graphql": clientSideOnlyQuery.toString(),
-      "apollo.config.js": `
+      "my.config.js": `
         module.exports = {
           client: {
             includes: ["./clientSideOnlyQuery.graphql"], // queries
@@ -280,6 +290,7 @@ describe("client:codegen", () => {
     })
     .command([
       "client:codegen",
+      "--config=my.config.js",
       "--target=typescript",
       "--outputFlat",
       "__tmp__API.ts"
@@ -292,10 +303,11 @@ describe("client:codegen", () => {
     .fs({
       "schema.json": fullSchemaJsonString,
       "queryOne.graphql": simpleQuery.toString(),
-      "apollo.config.js": defaultConfig
+      "my.config.js": defaultConfig
     })
     .command([
       "client:codegen",
+      "--config=my.config.js",
       "--target=flow",
       "--outputFlat",
       "__tmp__API.js"
@@ -308,10 +320,11 @@ describe("client:codegen", () => {
     .fs({
       "schema.json": fullSchemaJsonString,
       "queryOne.graphql": simpleQuery.toString(),
-      "apollo.config.js": defaultConfig
+      "my.config.js": defaultConfig
     })
     .command([
       "client:codegen",
+      "--config=my.config.js",
       "--target=flow",
       "--outputFlat",
       "--useFlowExactObjects",
@@ -328,10 +341,11 @@ describe("client:codegen", () => {
     .fs({
       "schema.json": fullSchemaJsonString,
       "queryOne.graphql": simpleQuery.toString(),
-      "apollo.config.js": defaultConfig
+      "my.config.js": defaultConfig
     })
     .command([
       "client:codegen",
+      "--config=my.config.js",
       "--target=flow",
       "--outputFlat",
       "--useFlowReadOnlyTypes",
@@ -345,9 +359,14 @@ describe("client:codegen", () => {
     .fs({
       "schema.json": fullSchemaJsonString,
       "queryOne.graphql": simpleQuery.toString(),
-      "apollo.config.js": defaultConfig
+      "my.config.js": defaultConfig
     })
-    .command(["client:codegen", "--target=json", "__tmp__operations.json"])
+    .command([
+      "client:codegen",
+      "--target=json",
+      "--config=my.config.js",
+      "__tmp__operations.json"
+    ])
     .it("writes json operations", () => {
       const output = JSON.parse(
         fs.readFileSync("__tmp__operations.json").toString()
@@ -369,7 +388,7 @@ describe("client:codegen", () => {
           }
         \`;
       `,
-      "apollo.config.js": `
+      "my.config.js": `
         module.exports = {
           client: {
             includes: ["./**.graphql", "./**/*.tsx"],
@@ -378,7 +397,7 @@ describe("client:codegen", () => {
         }
       `
     })
-    .command(["client:codegen", "--target=typescript"])
+    .command(["client:codegen", "--target=typescript", "--config=my.config.js"])
     .it(
       "writes TypeScript types into a __generated__ directory next to sources when no output is set",
       () => {
@@ -405,7 +424,7 @@ describe("client:codegen", () => {
           }
         \`;
       `,
-      "apollo.config.js": `
+      "my.config.js": `
         module.exports = {
           client: {
             includes: ["./**.graphql", "./**/*.jsx"],
@@ -414,7 +433,7 @@ describe("client:codegen", () => {
         }
       `
     })
-    .command(["client:codegen", "--target=flow"])
+    .command(["client:codegen", "--target=flow", "--config=my.config.js"])
     .it(
       "writes flow types into a __generated__ directory next to sources when no output is set",
       () => {
@@ -438,7 +457,7 @@ describe("client:codegen", () => {
           }
         \`;
       `,
-      "apollo.config.js": `
+      "my.config.js": `
         module.exports = {
           client: {
             includes: ["./**.graphql", "./**/*.tsx"],
@@ -447,7 +466,12 @@ describe("client:codegen", () => {
         }
       `
     })
-    .command(["client:codegen", "--target=typescript", "__foo__"])
+    .command([
+      "client:codegen",
+      "--config=my.config.js",
+      "--target=typescript",
+      "__foo__"
+    ])
     .it(
       "writes TypeScript types to a custom directory next to sources when output is set",
       () => {
@@ -470,7 +494,7 @@ describe("client:codegen", () => {
           }
         \`;
       `,
-      "apollo.config.js": `
+      "my.config.js": `
         module.exports = {
           client: {
             includes: ["./**.graphql", "./**/*.tsx"],
@@ -481,6 +505,7 @@ describe("client:codegen", () => {
     })
     .command([
       "client:codegen",
+      "--config=my.config.js",
       "--target=typescript",
       "--globalTypesFile=__foo__/bar.ts"
     ])
@@ -506,7 +531,7 @@ describe("client:codegen", () => {
           }
         \`;
       `,
-      "apollo.config.js": `
+      "my.config.js": `
         module.exports = {
           client: {
             includes: ["./**.graphql", "./**/*.jsx"],
@@ -515,7 +540,12 @@ describe("client:codegen", () => {
         }
     `
     })
-    .command(["client:codegen", "--target=flow", "__foo__"])
+    .command([
+      "client:codegen",
+      "--config=my.config.js",
+      "--target=flow",
+      "__foo__"
+    ])
     .it(
       "writes Flow types to a custom directory next to sources when output is set",
       () => {
@@ -537,7 +567,7 @@ describe("client:codegen", () => {
           }
         \`;
       `,
-      "apollo.config.js": `
+      "my.config.js": `
         module.exports = {
           client: {
             includes: ["./**.graphql", "./**/*.tsx"],
@@ -546,7 +576,12 @@ describe("client:codegen", () => {
         }
       `
     })
-    .command(["client:codegen", "--target=typescript", ""])
+    .command([
+      "client:codegen",
+      "--config=my.config.js",
+      "--target=typescript",
+      ""
+    ])
     .it(
       "writes TypeScript types next to sources when output is set to empty string",
       () => {
@@ -569,7 +604,7 @@ describe("client:codegen", () => {
           }
         \`;
       `,
-      "apollo.config.js": `
+      "my.config.js": `
         module.exports = {
           client: {
             includes: ["./**.graphql", "./**/*.jsx"],
@@ -578,7 +613,7 @@ describe("client:codegen", () => {
         }
       `
     })
-    .command(["client:codegen", "--target=flow", ""])
+    .command(["client:codegen", "--config=my.config.js", "--target=flow", ""])
     .it(
       "writes flow types next to sources when output is set to empty string",
       () => {
@@ -598,7 +633,7 @@ describe("client:codegen", () => {
           }
         \`;
       `,
-      "apollo.config.js": `
+      "my.config.js": `
         module.exports = {
           client: {
             includes: ["./**/*.tsx"],
@@ -609,6 +644,7 @@ describe("client:codegen", () => {
     })
     .command([
       "client:codegen",
+      "--config=my.config.js",
       "--target=typescript",
       "--tagName=customGraphQLTag",
       "--outputFlat"
@@ -629,7 +665,7 @@ describe("client:codegen", () => {
           }
         \`;
       `,
-      "apollo.config.js": `
+      "my.config.js": `
         module.exports = {
           client: {
             includes: ["./**/*.tsx"],
@@ -639,7 +675,12 @@ describe("client:codegen", () => {
         }
     `
     })
-    .command(["client:codegen", "--target=typescript", "--outputFlat"])
+    .command([
+      "client:codegen",
+      "--config=my.config.js",
+      "--target=typescript",
+      "--outputFlat"
+    ])
     .it("extracts queries with a custom tagName provided in the config", () => {
       expect(
         fs.readFileSync("__generated__/SimpleQuery.ts").toString()
@@ -650,13 +691,13 @@ describe("client:codegen", () => {
 describe("error handling", () => {
   test
     .fs(defaultFiles)
-    .command(["client:codegen", "--target=foobar"])
+    .command(["client:codegen", "--config=my.config.js", "--target=foobar"])
     .catch(err => expect(err.message).toMatch(/Unsupported target: foobar/))
     .it("errors with an unsupported target");
 
   test
     .fs(defaultFiles)
-    .command(["client:codegen", "--target=swift"])
+    .command(["client:codegen", "--config=my.config.js", "--target=swift"])
     .catch(err =>
       expect(err.message).toMatch(/The output path must be specified/)
     )
@@ -664,7 +705,7 @@ describe("error handling", () => {
 
   test
     .fs(defaultFiles)
-    .command(["client:codegen", "output-file"])
+    .command(["client:codegen", "--config=my.config.js", "output-file"])
     .catch(err => expect(err.message).toMatch(/Missing required flag/))
     .it("errors when no target specified");
 });


### PR DESCRIPTION
This PR brings some sanity to the configuration code. Functionally, it should be a no-op.

* Create a config _folder_, in order to break up `config.ts` into smaller, more manageable parts
* Move utility functions out of `config.ts` into `utils.ts`
* `loadConfig` lives in its own file now, along with related cosmiconfig code
* Remove some duplication
* Clean up functions with some minor TS improvements

> Want to add some tests for util functions, probably will get to that

TODO:

- [ ] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [ ] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
