### PR TITLE
Add tests for config file loader util

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Upcoming
 
+- apollo-language-server
+  - Stop loadConfig from looking up the tree when a --config location is defined [#1059](https://github.com/apollographql/apollo-tooling/pull/1059)
+  - Refactored/documented/tested loadConfig [#1059](https://github.com/apollographql/apollo-tooling/pull/1059)
+
 ## `apollo-codegen-flow@0.32.11`
 
 - `apollo-codegen-flow@0.32.11`

--- a/packages/apollo-language-server/src/config/__tests__/loadConfig.ts
+++ b/packages/apollo-language-server/src/config/__tests__/loadConfig.ts
@@ -1,4 +1,5 @@
 import { loadConfig } from "../";
+import * as path from "path";
 import * as fs from "fs";
 
 const makeNestedDir = dir => {
@@ -236,21 +237,62 @@ Object {
   });
 
   describe("env loading", () => {
-    it("finds .env in config path", () => {});
-    it("finds .env in cwd", () => {});
-    it("parses .env for api key and service name", () => {});
+    it("finds .env in config path & parses for key", async () => {
+      writeFilesToDir(dir, {
+        "my.config.js": `module.exports = { client: { name: 'hello' } }`,
+        ".env": `ENGINE_API_KEY=service:harambe:54378950jn`
+      });
+
+      const config = await loadConfig({
+        configPath: dirPath,
+        configFileName: "my.config.js"
+      });
+
+      expect(config.client.service).toEqual("harambe");
+    });
+
+    // this doesn't work right now :)
+    xit("finds .env in cwd & parses for key", async () => {
+      writeFilesToDir(dir, {
+        "dir/my.config.js": `module.exports = { client: { name: 'hello' } }`,
+        ".env": `ENGINE_API_KEY=service:harambe:54378950jn`
+      });
+      process.chdir(dir);
+      const config = await loadConfig({
+        configPath: "dir/",
+        configFileName: "my.config.js"
+      });
+
+      process.chdir("../");
+      expect(config.client.service).toEqual("harambe");
+    });
   });
+
   describe("project type", () => {
-    it("uses passed in type as override", () => {});
+    it("uses passed in type as override", async () => {
+      writeFilesToDir(dir, {
+        "my.config.js": `module.exports = { engine: { endpoint: 'http://a.a' } }`
+      });
+
+      const config = await loadConfig({
+        configPath: dirPath,
+        configFileName: "my.config.js",
+        type: "client"
+      });
+
+      expect(config.isClient).toEqual(true);
+    });
     it("infers client projects", () => {});
     it("infers service projects", () => {});
     it("throws if project type cant be inferred", () => {});
   });
+
   describe("service name", () => {
     it("lets config service name take precedence for client project", () => {});
     it("lets name passed in take precedence over env var", () => {});
     it("uses env var to determine service name when no other options", () => {});
   });
+
   describe("default merging", () => {
     it("merges service name and default config for client projects", () => {});
     it("merges service name and default config for service projects", () => {});

--- a/packages/apollo-language-server/src/config/__tests__/loadConfig.ts
+++ b/packages/apollo-language-server/src/config/__tests__/loadConfig.ts
@@ -1,0 +1,239 @@
+import { loadConfig } from "../";
+import * as fs from "fs";
+
+const makeNestedDir = dir => {
+  if (fs.existsSync(dir)) return;
+
+  try {
+    fs.mkdirSync(dir);
+  } catch (err) {
+    if (err.code == "ENOENT") {
+      makeNestedDir(path.dirname(dir)); //create parent dir
+      makeNestedDir(dir); //create dir
+    }
+  }
+};
+
+const deleteFolderRecursive = path => {
+  // don't delete files on azure CI
+  if (process.env.AZURE_HTTP_USER_AGENT) return;
+
+  if (fs.existsSync(path)) {
+    fs.readdirSync(path).forEach(function(file, index) {
+      var curPath = path + "/" + file;
+      if (fs.lstatSync(curPath).isDirectory()) {
+        // recurse
+        deleteFolderRecursive(curPath);
+      } else {
+        // delete file
+        fs.unlinkSync(curPath);
+      }
+    });
+    fs.rmdirSync(path);
+  }
+};
+
+const writeFilesToDir = (dir: string, files: Record<string, string>) => {
+  Object.keys(files).forEach(key => {
+    if (key.includes("/")) makeNestedDir(path.dirname(key));
+    fs.writeFileSync(`${dir}/${key}`, files[key]);
+  });
+};
+
+describe("loadConfig", () => {
+  let dir, dirPath;
+
+  // set up a temp dir
+  beforeEach(() => {
+    dir = fs.mkdtempSync("__tmp__");
+    dirPath = `${process.cwd()}/${dir}`;
+  });
+
+  // clean up our temp dir
+  afterEach(() => {
+    if (dir) deleteFolderRecursive(dir);
+    dir = dirPath = undefined;
+  });
+
+  it("loads with client defaults from different dir", async () => {
+    writeFilesToDir(dir, {
+      "my.config.js": `
+        module.exports = {
+          client: {
+            service: 'hello'
+          }
+        }
+      `
+    });
+
+    const config = await loadConfig({
+      configPath: dirPath,
+      configFileName: "my.config.js"
+    });
+    expect(config.rawConfig).toMatchInlineSnapshot(`
+Object {
+  "client": Object {
+    "addTypename": true,
+    "clientOnlyDirectives": Array [
+      "connection",
+      "type",
+    ],
+    "clientSchemaDirectives": Array [
+      "client",
+      "rest",
+    ],
+    "excludes": Array [
+      "**/node_modules",
+      "**/__tests__",
+    ],
+    "includes": Array [
+      "src/**/*.{ts,tsx,js,jsx,graphql}",
+    ],
+    "service": "hello",
+    "statsWindow": Object {
+      "from": -86400,
+      "to": -0,
+    },
+    "tagName": "gql",
+  },
+  "engine": Object {
+    "endpoint": "https://engine-graphql.apollographql.com/api/graphql",
+    "frontend": "https://engine.apollographql.com",
+  },
+}
+`);
+  });
+
+  it("loads with service defaults from different dir", async () => {
+    writeFilesToDir(dir, {
+      "my.config.js": `
+        module.exports = {
+          service: {
+            name: 'hello'
+          }
+        }
+      `
+    });
+
+    const config = await loadConfig({
+      configPath: dirPath,
+      configFileName: "my.config.js"
+    });
+    expect(config.rawConfig).toMatchInlineSnapshot(`
+Object {
+  "engine": Object {
+    "endpoint": "https://engine-graphql.apollographql.com/api/graphql",
+    "frontend": "https://engine.apollographql.com",
+  },
+  "service": Object {
+    "endpoint": Object {
+      "url": "http://localhost:4000/graphql",
+    },
+    "excludes": Array [
+      "**/node_modules",
+      "**/__tests__",
+    ],
+    "includes": Array [
+      "src/**/*.{ts,tsx,js,jsx,graphql}",
+    ],
+    "name": "hello",
+  },
+}
+`);
+  });
+
+  it("[deprecated] loads config from package.json", async () => {
+    writeFilesToDir(dir, {
+      "package.json": `{"apollo":{"client": {"service": "hello"}} }`
+    });
+    const config = await loadConfig({ configPath: dirPath });
+
+    expect(config.client.service).toEqual("hello");
+  });
+
+  it("loads config from a ts file", async () => {
+    writeFilesToDir(dir, {
+      "apollo.config.ts": `module.exports = {"client": {"service": "hello"}`
+    });
+    const config = await loadConfig({ configPath: dirPath });
+
+    expect(config.client.service).toEqual("hello");
+  });
+
+  describe("errors", () => {
+    it("throws when config file is empty", done => {
+      writeFilesToDir(dir, { "my.config.js": `` });
+
+      return loadConfig({
+        configPath: dirPath,
+        configFileName: "my.config.js",
+        loadExactOnly: true
+      }).catch(err => {
+        expect(err.message).toMatch(/.*A config file failed to load at.*/);
+        done();
+      });
+    });
+
+    it("throws when explorer.search fails", done => {
+      writeFilesToDir(dir, { "my.config.js": `* 98375^%*&^ its lit` });
+
+      return loadConfig({
+        configPath: dirPath,
+        configFileName: "my.config.js",
+        loadExactOnly: true
+      }).catch(err => {
+        expect(err.message).toMatch(
+          /.*A config file failed to load with options.*/
+        );
+        done();
+      });
+    });
+
+    it("issues a deprecation warning when loading config from package.json", async () => {
+      jest.spyOn(global.console, "warn");
+
+      writeFilesToDir(dir, {
+        "package.json": `{"apollo":{"client": {"service": "hello"}} }`
+      });
+
+      await loadConfig({
+        configPath: dirPath,
+        configFileName: "package.json",
+        loadExactOnly: true
+      });
+
+      expect(console.warn.mock.calls[0][0]).toMatchInlineSnapshot(
+        `"The \\"apollo\\" package.json configuration key will no longer be supported in Apollo v3. Please use the apollo.config.js file for Apollo project configuration. For more information, see: https://bit.ly/2ByILPj"`
+      );
+    });
+
+    it("throws if a config file was expected but not found", done => {
+      writeFilesToDir(dir, { "my.config.js": `module.exports = {}` });
+
+      return loadConfig({
+        configFileName: "my.TYPO.js",
+        loadExactOnly: true,
+        requireConfig: true // this is what we're testing
+      }).catch(err => {
+        expect(err.message).toMatch(/.*No Apollo config found for project*/);
+        done();
+      });
+    });
+
+    it("throws if project type cant be resolved", () => {
+      writeFilesToDir(dir, {
+        "my.config.js": `module.exports = {}`
+      });
+
+      const load = async () =>
+        await loadConfig({
+          configPath: dirPath,
+          configFileName: "my.config.js"
+        });
+
+      return expect(load()).rejects.toMatchInlineSnapshot(
+        `[Error: Unable to resolve project type. Please add either a client or service config. For more information, please refer to https://bit.ly/2ByILPj]`
+      );
+    });
+  });
+});

--- a/packages/apollo-language-server/src/config/__tests__/loadConfig.ts
+++ b/packages/apollo-language-server/src/config/__tests__/loadConfig.ts
@@ -55,22 +55,23 @@ describe("loadConfig", () => {
     dir = dirPath = undefined;
   });
 
-  it("loads with client defaults from different dir", async () => {
-    writeFilesToDir(dir, {
-      "my.config.js": `
-        module.exports = {
-          client: {
-            service: 'hello'
+  describe("finding files", () => {
+    it("loads with client defaults from different dir", async () => {
+      writeFilesToDir(dir, {
+        "my.config.js": `
+          module.exports = {
+            client: {
+              service: 'hello'
+            }
           }
-        }
-      `
-    });
+        `
+      });
 
-    const config = await loadConfig({
-      configPath: dirPath,
-      configFileName: "my.config.js"
-    });
-    expect(config.rawConfig).toMatchInlineSnapshot(`
+      const config = await loadConfig({
+        configPath: dirPath,
+        configFileName: "my.config.js"
+      });
+      expect(config.rawConfig).toMatchInlineSnapshot(`
 Object {
   "client": Object {
     "addTypename": true,
@@ -102,24 +103,24 @@ Object {
   },
 }
 `);
-  });
+    });
 
-  it("loads with service defaults from different dir", async () => {
-    writeFilesToDir(dir, {
-      "my.config.js": `
-        module.exports = {
-          service: {
-            name: 'hello'
+    it("loads with service defaults from different dir", async () => {
+      writeFilesToDir(dir, {
+        "my.config.js": `
+          module.exports = {
+            service: {
+              name: 'hello'
+            }
           }
-        }
-      `
-    });
+        `
+      });
 
-    const config = await loadConfig({
-      configPath: dirPath,
-      configFileName: "my.config.js"
-    });
-    expect(config.rawConfig).toMatchInlineSnapshot(`
+      const config = await loadConfig({
+        configPath: dirPath,
+        configFileName: "my.config.js"
+      });
+      expect(config.rawConfig).toMatchInlineSnapshot(`
 Object {
   "engine": Object {
     "endpoint": "https://engine-graphql.apollographql.com/api/graphql",
@@ -140,24 +141,25 @@ Object {
   },
 }
 `);
-  });
-
-  it("[deprecated] loads config from package.json", async () => {
-    writeFilesToDir(dir, {
-      "package.json": `{"apollo":{"client": {"service": "hello"}} }`
     });
-    const config = await loadConfig({ configPath: dirPath });
 
-    expect(config.client.service).toEqual("hello");
-  });
+    it("[deprecated] loads config from package.json", async () => {
+      writeFilesToDir(dir, {
+        "package.json": `{"apollo":{"client": {"service": "hello"}} }`
+      });
+      const config = await loadConfig({ configPath: dirPath });
 
-  it("loads config from a ts file", async () => {
-    writeFilesToDir(dir, {
-      "apollo.config.ts": `module.exports = {"client": {"service": "hello"}`
+      expect(config.client.service).toEqual("hello");
     });
-    const config = await loadConfig({ configPath: dirPath });
 
-    expect(config.client.service).toEqual("hello");
+    it("loads config from a ts file", async () => {
+      writeFilesToDir(dir, {
+        "apollo.config.ts": `module.exports = {"client": {"service": "hello"}`
+      });
+      const config = await loadConfig({ configPath: dirPath });
+
+      expect(config.client.service).toEqual("hello");
+    });
   });
 
   describe("errors", () => {
@@ -166,8 +168,7 @@ Object {
 
       return loadConfig({
         configPath: dirPath,
-        configFileName: "my.config.js",
-        loadExactOnly: true
+        configFileName: "my.config.js"
       }).catch(err => {
         expect(err.message).toMatch(/.*A config file failed to load at.*/);
         done();
@@ -179,8 +180,7 @@ Object {
 
       return loadConfig({
         configPath: dirPath,
-        configFileName: "my.config.js",
-        loadExactOnly: true
+        configFileName: "my.config.js"
       }).catch(err => {
         expect(err.message).toMatch(
           /.*A config file failed to load with options.*/
@@ -198,8 +198,7 @@ Object {
 
       await loadConfig({
         configPath: dirPath,
-        configFileName: "package.json",
-        loadExactOnly: true
+        configFileName: "package.json"
       });
 
       expect(console.warn.mock.calls[0][0]).toMatchInlineSnapshot(
@@ -212,7 +211,6 @@ Object {
 
       return loadConfig({
         configFileName: "my.TYPO.js",
-        loadExactOnly: true,
         requireConfig: true // this is what we're testing
       }).catch(err => {
         expect(err.message).toMatch(/.*No Apollo config found for project*/);
@@ -235,5 +233,28 @@ Object {
         `[Error: Unable to resolve project type. Please add either a client or service config. For more information, please refer to https://bit.ly/2ByILPj]`
       );
     });
+  });
+
+  describe("env loading", () => {
+    it("finds .env in config path", () => {});
+    it("finds .env in cwd", () => {});
+    it("parses .env for api key and service name", () => {});
+  });
+  describe("project type", () => {
+    it("uses passed in type as override", () => {});
+    it("infers client projects", () => {});
+    it("infers service projects", () => {});
+    it("throws if project type cant be inferred", () => {});
+  });
+  describe("service name", () => {
+    it("lets config service name take precedence for client project", () => {});
+    it("lets name passed in take precedence over env var", () => {});
+    it("uses env var to determine service name when no other options", () => {});
+  });
+  describe("default merging", () => {
+    it("merges service name and default config for client projects", () => {});
+    it("merges service name and default config for service projects", () => {});
+    it("merges engine config with projects", () => {});
+    it("merges defaults in at the end", () => {});
   });
 });


### PR DESCRIPTION
## Goals

- Test the loadConfig functionality
- Document/reorganize the logic
- Bugfixes where discovered by tests

## What I did

- Fixed bug where a user specifies loading of a config with a flag, but if that file isn't found, it loads an `apollo.config.js`. 
	- Ex: `apollo client:check --config=config/apollo.js` would also load `./apollo.config.js` if it couldn't find the specified config. I think if a user is _manually specifying_ a config, it should _only_ load what they specified and throw an error if not found. 
	- This was preventing testing errors, since leaving off a config would just load this repo's config (which wouldn't work)
- Removed the `getSearchPlaces` function. It was extraneous, and misleading. While `search places` is the term that dotenv uses, it is less descriptive than `defaultFileNames`, since that what the search places are–filenames.
- Added `try/catch` around the cosmiconfig's loader, since it can throw on malformed files with an unhelpful error.
- Handled case where `.env` is not a `File`, but a folder or something else. Resolves #1132 
- Split up project type and service name setting, since those being intertwined added unnecessary complexity
- commented :allthethings:

<!--
  Thanks for filing a pull request on Apollo Tooling!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [x] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass

\*Make sure changelog entries note which project(s) has been affected. See older entries for examples on what this looks like.
