### PR TITLE
Keep `@types/node` types at v8.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1793,9 +1793,9 @@
       }
     },
     "@types/node": {
-      "version": "11.9.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-11.9.5.tgz",
-      "integrity": "sha512-vVjM0SVzgaOUpflq4GYBvCpozes8OgIIS5gVXVka+OfK3hvnkC1i93U8WiY2OtNE4XUWyyy/86Kf6e0IHTQw1Q==",
+      "version": "8.10.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.43.tgz",
+      "integrity": "sha512-5m5W13HR2k3cu88mpzlnPBBv5+GyMHtj4F0P83RG4mqoC0AYVYHVMHfF3SgwKNtqEZiZQASMxU92QsLEekKcnw==",
       "dev": true
     },
     "@types/node-fetch": {

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "@types/lodash.sortby": "4.7.6",
     "@types/minimatch": "3.0.3",
     "@types/nock": "9.3.1",
-    "@types/node": "11.9.5",
+    "@types/node": "8.10.43",
     "@types/node-fetch": "2.1.6",
     "@types/react": "16.8.7",
     "@types/react-dom": "16.8.2",

--- a/packages/vscode-apollo/src/testRunner/vscode-test-script.ts
+++ b/packages/vscode-apollo/src/testRunner/vscode-test-script.ts
@@ -11,6 +11,7 @@ const cp = spawn(
     "bin",
     "test"
   )}`,
+  [],
   {
     shell: true,
     env: {

--- a/renovate.json
+++ b/renovate.json
@@ -13,6 +13,10 @@
       ]
     },
     {
+      "packageNames": ["@types/node"],
+      "allowedVersions": "8.x"
+    },
+    {
       "packageNames": ["@oclif/config"],
       "rangeStrategy": "pin",
       "allowedVersions": ["=1.12.0"]


### PR DESCRIPTION
In the same spirit as https://github.com/apollographql/apollo-server/pull/2344,
this should hopefully _gently_ help us not use types which aren't available
in all of the versions of Node.js which we currently target.

This also required a change to the way we invoke [`child_process.spawn`](https://nodejs.org/docs/latest-v10.x/api/child_process.html#child_process_child_process_spawn_command_args_options) since the older types aren't as accommodating to the optional presence of the `args` positional parameter, but since we're actually using using arguments, it seems to make sense to put them in that position anyhow, rather than string-concatenating them to the `node` command itself.

Input appreciated on the former bit of this.  Certainly curious if we should model that more after https://github.com/Unibeautify/vscode/blob/9908eadd0dcc42ee123b66f8798c6e3956b0df53/package.json#L18, but it doesn't matter for this PR.

I expect this to close #1100, whose title (`@types/node to v11.11.0`) is strangely correlated with its PR number.