### PR TITLE
apollo: fix remoteUrl in service:check [UI-258]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Upcoming
 
+- `apollo`
+  - fix remoteUrl(remove slug) for service:check [#1121](https://github.com/apollographql/apollo-tooling/pull/1121)
+
 ## `apollo-graphql@0.2.0`
 
 - `apollo-graphql@0.2.0`

--- a/packages/apollo/src/__tests__/git.test.ts
+++ b/packages/apollo/src/__tests__/git.test.ts
@@ -4,11 +4,15 @@ describe("Git integration", () => {
   it("Returns commit, branch, message, committer, and remoteUrl", async () => {
     // Currently these tests are too granular and would be better as
     // service:push tests when they are uncommented
-    const info = await gitInfo();
+    const info = await gitInfo(console.log);
 
     expect(info.commit).toBeDefined();
     expect(info.committer).toBeDefined();
     expect(info.remoteUrl).toBeDefined();
+    // Match both ssh and http/s remotes
+    expect(info.remoteUrl).toMatch(
+      /(https?:\/\/|git@)github.com(\/|:)apollographql\/apollo-tooling(.git)?/
+    );
     expect(info.message).toBeDefined();
     expect(info.branch).toBeDefined();
   });

--- a/packages/apollo/src/commands/client/check.ts
+++ b/packages/apollo/src/commands/client/check.ts
@@ -38,7 +38,7 @@ export default class ClientCheck extends ClientCommand {
           if (!config.name) {
             throw new Error("No service found to link to Engine");
           }
-          ctx.gitContext = await gitInfo();
+          ctx.gitContext = await gitInfo(this.log);
 
           ctx.operations = Object.entries(
             this.project.mergedOperationsAndFragmentsForService

--- a/packages/apollo/src/commands/service/check.ts
+++ b/packages/apollo/src/commands/service/check.ts
@@ -74,7 +74,7 @@ export default class ServiceCheck extends ProjectCommand {
 
           const tag = flags.tag || config.tag || "current";
           const schema = await project.resolveSchema({ tag });
-          ctx.gitContext = await gitInfo();
+          ctx.gitContext = await gitInfo(this.log);
 
           const historicParameters = validateHistoricParams({
             validationPeriod: flags.validationPeriod,

--- a/packages/apollo/src/commands/service/push.ts
+++ b/packages/apollo/src/commands/service/push.ts
@@ -33,7 +33,7 @@ export default class ServicePush extends ProjectCommand {
           }
 
           const schema = await project.resolveSchema({ tag: flags.tag });
-          gitContext = await gitInfo();
+          gitContext = await gitInfo(this.log);
 
           const { tag, code } = await project.engine.uploadSchema({
             id: config.name,


### PR DESCRIPTION
The remoteUrl can no longer be the slug, since we can't assume that the
feature is going to be used exclusively in GitHub and create an accurate
link the frontend. Additionally we add some logging in order to help
debug.

> Note: My first though was be to make the logging protected by a
verbose flag. Did I miss that functionality?

<!--
  Thanks for filing a pull request on Apollo Tooling!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [x] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
