### PR TITLE
Introduced `type` keyword among the ones that need to be escaped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   - Use generated Typescript types via client:codegen [#1016](https://github.com/apollographql/apollo-tooling/pull/1016)
   - Remove default `--tag=current` for some client commands that used it [#1062](https://github.com/apollographql/apollo-tooling/pull/1062)
   - Add missing dependency `@oclif/errors` [#1068](https://github.com/apollographql/apollo-tooling/pull/1068)
+  - The keyword "type" is escaped when generating scala.js via client:codegen [#1066](https://github.com/apollographql/apollo-tooling/pull/1066)
 
 # `apollo@2.5.3`
 

--- a/packages/apollo-codegen-scala/src/language.ts
+++ b/packages/apollo-codegen-scala/src/language.ts
@@ -189,6 +189,7 @@ const reservedKeywords = new Set([
   "trait",
   "true",
   "try",
+  "type",
   "until",
   "val",
   "var",


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Tooling!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [X] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [X] Make sure all of the significant new logic is covered by tests
Tests are only there for the general case and not for each single keyword
- [X] Rebase your changes on master so that they can be merged easily
- [X] Make sure all tests and linter rules pass

\*Make sure changelog entries note which project(s) has been affected. See older entries for examples on what this looks like.
