### PR TITLE
Add graphqls as a supported file extension for VS Code

### DIFF
--- a/packages/vscode-apollo/package.json
+++ b/packages/vscode-apollo/package.json
@@ -63,8 +63,9 @@
       {
         "id": "graphql",
         "extensions": [
+          ".gql",
           ".graphql",
-          ".gql"
+          ".graphqls"
         ],
         "aliases": [
           "GraphQL"


### PR DESCRIPTION
The VS Code extension supports graphqls, but we don't list it as such.
