### PR TITLE
Remove the default --tag flag from client commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - `apollo`
   - Use generated Typescript types via client:codegen [#1016](https://github.com/apollographql/apollo-tooling/pull/1016)
+  - Remove default `--tag=current` for some client commands that used it [#1062](https://github.com/apollographql/apollo-tooling/pull/1062)
 
 # `apollo@2.5.3`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2225,8 +2225,7 @@
       "dependencies": {
         "@babel/types": {
           "version": "7.3.4",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.3.4.tgz",
-          "integrity": "sha512-WEkp8MsLftM7O/ty580wAmZzN1nDmCACc5+jFzUt+GUFNNIi3LdRlueYz0YIlmJhlZx1QYDMZL5vdWCL0fNjFQ==",
+          "bundled": true,
           "requires": {
             "esutils": "^2.0.2",
             "lodash": "^4.17.11",
@@ -2247,8 +2246,7 @@
       "dependencies": {
         "@babel/types": {
           "version": "7.3.4",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.3.4.tgz",
-          "integrity": "sha512-WEkp8MsLftM7O/ty580wAmZzN1nDmCACc5+jFzUt+GUFNNIi3LdRlueYz0YIlmJhlZx1QYDMZL5vdWCL0fNjFQ==",
+          "bundled": true,
           "requires": {
             "esutils": "^2.0.2",
             "lodash": "^4.17.11",
@@ -2287,8 +2285,7 @@
       "dependencies": {
         "@babel/types": {
           "version": "7.3.4",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.3.4.tgz",
-          "integrity": "sha512-WEkp8MsLftM7O/ty580wAmZzN1nDmCACc5+jFzUt+GUFNNIi3LdRlueYz0YIlmJhlZx1QYDMZL5vdWCL0fNjFQ==",
+          "bundled": true,
           "requires": {
             "esutils": "^2.0.2",
             "lodash": "^4.17.11",

--- a/packages/apollo-language-server/src/graphqlTypes.ts
+++ b/packages/apollo-language-server/src/graphqlTypes.ts
@@ -9,7 +9,7 @@
 export interface CheckSchema_service_checkSchema_diffToPrevious_changes {
   __typename: "Change";
   /**
-   * Indication of the success of the change, either failure, warning, or notice.
+   * Indication of the success of the overall change, either failure, warning, or notice.
    */
   type: ChangeType;
   /**
@@ -39,10 +39,7 @@ export interface CheckSchema_service_checkSchema_diffToPrevious_validationConfig
 
 export interface CheckSchema_service_checkSchema_diffToPrevious {
   __typename: "SchemaDiff";
-  /**
-   * Indication of the most frequently occurring ChangeType in the list of changes from this diff.
-   */
-  type: ChangeType | null;
+  type: ChangeType;
   changes: CheckSchema_service_checkSchema_diffToPrevious_changes[];
   validationConfig: CheckSchema_service_checkSchema_diffToPrevious_validationConfig | null;
 }

--- a/packages/apollo/src/Command.ts
+++ b/packages/apollo/src/Command.ts
@@ -243,8 +243,7 @@ export abstract class ClientCommand extends ProjectCommand {
     }),
     tag: flags.string({
       char: "t",
-      description: "The published service tag for this client",
-      default: "current"
+      description: "The published service tag for this client"
     }),
     queries: flags.string({
       description: "Deprecated in favor of the includes flag"

--- a/packages/apollo/src/commands/client/check.ts
+++ b/packages/apollo/src/commands/client/check.ts
@@ -24,11 +24,7 @@ interface LocationOffset {
 export default class ClientCheck extends ClientCommand {
   static description = "Check a client project against a pushed service";
   static flags = {
-    ...ClientCommand.flags,
-    tag: flags.string({
-      char: "t",
-      description: "The published tag to check this client against"
-    })
+    ...ClientCommand.flags
   };
 
   async run() {

--- a/packages/apollo/src/commands/client/extract.ts
+++ b/packages/apollo/src/commands/client/extract.ts
@@ -27,8 +27,6 @@ export default class ClientExtract extends ClientCommand {
   static flags = {
     ...ClientCommand.flags
   };
-  // not a public feature for now
-  // static hidden = true;
 
   static args = [
     {


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Tooling!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

`client:codegen` was defaulting to `--tag=current` when not specifying a flag. That's because there was a default set. It didn't matter if you set another tag in your config, because the CLI flags took precedence over any other configs.

This PR just removes the default _flag_, not the default _tag_. Hopefully this should be non-breaking in any way since the `current` tag fallback is already set other places as a last-resort item.

fallbacks: 
- https://github.com/apollographql/apollo-tooling/blob/master/packages/apollo-language-server/src/config/config.ts#L147
- https://github.com/apollographql/apollo-tooling/blob/master/packages/apollo-language-server/src/engine/operations/schemaTagInfo.ts#L4
- https://github.com/apollographql/apollo-tooling/blob/master/packages/apollo-language-server/src/schema/providers/engine.ts#L54

TODO:

- [x] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass

\*Make sure changelog entries note which project(s) has been affected. See older entries for examples on what this looks like.
