### PR TITLE
Import apollo-env utility types directly instead of treating them as globals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   - Add missing dependency `@oclif/errors` [#1068](https://github.com/apollographql/apollo-tooling/pull/1068)
   - The keyword "type" is escaped when generating scala.js via client:codegen [#1066](https://github.com/apollographql/apollo-tooling/pull/1066)
   - Include targetUrl in the output of the `service:check` command [#1072](https://github.com/apollographql/apollo-tooling/pull/1072)
+  - Import apollo-env utility types directly instead of treating them as globals [#1074](https://github.com/apollographql/apollo-tooling/pull/1074)
 
 # `apollo@2.5.3`
 

--- a/packages/apollo-env/src/index.ts
+++ b/packages/apollo-env/src/index.ts
@@ -1,4 +1,4 @@
 import "./polyfills";
-import "./typescript-utility-types";
 
+export * from "./typescript-utility-types";
 export * from "../lib/fetch";

--- a/packages/apollo-env/src/typescript-utility-types.ts
+++ b/packages/apollo-env/src/typescript-utility-types.ts
@@ -1,2 +1,2 @@
-type WithRequired<T, K extends keyof T> = T & Required<Pick<T, K>>;
-type DeepPartial<T> = { [P in keyof T]?: DeepPartial<T[P]> };
+export type WithRequired<T, K extends keyof T> = T & Required<Pick<T, K>>;
+export type DeepPartial<T> = { [P in keyof T]?: DeepPartial<T[P]> };

--- a/packages/apollo-language-server/src/config/config.ts
+++ b/packages/apollo-language-server/src/config/config.ts
@@ -7,6 +7,7 @@ import {
   StatsWindowSize
 } from "../engine";
 import URI from "vscode-uri";
+import { WithRequired } from "apollo-env";
 import { getServiceName, parseServiceSpecifier } from "./utils";
 
 export interface EngineStatsWindow {

--- a/packages/apollo/src/Command.ts
+++ b/packages/apollo/src/Command.ts
@@ -13,6 +13,7 @@ import {
   ApolloConfig,
   getServiceFromKey
 } from "apollo-language-server";
+import { WithRequired, DeepPartial } from "apollo-env";
 import { OclifLoadingHandler } from "./OclifLoadingHandler";
 import URI from "vscode-uri";
 


### PR DESCRIPTION
Instead of treating these types as globals, import them directly.

This makes it more straightforward for other projects outside this repo to depend on packages inside this repo (aka if you want to write custom tooling around `apollo-language-server`).

----

TODO:

- [x] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass

\*Make sure changelog entries note which project(s) has been affected. See older entries for examples on what this looks like.