### PR TITLE
Also install the latest `npm` version in CircleCI when running Linting.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,7 +84,7 @@ jobs:
   Linting:
     docker: [{ image: "circleci/node:8" }]
     steps:
-      # (speed) Intentionally omitted, unnecessary, run_install_desired_npm.
+      - *run_install_desired_npm
       - checkout
       # (speed) --ignore-scripts to skip unnecessary Lerna build during linting.
       - run: npm install --ignore-scripts


### PR DESCRIPTION
This was previously disabled (as it is on other repositories), since it
offered some speed benefits.

However, unlikely other repositories, this repo is suffering from a bug with
npm with regard to `.staging` directories and the _Linting_ test seems to be
the one that is failing most often because of `.staging` errors occurring
during the `npm install` step of the _Linting_ job in CircleCI.

This type of failure seems to be fixed in npm@6.9.0, and a local test which
I ran seems to prove that the version of npm that ships with Node.js (which
is what is used by default if we don't run this `run_install_desired_npm`
snippet) exhibits this problem while the latest npm@6.9.0 does not.