### PR TITLE
Document engine requirements in client:check and client:push

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@
 
 ## `apollo@2.11.1`, `apollo-language-server@1.8.1`, `vscode-apollo@1.6.9`
 
+- `apollo@2.11.1`
+  - Document engine requirements in client:check and client:push [#1077](https://github.com/apollographql/apollo-tooling/pull/1077)
 - `apollo-language-server@1.8.1`
   - Fix windows file paths by normalizing all URIs to a consistent format [#1213](https://github.com/apollographql/apollo-tooling/pull/1213).
   - Fix positionToOffset to consider windows line endings [#1213](https://github.com/apollographql/apollo-tooling/pull/1213).

--- a/packages/apollo/src/commands/client/check.ts
+++ b/packages/apollo/src/commands/client/check.ts
@@ -36,7 +36,9 @@ export default class ClientCheck extends ClientCommand {
         title: "Checking client compatibility with service",
         task: async ctx => {
           if (!config.name) {
-            throw new Error("No service found to link to Engine");
+            throw new Error(
+              "No service found to link to Engine. Engine is required for this command."
+            );
           }
           ctx.gitContext = await gitInfo(this.log);
 

--- a/packages/apollo/src/commands/client/push.ts
+++ b/packages/apollo/src/commands/client/push.ts
@@ -21,7 +21,9 @@ export default class ServicePush extends ClientCommand {
         title: "Pushing client information to Engine",
         task: async ctx => {
           if (!config.name) {
-            throw new Error("No service found to link to Engine");
+            throw new Error(
+              "No service found to link to Engine. Engine is required for this command."
+            );
           }
 
           const operationManifest = getOperationManifestFromProject(


### PR DESCRIPTION
from #1075

<!--
  Thanks for filing a pull request on Apollo Tooling!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

Previously, there was no explicit message stating that engine is a requirement for `client:check` and `client:push` commands.

It'd be easy to mistake these commands as ones that could be run with a `client.service.url` or `localSchemaFile`.

TODO:

- [x] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass

\*Make sure changelog entries note which project(s) has been affected. See older entries for examples on what this looks like.
