### PR TITLE
Handle `subscribe` in resolverMap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ## Upcoming
 
-- Handle `subscribe` in `buildServiceDefinition` and add type in `resolverMap` [#1047](https://github.com/apollographql/apollo-tooling/pull/1047)
-
 - `apollo`
   - Relax graphql version, resolve missing types "Boolean", "String" [#1355](https://github.com/apollographql/apollo-tooling/pull/1355)
   - Add `service:list` and tests [#1358](https://github.com/apollographql/apollo-tooling/pull/1358) and header [#1377](https://github.com/apollographql/apollo-tooling/pull/1377)
@@ -23,14 +21,10 @@
 - `apollo-graphql`
   - <First `apollo-graphql` related entry goes here>
 - `apollo-language-server`
-<<<<<<< HEAD
-  - <First `apollo-language-server` related entry goes here>
-=======
   - Allow template literal placeholders that span multiple rows[#1299](https://github.com/apollographql/apollo-tooling/pull/1299)
   - Add support for extracting GraphQL documents from Ruby source files using `<<-GRAPHQL...GRAPHQL` heredoc. [#1304](https://github.com/apollographql/apollo-tooling/pull/1304)
->>>>>>> [language server] Extract GraphQL documents from Ruby source
 - `apollo-tools`
-  - <First `apollo-tools` related entry goes here>
+  - Handle `subscribe` in `buildServiceDefinition` and add type in `resolverMap` [#1047](https://github.com/apollographql/apollo-tooling/pull/1047)
 - `vscode-apollo`
   - Add support for Ruby source files using `<<-GRAPHQL...GRAPHQL` heredoc. [#1304](https://github.com/apollographql/apollo-tooling/pull/1304)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Upcoming
 
+- Handle `subscribe` in `buildServiceDefinition` and add type in `resolverMap` [#1047](https://github.com/apollographql/apollo-tooling/pull/1047)
+
 - `apollo`
   - Relax graphql version, resolve missing types "Boolean", "String" [#1355](https://github.com/apollographql/apollo-tooling/pull/1355)
   - Add `service:list` and tests [#1358](https://github.com/apollographql/apollo-tooling/pull/1358) and header [#1377](https://github.com/apollographql/apollo-tooling/pull/1377)

--- a/packages/apollo-tools/src/__tests__/buildServiceDefinition.test.ts
+++ b/packages/apollo-tools/src/__tests__/buildServiceDefinition.test.ts
@@ -390,5 +390,44 @@ type MutationRoot {
 
       expect(nameField.resolve).toEqual(name);
     });
+
+    it(`should handle subscriptions`, () => {
+      const commentAddedSubscription = () =>
+        async function*() {
+          yield "111";
+          yield "222";
+          yield "333";
+        };
+
+      const service = buildServiceDefinition([
+        {
+          typeDefs: gql`
+            type Subscription {
+              commentAdded: String
+            }
+          `,
+          resolvers: {
+            Subscription: {
+              commentAdded: {
+                subscribe: commentAddedSubscription
+              }
+            }
+          }
+        }
+      ]);
+
+      expect(service.schema).toBeDefined();
+      const schema = service.schema!;
+
+      const subscriptionType = schema.getType("Subscription");
+      expect(subscriptionType).toBeDefined();
+
+      const commentAdded = (subscriptionType! as GraphQLObjectType).getFields()[
+        "commentAdded"
+      ];
+      expect(commentAdded).toBeDefined();
+
+      expect(commentAdded.subscribe).toEqual(commentAddedSubscription);
+    });
   });
 });

--- a/packages/apollo-tools/src/buildServiceDefinition.ts
+++ b/packages/apollo-tools/src/buildServiceDefinition.ts
@@ -229,7 +229,12 @@ function addResolversToSchema(
       if (typeof fieldConfig === "function") {
         field.resolve = fieldConfig;
       } else {
-        field.resolve = fieldConfig.resolve;
+        if (fieldConfig.resolve) {
+          field.resolve = fieldConfig.resolve;
+        }
+        if (fieldConfig.subscribe) {
+          field.subscribe = fieldConfig.subscribe;
+        }
       }
     }
   }

--- a/packages/apollo-tools/src/schema/resolverMap.ts
+++ b/packages/apollo-tools/src/schema/resolverMap.ts
@@ -7,6 +7,17 @@ export interface GraphQLResolverMap<TContext> {
       | {
           requires?: string;
           resolve: GraphQLFieldResolver<any, TContext>;
+          subscribe?: undefined;
+        }
+      | {
+          requires?: string;
+          resolve?: undefined;
+          subscribe: GraphQLFieldResolver<any, TContext>;
+        }
+      | {
+          requires?: string;
+          resolve: GraphQLFieldResolver<any, TContext>;
+          subscribe: GraphQLFieldResolver<any, TContext>;
         };
   };
 }


### PR DESCRIPTION
This PR adds a handler and typing for resolvers for Subscriptions

As Jesse helped find in graphql-tools, [resolve and subscribe are not mutually exclusive](https://github.com/apollographql/graphql-tools/blob/641d7058fdf4b7af08a92a770c0b9a4f0febea29/src/stitching/mergeSchemas.ts#L259-L272)

I believe this relates to https://github.com/apollographql/apollo-server/issues/2149

TODO:

- [x] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
