### PR TITLE
Bump CircleCI cache salt to hopefully solve peculiar failures.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,13 +22,13 @@ common_test_steps: &common_test_steps
     - restore_cache:
         keys:
           # When lock file changes, use increasingly general patterns to restore cache
-          - npm-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-{{ checksum "package-lock.json" }}
-          - npm-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-
-          - npm-{{ .Environment.CACHE_VERSION }}-
+          - npm-v2-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-{{ checksum "package-lock.json" }}
+          - npm-v2-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-
+          - npm-v2-{{ .Environment.CACHE_VERSION }}-
     - run: npm --version
     - run: npm ci
     - save_cache:
-        key: npm-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-{{ checksum "package-lock.json" }}
+        key: npm-v2-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-{{ checksum "package-lock.json" }}
         paths:
           # This should cache the npm cache instead of node_modules, which is needed because
           # npm ci actually removes node_modules before installing to guarantee a clean slate.
@@ -60,13 +60,13 @@ jobs:
       - restore_cache:
           keys:
             # When lock file changes, use increasingly general patterns to restore cache
-            - npm-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-{{ checksum "package-lock.json" }}
-            - npm-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-
-            - npm-{{ .Environment.CACHE_VERSION }}-
+            - npm-v2-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-{{ checksum "package-lock.json" }}
+            - npm-v2-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-
+            - npm-v2-{{ .Environment.CACHE_VERSION }}-
       - run: npm --version
       - run: npm ci
       - save_cache:
-          key: npm-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-{{ checksum "package-lock.json" }}
+          key: npm-v2-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-{{ checksum "package-lock.json" }}
           paths:
             # This should cache the npm cache instead of node_modules, which is needed because
             # npm ci actually removes node_modules before installing to guarantee a clean slate.
@@ -98,13 +98,13 @@ jobs:
       - restore_cache:
           keys:
             # When lock file changes, use increasingly general patterns to restore cache
-            - npm-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-{{ checksum "package-lock.json" }}
-            - npm-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-
-            - npm-{{ .Environment.CACHE_VERSION }}-
+            - npm-v2-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-{{ checksum "package-lock.json" }}
+            - npm-v2-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-
+            - npm-v2-{{ .Environment.CACHE_VERSION }}-
       - run: npm --version
       - run: npm ci
       - save_cache:
-          key: npm-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-{{ checksum "package-lock.json" }}
+          key: npm-v2-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-{{ checksum "package-lock.json" }}
           paths:
             # This should cache the npm cache instead of node_modules, which is needed because
             # npm ci actually removes node_modules before installing to guarantee a clean slate.
@@ -119,13 +119,13 @@ jobs:
       - restore_cache:
           keys:
             # When lock file changes, use increasingly general patterns to restore cache
-            - npm-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-{{ checksum "package-lock.json" }}
-            - npm-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-
-            - npm-{{ .Environment.CACHE_VERSION }}-
+            - npm-v2-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-{{ checksum "package-lock.json" }}
+            - npm-v2-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-
+            - npm-v2-{{ .Environment.CACHE_VERSION }}-
       - run: npm --version
       - run: npm ci
       - save_cache:
-          key: npm-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-{{ checksum "package-lock.json" }}
+          key: npm-v2-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-{{ checksum "package-lock.json" }}
           paths:
             # This should cache the npm cache instead of node_modules, which is needed because
             # npm ci actually removes node_modules before installing to guarantee a clean slate.


### PR DESCRIPTION
Right now each CircleCI test run is resulting in different failures.  For
example, each of these were run on the same branch one after each other with
no changes:

* https://circleci.com/workflow-run/60706f8f-1059-496b-a7af-2d24a20d546e
* https://circleci.com/workflow-run/358e33c1-a84a-41ab-9ebd-013507f088f6
* https://circleci.com/workflow-run/89788740-a884-4813-87b3-e4f997362ca9

This is a first step in debugging, and matches the seed pattern used in
other repositories in our organization.