### PR TITLE
Add ability to download schema to file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Upcoming
 
 - `apollo`
-  - <First `apollo` related entry goes here>
+  - Add `client:download-schema` command to download schemas from engine to an output file [#1108](https://github.com/apollographql/apol    lo-tooling/pull/1108)
 - `apollo-codegen-core`
   - <First `apollo-codegen-core` related entry goes here>
 - `apollo-codegen-flow`

--- a/packages/apollo/src/commands/client/download-schema.ts
+++ b/packages/apollo/src/commands/client/download-schema.ts
@@ -1,0 +1,39 @@
+import { flags } from "@oclif/command";
+import { introspectionFromSchema } from "graphql";
+import { writeFileSync } from "fs";
+
+import { ClientCommand } from "../../Command";
+
+export default class SchemaDownload extends ClientCommand {
+  static description = "Download a schema from engine or a GraphQL endpoint.";
+
+  static flags = {
+    ...ClientCommand.flags
+  };
+
+  static args = [
+    {
+      name: "output",
+      description: "Path to write the introspection result to",
+      required: true,
+      default: "schema.json"
+    }
+  ];
+
+  async run() {
+    let result;
+    let gitContext;
+    await this.runTasks(({ args, project, flags }) => [
+      {
+        title: `Saving schema to ${args.output}`,
+        task: async () => {
+          const schema = await project.resolveSchema({ tag: flags.tag });
+          writeFileSync(
+            args.output,
+            JSON.stringify(introspectionFromSchema(schema), null, 2)
+          );
+        }
+      }
+    ]);
+  }
+}

--- a/packages/apollo/src/commands/service/download.ts
+++ b/packages/apollo/src/commands/service/download.ts
@@ -1,6 +1,7 @@
 import { flags } from "@oclif/command";
 import { introspectionFromSchema } from "graphql";
 import { writeFileSync } from "fs";
+import chalk from "chalk";
 import { ProjectCommand } from "../../Command";
 
 export default class ServiceDownload extends ProjectCommand {
@@ -45,9 +46,16 @@ export default class ServiceDownload extends ProjectCommand {
             );
           } catch (e) {
             if (e.code == "ECONNREFUSED") {
-              console.error(
-                `❌ ERROR: Connection refused. You may not be running a service locally, or your endpoint url is incorrect.\n` +
+              this.log(chalk.red("ERROR: Connection refused."));
+              this.log(
+                chalk.red(
+                  "You may not be running a service locally, or your endpoint url is incorrect."
+                )
+              );
+              this.log(
+                chalk.red(
                   "If you're trying to download a schema from Apollo Engine, use the `client:download-schema` command instead."
+                )
               );
             }
             throw e;

--- a/packages/apollo/src/commands/service/download.ts
+++ b/packages/apollo/src/commands/service/download.ts
@@ -1,12 +1,12 @@
 import { flags } from "@oclif/command";
 import { introspectionFromSchema } from "graphql";
 import { writeFileSync } from "fs";
-
 import { ProjectCommand } from "../../Command";
 
 export default class ServiceDownload extends ProjectCommand {
   static aliases = ["schema:download"];
-  static description = "Download the schema from your GraphQL endpoint.";
+  static description =
+    "Download a schema from a locally running GraphQL endpoint.";
 
   static flags = {
     ...ProjectCommand.flags,
@@ -37,11 +37,21 @@ export default class ServiceDownload extends ProjectCommand {
       {
         title: `Saving schema to ${args.output}`,
         task: async () => {
-          const schema = await project.resolveSchema({ tag: flags.tag });
-          writeFileSync(
-            args.output,
-            JSON.stringify(introspectionFromSchema(schema), null, 2)
-          );
+          try {
+            const schema = await project.resolveSchema({ tag: flags.tag });
+            writeFileSync(
+              args.output,
+              JSON.stringify(introspectionFromSchema(schema), null, 2)
+            );
+          } catch (e) {
+            if (e.code == "ECONNREFUSED") {
+              console.error(
+                `❌ ERROR: Connection refused. You may not be running a service locally, or your endpoint url is incorrect.\n` +
+                  "If you're trying to download a schema from Apollo Engine, use the `client:download schema` command instead."
+              );
+            }
+            throw e;
+          }
         }
       }
     ]);

--- a/packages/apollo/src/commands/service/download.ts
+++ b/packages/apollo/src/commands/service/download.ts
@@ -47,7 +47,7 @@ export default class ServiceDownload extends ProjectCommand {
             if (e.code == "ECONNREFUSED") {
               console.error(
                 `❌ ERROR: Connection refused. You may not be running a service locally, or your endpoint url is incorrect.\n` +
-                  "If you're trying to download a schema from Apollo Engine, use the `client:download schema` command instead."
+                  "If you're trying to download a schema from Apollo Engine, use the `client:download-schema` command instead."
               );
             }
             throw e;

--- a/packages/apollo/src/commands/service/download.ts
+++ b/packages/apollo/src/commands/service/download.ts
@@ -6,8 +6,7 @@ import { ProjectCommand } from "../../Command";
 
 export default class ServiceDownload extends ProjectCommand {
   static aliases = ["schema:download"];
-  static description =
-    "Download a schema from a locally running GraphQL endpoint.";
+  static description = "Download the schema from your GraphQL endpoint.";
 
   static flags = {
     ...ProjectCommand.flags,


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Tooling!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

Client projects could already download a schema from engine or an endpoint for codegen. This just exposes a command to download a schema to an output file, rather than just keeping it in memory.

I also updated the description for the service:download command and added an error to be more explicit that service:download is supposed to be used for `local` endpoints. Not registry downloads.

TODO:

- [x] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass

\*Make sure changelog entries note which project(s) has been affected. See older entries for examples on what this looks like.

<img width="759" alt="Screen Shot 2019-03-12 at 3 38 21 PM" src="https://user-images.githubusercontent.com/9259509/54230536-fb3bb980-44dc-11e9-8e25-ee71cb346d4a.png">
