### PR TITLE
Only `widen` the semver range for the `graphql` dependency of `apollo`.

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,14 @@
   "packageRules": [
     {
       "paths": ["packages/apollo/package.json"],
-      "extends": [":pinAllExceptPeerDependencies"]
+      "extends": [":pinAllExceptPeerDependencies"],
+      "packageRules": [
+        {
+          "packageNames": ["graphql"],
+          "rangeStrategy": "widen",
+          "allowedVersions": "^14.0.0"
+        }
+      ]
     },
     {
       "packageNames": ["@oclif/config"],


### PR DESCRIPTION
Per the correct assessment of what we want from the `graphql` package within
the `apollo` package, in the following conversation:

https://github.com/apollographql/apollo-tooling/pull/1078#issuecomment-471099746

Specifically, we're okay using whatever 14.x version of `graphql` is
potentially already available to us when someone installs `apollo` into
their application's `devDependencies` in an existing application.

If the existing application doesn't already have a 14.x version of `graphql`
we will use the latest `14.x` version.

With any success, this will cl_ose #1078 automatically (and not just because
I said "close PR number" in this commit message!).