### PR TITLE
Re-enable logging when codegen is in watch mode and detects changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Changelog
 
 ## Upcoming
-- Fix a bug where tagging a build will cause the tool to not be able to figure out where the git repo is [#944](https://github.com/apollographql/apollo-tooling/pull/944)
 
+- `apollo`
+  - Fix a bug where tagging a build will cause the tool to not be able to figure out where the git repo is [#944](https://github.com/apollographql/apollo-tooling/pull/944)
+  - Re-enable logging for codegen when in watch mode [#1039](https://github.com/apollographql/apollo-tooling/pull/1039)
 - `apollo-language-server`
   - Added a warning when there are 0 files found in a project [#1007](https://github.com/apollographql/apollo-tooling/pull/1007)
   - Allow relative paths in includes/excludes globs [#1007](https://github.com/apollographql/apollo-tooling/pull/1007)

--- a/packages/apollo/src/commands/client/codegen.ts
+++ b/packages/apollo/src/commands/client/codegen.ts
@@ -215,7 +215,7 @@ export default class Generate extends ClientCommand {
       await run().catch(() => {});
       const watcher = new Gaze(this.project.config.client.includes);
       watcher.on("all", (event, file) => {
-        // console.log("\nChange detected, generating types...");
+        console.log("\nChange detected, generating types...");
         this.project.fileDidChange(URI.file(file).toString());
       });
       if (tty.isatty((process.stdin as any).fd)) {


### PR DESCRIPTION
Resolves #603 

At some point the console log was disabled telling users that types had been updated from codegen in watch mode. This PR is just re-enabling that :)

<!--
  Thanks for filing a pull request on Apollo Tooling!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [x] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass

\*Make sure changelog entries note which project(s) has been affected. See older entries for examples on what this looks like.
