### PR TITLE
Update usage of registerOperations for v2 operations manifest

### DIFF
--- a/packages/apollo-language-server/src/engine/operations/registerOperations.ts
+++ b/packages/apollo-language-server/src/engine/operations/registerOperations.ts
@@ -5,11 +5,13 @@ export const REGISTER_OPERATIONS = gql`
     $id: ID!
     $clientIdentity: RegisteredClientIdentityInput!
     $operations: [RegisteredOperationInput!]!
+    $manifestVersion: Int!
   ) {
     service(id: $id) {
       registerOperations(
         clientIdentity: $clientIdentity
         operations: $operations
+        manifestVersion: $manifestVersion
       )
     }
   }

--- a/packages/apollo-language-server/src/graphqlTypes.ts
+++ b/packages/apollo-language-server/src/graphqlTypes.ts
@@ -97,6 +97,7 @@ export interface RegisterOperationsVariables {
   id: string;
   clientIdentity: RegisteredClientIdentityInput;
   operations: RegisteredOperationInput[];
+  manifestVersion: number;
 }
 
 /* tslint:disable */
@@ -136,9 +137,6 @@ export interface SchemaTagInfo_service {
 }
 
 export interface SchemaTagInfo {
-  /**
-   * Service by ID
-   */
   service: SchemaTagInfo_service | null;
 }
 
@@ -177,13 +175,7 @@ export interface SchemaTagsAndFieldStats_service_stats_fieldStats_metrics {
 
 export interface SchemaTagsAndFieldStats_service_stats_fieldStats {
   __typename: "ServiceFieldStatsRecord";
-  /**
-   * Dimensions of ServiceFieldStats that can be grouped by.
-   */
   groupBy: SchemaTagsAndFieldStats_service_stats_fieldStats_groupBy;
-  /**
-   * Metrics of ServiceFieldStats that can be aggregated over.
-   */
   metrics: SchemaTagsAndFieldStats_service_stats_fieldStats_metrics;
 }
 
@@ -202,9 +194,6 @@ export interface SchemaTagsAndFieldStats_service {
 }
 
 export interface SchemaTagsAndFieldStats {
-  /**
-   * Service by ID
-   */
   service: SchemaTagsAndFieldStats_service | null;
 }
 
@@ -763,9 +752,6 @@ export interface GetSchemaByTag_service_Service {
 export type GetSchemaByTag_service = GetSchemaByTag_service_User | GetSchemaByTag_service_Service;
 
 export interface GetSchemaByTag {
-  /**
-   * Current identity, null if not authenticated
-   */
   service: GetSchemaByTag_service | null;
 }
 

--- a/packages/apollo/src/commands/client/push.ts
+++ b/packages/apollo/src/commands/client/push.ts
@@ -40,7 +40,8 @@ export default class ServicePush extends ClientCommand {
               version
             },
             id: config.name,
-            operations: operationManifest
+            operations: operationManifest,
+            manifestVersion: 2
           };
 
           await project.engine.registerOperations(variables);


### PR DESCRIPTION
Now that registerOperations supports version # as an argument to the mutation, we can leverage this for v2 operations manifest work.

This PR finalizes the CLI work to wrap up the sorting fragments bug that lives in v1 of the manifest (currently, the current version of the manifest, but soon to be the previous version).

TODO:

- [ ] Verify both codegen type check and query check pass after ^
- [ ] Upon landing, publish updated alpha release
