### PR TITLE
Fix config loading issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Upcoming
 
+- `apollo-language-server`
+  - fix single apollo.config breaking others loaded at the same time [#1055](https://github.com/apollographql/apollo-tooling/pull/1055)
+  - Fix broken fileSet.includesFile to use full filepath [#1055](https://github.com/apollographql/apollo-tooling/pull/1055)
+
 ## `apollo@2.5.2`
 
 - `apollo@2.5.2`

--- a/packages/apollo-language-server/src/config/loadConfig.ts
+++ b/packages/apollo-language-server/src/config/loadConfig.ts
@@ -72,6 +72,12 @@ export async function loadConfig({
     ApolloConfigFormat
   >;
 
+  if (configPath && !loadedConfig) {
+    throw new Error(
+      `A config file failed to load at '${configPath}'. This is likely because this file is empty or malformed. For more information, please refer to: https://bit.ly/2ByILPj`
+    );
+  }
+
   if (loadedConfig && loadedConfig.filepath.endsWith("package.json")) {
     console.warn(
       'The "apollo" package.json configuration key will no longer be supported in Apollo v3. Please use the apollo.config.js file for Apollo project configuration. For more information, see: https://bit.ly/2ByILPj'

--- a/packages/apollo-language-server/src/fileSet.ts
+++ b/packages/apollo-language-server/src/fileSet.ts
@@ -51,7 +51,7 @@ export class FileSet {
   }
 
   includesFile(filePath: string): boolean {
-    return this.allFiles().includes(relative(this.rootURI.fsPath, filePath));
+    return this.allFiles().includes(filePath);
   }
 
   allFiles(): string[] {


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Tooling!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

Fixes 2 bugs:
- VS Code not recognizing a file as being part of the `project` (first commit)
	- Changed it from using relative filepath (which is wrong) to use the full path as expected.
- In monorepos, if there are multiple configs, and one fails to load, it won't load _any_ configs.
	- Added warning for failed config including path to broken config.

<img width="1082" alt="screen shot 2019-02-26 at 3 09 20 pm" src="https://user-images.githubusercontent.com/9259509/53444289-be030200-39db-11e9-81df-90edb32fa1f5.png">

TODO:

- [x] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [ ] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass

\*Make sure changelog entries note which project(s) has been affected. See older entries for examples on what this looks like.

