### PR TITLE
apollo: ensure targetUrl is defined when printing

### DIFF
--- a/packages/apollo/src/commands/service/check.ts
+++ b/packages/apollo/src/commands/service/check.ts
@@ -122,7 +122,9 @@ export default class ServiceCheck extends ProjectCommand {
       ]
     });
     this.log("\n");
-    this.log(`View full details at: ${targetUrl}`);
+    if (targetUrl) {
+      this.log(`View full details at: ${targetUrl}`);
+    }
     // exit with failing status if we have failures
     if (failures.length > 0) {
       this.exit();


### PR DESCRIPTION
The `targetUrl` can be undefined, so we need to ensure it's defined, otherwise we'll print the line without anything actionable 😰 

- [x] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
