### PR TITLE
Adjust pinning for `apollo` to not explicitly pin `engines`.

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,12 +1,9 @@
 {
   "extends": ["apollo-open-source"],
-  "engines": {
-    "node": { "supportPolicy": ["lts_active"] }
-  },
   "packageRules": [
     {
       "paths": ["packages/apollo/package.json"],
-      "rangeStrategy": "pin"
+      "extends": [":pinAllExceptPeerDependencies"]
     },
     {
       "packageNames": ["@oclif/config"],


### PR DESCRIPTION
This follows up on @trevor-scheer's #951, which switched to exact pinning for all deps in the `apollo` CLI.

As the #951 PR body notes, we want exactly that for `apollo`, however using the `rangeStrategy` of `pin` also includes renovation of the `engines` setting in `package.json`, which we don't want and resulted in https://github.com/apollographql/apollo-tooling/pull/1078 which also exact-pinned `engines` for `node` and `npm`.  (screenshot as it will change after this PR: https://c.jro.cc/ac9256ebf6ae).

I think @trevor-scheer tried to fix this with #889 and #1069, but I believe this would be the more complete solution to that configuration.  It's also worth noting that `lts_active` isn't the version range we wanted to limit to as Node.js 8 is not LTS active, but rather LTS maintenance.  The only LTS active version is Node.js 10.

The #951 which prompted this commit message didn't and won't land, but it's currently immortal and we want it to go away.  It's existence, as it makes clear in the PR body, is defined by configuration though.

Specifically, the default Renovate configuration on this repository uses [the `renovate-config-apollo-open-source` defaults](https://github.com/apollographql/renovate-config-apollo-open-source/blob/master/package.json) and that default [specifies we extend `:pinOnlyDevDependencies`](https://github.com/apollographql/renovate-config-apollo-open-source/blob/master/package.json#L14).  That `:pinOnlyDevDependencies` is [defined here](https://renovatebot.com/docs/presets-default/#pinonlydevdependencies).  What we really wanted is [`:pinAllExceptPeerDependencies`](https://renovatebot.com/docs/presets-default/#pinallexceptpeerdependencies) which excludes `engines`.