### PR TITLE
Remove second parameter to `getOperationManifestFromProject`, always empty.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ## Upcoming
 
-## `apollo-graphql@0.2.0`
+## `apollo-graphql@0.2.1`
 
-- `apollo-graphql@0.2.0`
+- `apollo-graphql@0.2.1`
   - Change the `sortAST` algorithm to sort fragments at the top-level of the `DocumentNode`, providing a more deterministic normalization of the operation for use by `apollo-engine-reporting` (which consumes this package's `defaultOperationRegistrySignature` function). This will more correctly combine operations for Engine reporting. This also adds a `defaultOperationRegistrySignature` function for use by the `apollo-server-plugin-operation-registry` plugin to eventually consume. [#1112](https://github.com/apollographql/apollo-tooling/pull/1112)
 
 ## `apollo@2.6.1`, `apollo-env@0.4.0`

--- a/packages/apollo-graphql/src/__tests__/operationId.test.ts
+++ b/packages/apollo-graphql/src/__tests__/operationId.test.ts
@@ -275,11 +275,9 @@ describe("defaultOperationRegistrySignature", () => {
       `
     }
   ];
-  cases.forEach(({ name, operationName, input }) => {
+  cases.forEach(({ name, input }) => {
     test(name, () => {
-      expect(
-        defaultOperationRegistrySignature(input, operationName)
-      ).toMatchSnapshot();
+      expect(defaultOperationRegistrySignature(input)).toMatchSnapshot();
     });
   });
 });

--- a/packages/apollo-graphql/src/operationId.ts
+++ b/packages/apollo-graphql/src/operationId.ts
@@ -79,14 +79,9 @@ export function defaultEngineReportingSignature(
 // to hide them at all. The rationale being, if queries are being shipped to
 // a client bundle, exposing PII via this signature is a very small concern,
 // relatively speaking.
-export function defaultOperationRegistrySignature(
-  ast: DocumentNode,
-  operationName: string
-): string {
+export function defaultOperationRegistrySignature(ast: DocumentNode): string {
   return printWithReducedWhitespace(
-    sortAST(
-      hideStringAndNumericLiterals(dropUnusedDefinitions(ast, operationName))
-    )
+    sortAST(hideStringAndNumericLiterals(dropUnusedDefinitions(ast, "")))
   );
 }
 


### PR DESCRIPTION
The `getOperationManifestFromProject` can never have anything passed to it
besides an empty string, so we'll just make that the default behavior.

This differs slightly from the similarly named
`defaultEngineReportingSignature`, which does accept the `operationName`.

cc @trevor-scheer