### PR TITLE
Pass operation name to the operation registry signature function

### DIFF
--- a/packages/apollo/src/utils/getOperationManifestFromProject.ts
+++ b/packages/apollo/src/utils/getOperationManifestFromProject.ts
@@ -15,10 +15,13 @@ export interface ManifestEntry {
 export function getOperationManifestFromProject(
   project: GraphQLClientProject
 ): ManifestEntry[] {
-  const manifest = Object.values(
+  const manifest = Object.entries(
     project.mergedOperationsAndFragmentsForService
-  ).map(operationAST => {
-    const printed = defaultOperationRegistrySignature(operationAST, "");
+  ).map(([operationName, operationAST]) => {
+    const printed = defaultOperationRegistrySignature(
+      operationAST,
+      operationName
+    );
 
     return {
       signature: operationHash(printed),


### PR DESCRIPTION
This PR corrects a previous oversight.

Operation names found during extraction by the language server should be passed along (by the CLI) to the signature function.

Failure to do so would result in publishing the full document, and we would fail to drop unused definitions in the process.

<!--
  Thanks for filing a pull request on Apollo Tooling!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [ ] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [ ] Make sure all of the significant new logic is covered by tests
- [ ] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests and linter rules pass

\*Make sure changelog entries note which project(s) has been affected. See older entries for examples on what this looks like.
