### PR TITLE
Add environment-aware createHash function to apollo-env

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2176,12 +2176,14 @@
       "version": "file:packages/apollo-env",
       "requires": {
         "core-js": "3.0.0-beta.13",
-        "node-fetch": "^2.2.0"
+        "node-fetch": "^2.2.0",
+        "sha.js": "^2.4.11"
       }
     },
     "apollo-graphql": {
       "version": "file:packages/apollo-graphql",
       "requires": {
+        "apollo-env": "file:packages/apollo-env",
         "lodash.sortby": "^4.7.0"
       }
     },
@@ -12560,6 +12562,15 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
       "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
+    },
+    "sha.js": {
+      "version": "2.4.11",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+      "requires": {
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
     },
     "shebang-command": {
       "version": "1.2.0",

--- a/packages/apollo-env/package.json
+++ b/packages/apollo-env/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "core-js": "3.0.0-beta.13",
-    "node-fetch": "^2.2.0"
+    "node-fetch": "^2.2.0",
+    "sha.js": "^2.4.11"
   }
 }

--- a/packages/apollo-env/src/index.ts
+++ b/packages/apollo-env/src/index.ts
@@ -2,3 +2,4 @@ import "./polyfills";
 
 export * from "./typescript-utility-types";
 export * from "../lib/fetch";
+export * from "./utils";

--- a/packages/apollo-env/src/utils/createHash.ts
+++ b/packages/apollo-env/src/utils/createHash.ts
@@ -1,0 +1,10 @@
+import { isNode } from "./isNode";
+
+export function createHash(kind: string): import("crypto").Hash {
+  if (isNode) {
+    // Use module.require instead of just require to avoid bundling whatever
+    // crypto polyfills a non-Node bundler might fall back to.
+    return module.require("crypto").createHash(kind);
+  }
+  return require("sha.js")(kind);
+}

--- a/packages/apollo-env/src/utils/index.ts
+++ b/packages/apollo-env/src/utils/index.ts
@@ -1,0 +1,2 @@
+export * from "./createHash";
+export * from "./isNode";

--- a/packages/apollo-env/src/utils/isNode.ts
+++ b/packages/apollo-env/src/utils/isNode.ts
@@ -1,0 +1,7 @@
+export const isNode =
+  typeof process === "object" &&
+  process &&
+  process.release &&
+  process.release.name === "node" &&
+  process.versions &&
+  typeof process.versions.node === "string";

--- a/packages/apollo-graphql/package.json
+++ b/packages/apollo-graphql/package.json
@@ -11,6 +11,7 @@
     "node": ">=6"
   },
   "dependencies": {
+    "apollo-env": "file:../apollo-env",
     "lodash.sortby": "^4.7.0"
   },
   "peerDependencies": {

--- a/packages/apollo-graphql/src/signature.ts
+++ b/packages/apollo-graphql/src/signature.ts
@@ -43,8 +43,8 @@
 // the server no longer needs to parse the signature or run its own signature
 // algorithm on it, and the details of the signature algorithm are now up to the
 // reporting agent.
-
 import { DocumentNode } from "graphql";
+import { createHash } from "apollo-env";
 import {
   printWithReducedWhitespace,
   dropUnusedDefinitions,


### PR DESCRIPTION
This is a subset of changes proposed by this PR:
https://github.com/apollographql/apollo-tooling/pull/1027

This PR adds a `createHash` function to `apollo-env` which is environment aware. That is to say, it will work in both node-like and non-node environments.

This PR also _uses_ this function from within the `apollo-graphql` package.

<!--
  Thanks for filing a pull request on Apollo Tooling!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [ ] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [ ] Make sure all of the significant new logic is covered by tests
- [ ] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests and linter rules pass

\*Make sure changelog entries note which project(s) has been affected. See older entries for examples on what this looks like.
