### PR TITLE
UI-281 Update schema:check output format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,14 @@
 ## `apollo-language-server`
 
 - apollo-language-server
+
   - Stop loadConfig from looking up the tree when a --config location is defined [#1059](https://github.com/apollographql/apollo-tooling/pull/1059)
   - Refactored/documented/tested loadConfig [#1059](https://github.com/apollographql/apollo-tooling/pull/1059)
   - Add `.vue` file support for codegen:generate [#1160](https://github.com/apollographql/apollo-tooling/pull/1160)
+
+- apollo
+  - Add `--markdown` output option to `service:check` [#1072](https://github.com/apollographql/apollo-tooling/pull/1072)
+  - Enhance formatting for `service:check` output [#1146](https://github.com/apollographql/apollo-tooling/pull/1146)
 
 ## `apollo-codegen-flow@0.32.11`
 
@@ -43,7 +48,6 @@
   - Add missing dependency `@oclif/errors` [#1068](https://github.com/apollographql/apollo-tooling/pull/1068)
   - Include targetUrl in the output of the `service:check` command [#1072](https://github.com/apollographql/apollo-tooling/pull/1072)
   - Import apollo-env utility types directly instead of treating them as globals [#1074](https://github.com/apollographql/apollo-tooling/pull/1074)
-  - Add `--markdown` output option to `service:check` [#1072](https://github.com/apollographql/apollo-tooling/pull/1072)
 - `apollo-env@0.3.4`
   - Import apollo-env utility types directly instead of treating them as globals [#1074](https://github.com/apollographql/apollo-tooling/pull/1074)
 - `apollo-language-server@1.5.3`

--- a/packages/apollo-language-server/src/engine/operations/checkSchema.ts
+++ b/packages/apollo-language-server/src/engine/operations/checkSchema.ts
@@ -23,6 +23,7 @@ export const CHECK_SCHEMA = gql`
           affectedQueries {
             __typename
           }
+          numberOfCheckedOperations
           changes {
             type
             code

--- a/packages/apollo-language-server/src/graphqlTypes.ts
+++ b/packages/apollo-language-server/src/graphqlTypes.ts
@@ -49,6 +49,10 @@ export interface CheckSchema_service_checkSchema_diffToPrevious {
    */
   affectedQueries: CheckSchema_service_checkSchema_diffToPrevious_affectedQueries[] | null;
   /**
+   * Number of operations that were validated during schema diff
+   */
+  numberOfCheckedOperations: number | null;
+  /**
    * List of schema changes with associated affected clients and operations
    */
   changes: CheckSchema_service_checkSchema_diffToPrevious_changes[];

--- a/packages/apollo/src/commands/service/__tests__/check.test.ts
+++ b/packages/apollo/src/commands/service/__tests__/check.test.ts
@@ -2,15 +2,16 @@ import { formatMarkdown } from "../check";
 import checkSchemaResult from "./fixtures/check-schema-result.json";
 import { ChangeType } from "apollo-language-server/lib/graphqlTypes";
 
-describe("markdown formatting", () => {
-  it("is correct with breaking changes", () => {
-    expect(
-      formatMarkdown({
-        serviceName: "engine",
-        tag: "staging",
-        checkSchemaResult
-      })
-    ).toMatchInlineSnapshot(`
+describe("service:check", () => {
+  describe("markdown formatting", () => {
+    it("is correct with breaking changes", () => {
+      expect(
+        formatMarkdown({
+          serviceName: "engine",
+          tag: "staging",
+          checkSchemaResult
+        })
+      ).toMatchInlineSnapshot(`
 "
 ### Apollo Service Check
 🔄 Validated your local schema against schema tag 'staging' on service 'engine'.
@@ -20,24 +21,24 @@ describe("markdown formatting", () => {
 🔗 [View your service check details](https://engine-dev.apollographql.com/service/engine/checks?schemaTag=Detached%3A%20d664f715645c5f0bb5ad4f2260cd6cb8d19bbc68&schemaTagId=f9f68e7e-1b5f-4eab-a3da-1fd8cd681111&from=2019-03-26T22%3A25%3A12.887Z).
 "
 `);
-  });
+    });
 
-  it("is correct with no breaking changes", () => {
-    expect(
-      formatMarkdown({
-        serviceName: "engine",
-        tag: "staging",
-        checkSchemaResult: {
-          ...checkSchemaResult,
-          diffToPrevious: {
-            ...checkSchemaResult.diffToPrevious,
-            type: ChangeType.NOTICE,
-            affectedQueries: [],
-            changes: []
+    it("is correct with no breaking changes", () => {
+      expect(
+        formatMarkdown({
+          serviceName: "engine",
+          tag: "staging",
+          checkSchemaResult: {
+            ...checkSchemaResult,
+            diffToPrevious: {
+              ...checkSchemaResult.diffToPrevious,
+              type: ChangeType.NOTICE,
+              affectedQueries: [],
+              changes: []
+            }
           }
-        }
-      })
-    ).toMatchInlineSnapshot(`
+        })
+      ).toMatchInlineSnapshot(`
 "
 ### Apollo Service Check
 🔄 Validated your local schema against schema tag 'staging' on service 'engine'.
@@ -47,6 +48,7 @@ describe("markdown formatting", () => {
 🔗 [View your service check details](https://engine-dev.apollographql.com/service/engine/checks?schemaTag=Detached%3A%20d664f715645c5f0bb5ad4f2260cd6cb8d19bbc68&schemaTagId=f9f68e7e-1b5f-4eab-a3da-1fd8cd681111&from=2019-03-26T22%3A25%3A12.887Z).
 "
 `);
+    });
   });
 });
 

--- a/packages/apollo/src/commands/service/__tests__/check.test.ts
+++ b/packages/apollo/src/commands/service/__tests__/check.test.ts
@@ -1,4 +1,4 @@
-import { formatMarkdown } from "../check";
+import { formatHumanReadable, formatMarkdown } from "../check";
 import checkSchemaResult from "./fixtures/check-schema-result.json";
 import { ChangeType } from "apollo-language-server/lib/graphqlTypes";
 
@@ -48,6 +48,56 @@ describe("service:check", () => {
 🔗 [View your service check details](https://engine-dev.apollographql.com/service/engine/checks?schemaTag=Detached%3A%20d664f715645c5f0bb5ad4f2260cd6cb8d19bbc68&schemaTagId=f9f68e7e-1b5f-4eab-a3da-1fd8cd681111&from=2019-03-26T22%3A25%3A12.887Z).
 "
 `);
+    });
+  });
+
+  describe("formatHumanReadable", () => {
+    it("should have correct output with breaking and non-breaking changes", () => {
+      expect(
+        formatHumanReadable({
+          checkSchemaResult
+        })
+      ).toMatchInlineSnapshot(`
+"
+Change   Code                       Description
+───────  ─────────────────────────  ───────────────────────────────────────────────────────────────────────────────────────
+[31mFAILURE[39m  [31mFIELD_CHANGED_TYPE[39m         [31m\`Change.argNode\` changed type from \`NamedIntrospectionArg\` to \`NamedIntrospectionValue\`[39m
+NOTICE   ARG_REMOVED                \`ServiceMutation.registerOperations\` arg \`manifestVersion\` was removed
+NOTICE   ARG_REMOVED                \`ServiceMutation.uploadSchema\` arg \`historicParameters\` was removed
+[31mFAILURE[39m  [31mARG_REMOVED[39m                [31m\`ServiceMutation.uploadSchema\` arg \`gitContext\` was removed[39m
+[31mFAILURE[39m  [31mARG_REMOVED[39m                [31m\`ServiceMutation.uploadSchema\` arg \`tag\` was removed[39m
+NOTICE   FIELD_REMOVED              \`SchemaDiff.numberOfCheckedOperations\` was removed
+[31mFAILURE[39m  [31mFIELD_REMOVED[39m              [31m\`Change.affectedClients\` was removed[39m
+NOTICE   FIELD_REMOVED              \`Change.affectedClientReferenceIds\` was removed
+NOTICE   FIELD_REMOVED              \`Change.affectedClientIdVersionPairs\` was removed
+[31mFAILURE[39m  [31mARG_REMOVED[39m                [31m\`ServiceMutation.uploadSchema\` arg \`schema\` was removed[39m
+NOTICE   FIELD_REMOVED              \`AffectedClient.clientReferenceId\` was removed
+[31mFAILURE[39m  [31mFIELD_REMOVED[39m              [31m\`NamedIntrospectionValue.printedType\` was removed[39m
+[31mFAILURE[39m  [31mTYPE_REMOVED[39m               [31m\`NamedIntrospectionArg\` removed[39m
+NOTICE   FIELD_DEPRECATION_REMOVED  \`Change.description\` is no longer deprecated
+NOTICE   FIELD_ADDED                \`ServiceMutation.deregisterSchemaNotificationChannel\` was added
+NOTICE   FIELD_ADDED                \`ServiceMutation.registerSchemaNotificationChannel\` was added
+NOTICE   FIELD_DEPRECATION_REMOVED  \`AffectedClient.clientId\` is no longer deprecated
+NOTICE   FIELD_ADDED                \`Service.schemaNotificationChannels\` was added
+
+View full details at: https://engine-dev.apollographql.com/service/engine/checks?schemaTag=Detached%3A%20d664f715645c5f0bb5ad4f2260cd6cb8d19bbc68&schemaTagId=f9f68e7e-1b5f-4eab-a3da-1fd8cd681111&from=2019-03-26T22%3A25%3A12.887Z"
+`);
+    });
+
+    it("is correct with no breaking changes", () => {
+      expect(
+        formatHumanReadable({
+          checkSchemaResult: {
+            ...checkSchemaResult,
+            diffToPrevious: {
+              ...checkSchemaResult.diffToPrevious,
+              type: ChangeType.NOTICE,
+              affectedQueries: [],
+              changes: []
+            }
+          }
+        })
+      ).toMatchInlineSnapshot(`"No changes present between schemas"`);
     });
   });
 });

--- a/packages/apollo/src/commands/service/__tests__/check.test.ts
+++ b/packages/apollo/src/commands/service/__tests__/check.test.ts
@@ -1,4 +1,8 @@
-import { formatHumanReadable, formatMarkdown } from "../check";
+import {
+  formatHumanReadable,
+  formatMarkdown,
+  formatTimePeriod
+} from "../check";
 import checkSchemaResult from "./fixtures/check-schema-result.json";
 import { ChangeType } from "apollo-language-server/lib/graphqlTypes";
 
@@ -15,7 +19,7 @@ describe("service:check", () => {
 "
 ### Apollo Service Check
 🔄 Validated your local schema against schema tag 'staging' on service 'engine'.
-🔢 Compared **18 schema changes** against operations seen over the **last day**.
+🔢 Compared **18 schema changes** against operations seen over the **last 24 hours**.
 ❌ Found **7 breaking changes** that would affect **3 operations**
 
 🔗 [View your service check details](https://engine-dev.apollographql.com/service/engine/checks?schemaTag=Detached%3A%20d664f715645c5f0bb5ad4f2260cd6cb8d19bbc68&schemaTagId=f9f68e7e-1b5f-4eab-a3da-1fd8cd681111&from=2019-03-26T22%3A25%3A12.887Z).
@@ -42,12 +46,30 @@ describe("service:check", () => {
 "
 ### Apollo Service Check
 🔄 Validated your local schema against schema tag 'staging' on service 'engine'.
-🔢 Compared **0 schema changes** against operations seen over the **last day**.
+🔢 Compared **0 schema changes** against operations seen over the **last 24 hours**.
 ✅ Found **no breaking changes**.
 
 🔗 [View your service check details](https://engine-dev.apollographql.com/service/engine/checks?schemaTag=Detached%3A%20d664f715645c5f0bb5ad4f2260cd6cb8d19bbc68&schemaTagId=f9f68e7e-1b5f-4eab-a3da-1fd8cd681111&from=2019-03-26T22%3A25%3A12.887Z).
 "
 `);
+    });
+  });
+
+  describe("formatTimePeriod", () => {
+    it("should show current result for 12 hours", () => {
+      expect(formatTimePeriod(12)).toMatchInlineSnapshot(`"12 hours"`);
+    });
+
+    it("should show current result for 24 hours", () => {
+      expect(formatTimePeriod(24)).toMatchInlineSnapshot(`"24 hours"`);
+    });
+
+    it("should show current result for 36 hours", () => {
+      expect(formatTimePeriod(36)).toMatchInlineSnapshot(`"1 day"`);
+    });
+
+    it("should show current result for 48 hours", () => {
+      expect(formatTimePeriod(48)).toMatchInlineSnapshot(`"2 days"`);
     });
   });
 

--- a/packages/apollo/src/commands/service/__tests__/check.test.ts
+++ b/packages/apollo/src/commands/service/__tests__/check.test.ts
@@ -5,8 +5,20 @@ import {
 } from "../check";
 import checkSchemaResult from "./fixtures/check-schema-result.json";
 import { ChangeType } from "apollo-language-server/lib/graphqlTypes";
+import chalk from "chalk";
 
 describe("service:check", () => {
+  let originalChalkEnabled;
+
+  beforeEach(() => {
+    originalChalkEnabled = chalk.enabled;
+    chalk.enabled = false;
+  });
+
+  afterEach(() => {
+    chalk.enabled = originalChalkEnabled;
+  });
+
   describe("markdown formatting", () => {
     it("is correct with breaking changes", () => {
       expect(

--- a/packages/apollo/src/commands/service/__tests__/check.test.ts
+++ b/packages/apollo/src/commands/service/__tests__/check.test.ts
@@ -68,6 +68,10 @@ describe("service:check", () => {
   });
 
   describe("formatTimePeriod", () => {
+    it("should show current result for 1 hour", () => {
+      expect(formatTimePeriod(1)).toMatchInlineSnapshot(`"1 hour"`);
+    });
+
     it("should show current result for 12 hours", () => {
       expect(formatTimePeriod(12)).toMatchInlineSnapshot(`"12 hours"`);
     });

--- a/packages/apollo/src/commands/service/__tests__/check.test.ts
+++ b/packages/apollo/src/commands/service/__tests__/check.test.ts
@@ -93,32 +93,31 @@ describe("service:check", () => {
         })
       ).toMatchInlineSnapshot(`
 "
-Change   Code                       Description
-───────  ─────────────────────────  ───────────────────────────────────────────────────────────────────────────────────────
-[31mFAILURE[39m  [31mFIELD_CHANGED_TYPE[39m         [31m\`Change.argNode\` changed type from \`NamedIntrospectionArg\` to \`NamedIntrospectionValue\`[39m
-NOTICE   ARG_REMOVED                \`ServiceMutation.registerOperations\` arg \`manifestVersion\` was removed
-NOTICE   ARG_REMOVED                \`ServiceMutation.uploadSchema\` arg \`historicParameters\` was removed
-[31mFAILURE[39m  [31mARG_REMOVED[39m                [31m\`ServiceMutation.uploadSchema\` arg \`gitContext\` was removed[39m
-[31mFAILURE[39m  [31mARG_REMOVED[39m                [31m\`ServiceMutation.uploadSchema\` arg \`tag\` was removed[39m
-NOTICE   FIELD_REMOVED              \`SchemaDiff.numberOfCheckedOperations\` was removed
-[31mFAILURE[39m  [31mFIELD_REMOVED[39m              [31m\`Change.affectedClients\` was removed[39m
-NOTICE   FIELD_REMOVED              \`Change.affectedClientReferenceIds\` was removed
-NOTICE   FIELD_REMOVED              \`Change.affectedClientIdVersionPairs\` was removed
-[31mFAILURE[39m  [31mARG_REMOVED[39m                [31m\`ServiceMutation.uploadSchema\` arg \`schema\` was removed[39m
-NOTICE   FIELD_REMOVED              \`AffectedClient.clientReferenceId\` was removed
-[31mFAILURE[39m  [31mFIELD_REMOVED[39m              [31m\`NamedIntrospectionValue.printedType\` was removed[39m
-[31mFAILURE[39m  [31mTYPE_REMOVED[39m               [31m\`NamedIntrospectionArg\` removed[39m
-NOTICE   FIELD_DEPRECATION_REMOVED  \`Change.description\` is no longer deprecated
-NOTICE   FIELD_ADDED                \`ServiceMutation.deregisterSchemaNotificationChannel\` was added
-NOTICE   FIELD_ADDED                \`ServiceMutation.registerSchemaNotificationChannel\` was added
-NOTICE   FIELD_DEPRECATION_REMOVED  \`AffectedClient.clientId\` is no longer deprecated
-NOTICE   FIELD_ADDED                \`Service.schemaNotificationChannels\` was added
+PASS    ARG_REMOVED                \`ServiceMutation.registerOperations\` arg \`manifestVersion\` was removed
+PASS    ARG_REMOVED                \`ServiceMutation.uploadSchema\` arg \`historicParameters\` was removed
+PASS    FIELD_REMOVED              \`SchemaDiff.numberOfCheckedOperations\` was removed
+PASS    FIELD_REMOVED              \`Change.affectedClientReferenceIds\` was removed
+PASS    FIELD_REMOVED              \`Change.affectedClientIdVersionPairs\` was removed
+PASS    FIELD_REMOVED              \`AffectedClient.clientReferenceId\` was removed
+PASS    FIELD_DEPRECATION_REMOVED  \`Change.description\` is no longer deprecated
+PASS    FIELD_ADDED                \`ServiceMutation.deregisterSchemaNotificationChannel\` was added
+PASS    FIELD_ADDED                \`ServiceMutation.registerSchemaNotificationChannel\` was added
+PASS    FIELD_DEPRECATION_REMOVED  \`AffectedClient.clientId\` is no longer deprecated
+PASS    FIELD_ADDED                \`Service.schemaNotificationChannels\` was added
+
+FAIL    FIELD_CHANGED_TYPE         \`Change.argNode\` changed type from \`NamedIntrospectionArg\` to \`NamedIntrospectionValue\`
+FAIL    ARG_REMOVED                \`ServiceMutation.uploadSchema\` arg \`gitContext\` was removed
+FAIL    ARG_REMOVED                \`ServiceMutation.uploadSchema\` arg \`tag\` was removed
+FAIL    FIELD_REMOVED              \`Change.affectedClients\` was removed
+FAIL    ARG_REMOVED                \`ServiceMutation.uploadSchema\` arg \`schema\` was removed
+FAIL    FIELD_REMOVED              \`NamedIntrospectionValue.printedType\` was removed
+FAIL    TYPE_REMOVED               \`NamedIntrospectionArg\` removed
 
 View full details at: https://engine-dev.apollographql.com/service/engine/checks?schemaTag=Detached%3A%20d664f715645c5f0bb5ad4f2260cd6cb8d19bbc68&schemaTagId=f9f68e7e-1b5f-4eab-a3da-1fd8cd681111&from=2019-03-26T22%3A25%3A12.887Z"
 `);
     });
 
-    it("is correct with no breaking changes", () => {
+    it("should have correct output with only non-breaking changes", () => {
       expect(
         formatHumanReadable({
           checkSchemaResult: {
@@ -131,7 +130,41 @@ View full details at: https://engine-dev.apollographql.com/service/engine/checks
             }
           }
         })
-      ).toMatchInlineSnapshot(`"No changes present between schemas"`);
+      ).toMatchInlineSnapshot(`
+"
+No changes present between schemas
+
+View full details at: https://engine-dev.apollographql.com/service/engine/checks?schemaTag=Detached%3A%20d664f715645c5f0bb5ad4f2260cd6cb8d19bbc68&schemaTagId=f9f68e7e-1b5f-4eab-a3da-1fd8cd681111&from=2019-03-26T22%3A25%3A12.887Z"
+`);
+    });
+
+    it("should have correct output with only breaking changes", () => {
+      expect(
+        formatHumanReadable({
+          checkSchemaResult: {
+            ...checkSchemaResult,
+            diffToPrevious: {
+              ...checkSchemaResult.diffToPrevious,
+              type: ChangeType.NOTICE,
+              affectedQueries: [],
+              changes: checkSchemaResult.diffToPrevious.changes.filter(
+                change => change.type === ChangeType.FAILURE
+              )
+            }
+          }
+        })
+      ).toMatchInlineSnapshot(`
+"
+FAIL    FIELD_CHANGED_TYPE  \`Change.argNode\` changed type from \`NamedIntrospectionArg\` to \`NamedIntrospectionValue\`
+FAIL    ARG_REMOVED         \`ServiceMutation.uploadSchema\` arg \`gitContext\` was removed
+FAIL    ARG_REMOVED         \`ServiceMutation.uploadSchema\` arg \`tag\` was removed
+FAIL    FIELD_REMOVED       \`Change.affectedClients\` was removed
+FAIL    ARG_REMOVED         \`ServiceMutation.uploadSchema\` arg \`schema\` was removed
+FAIL    FIELD_REMOVED       \`NamedIntrospectionValue.printedType\` was removed
+FAIL    TYPE_REMOVED        \`NamedIntrospectionArg\` removed
+
+View full details at: https://engine-dev.apollographql.com/service/engine/checks?schemaTag=Detached%3A%20d664f715645c5f0bb5ad4f2260cd6cb8d19bbc68&schemaTagId=f9f68e7e-1b5f-4eab-a3da-1fd8cd681111&from=2019-03-26T22%3A25%3A12.887Z"
+`);
     });
   });
 });

--- a/packages/apollo/src/commands/service/__tests__/check.test.ts
+++ b/packages/apollo/src/commands/service/__tests__/check.test.ts
@@ -99,21 +99,21 @@ describe("service:check", () => {
 "
 PASS    ARG_REMOVED                \`ServiceMutation.registerOperations\` arg \`manifestVersion\` was removed
 PASS    ARG_REMOVED                \`ServiceMutation.uploadSchema\` arg \`historicParameters\` was removed
-PASS    FIELD_REMOVED              \`SchemaDiff.numberOfCheckedOperations\` was removed
-PASS    FIELD_REMOVED              \`Change.affectedClientReferenceIds\` was removed
-PASS    FIELD_REMOVED              \`Change.affectedClientIdVersionPairs\` was removed
-PASS    FIELD_REMOVED              \`AffectedClient.clientReferenceId\` was removed
-PASS    FIELD_DEPRECATION_REMOVED  \`Change.description\` is no longer deprecated
+PASS    FIELD_ADDED                \`Service.schemaNotificationChannels\` was added
 PASS    FIELD_ADDED                \`ServiceMutation.deregisterSchemaNotificationChannel\` was added
 PASS    FIELD_ADDED                \`ServiceMutation.registerSchemaNotificationChannel\` was added
 PASS    FIELD_DEPRECATION_REMOVED  \`AffectedClient.clientId\` is no longer deprecated
-PASS    FIELD_ADDED                \`Service.schemaNotificationChannels\` was added
+PASS    FIELD_DEPRECATION_REMOVED  \`Change.description\` is no longer deprecated
+PASS    FIELD_REMOVED              \`AffectedClient.clientReferenceId\` was removed
+PASS    FIELD_REMOVED              \`Change.affectedClientIdVersionPairs\` was removed
+PASS    FIELD_REMOVED              \`Change.affectedClientReferenceIds\` was removed
+PASS    FIELD_REMOVED              \`SchemaDiff.numberOfCheckedOperations\` was removed
 
-FAIL    FIELD_CHANGED_TYPE         \`Change.argNode\` changed type from \`NamedIntrospectionArg\` to \`NamedIntrospectionValue\`
 FAIL    ARG_REMOVED                \`ServiceMutation.uploadSchema\` arg \`gitContext\` was removed
-FAIL    ARG_REMOVED                \`ServiceMutation.uploadSchema\` arg \`tag\` was removed
-FAIL    FIELD_REMOVED              \`Change.affectedClients\` was removed
 FAIL    ARG_REMOVED                \`ServiceMutation.uploadSchema\` arg \`schema\` was removed
+FAIL    ARG_REMOVED                \`ServiceMutation.uploadSchema\` arg \`tag\` was removed
+FAIL    FIELD_CHANGED_TYPE         \`Change.argNode\` changed type from \`NamedIntrospectionArg\` to \`NamedIntrospectionValue\`
+FAIL    FIELD_REMOVED              \`Change.affectedClients\` was removed
 FAIL    FIELD_REMOVED              \`NamedIntrospectionValue.printedType\` was removed
 FAIL    TYPE_REMOVED               \`NamedIntrospectionArg\` removed
 
@@ -159,11 +159,11 @@ View full details at: https://engine-dev.apollographql.com/service/engine/checks
         })
       ).toMatchInlineSnapshot(`
 "
-FAIL    FIELD_CHANGED_TYPE  \`Change.argNode\` changed type from \`NamedIntrospectionArg\` to \`NamedIntrospectionValue\`
 FAIL    ARG_REMOVED         \`ServiceMutation.uploadSchema\` arg \`gitContext\` was removed
-FAIL    ARG_REMOVED         \`ServiceMutation.uploadSchema\` arg \`tag\` was removed
-FAIL    FIELD_REMOVED       \`Change.affectedClients\` was removed
 FAIL    ARG_REMOVED         \`ServiceMutation.uploadSchema\` arg \`schema\` was removed
+FAIL    ARG_REMOVED         \`ServiceMutation.uploadSchema\` arg \`tag\` was removed
+FAIL    FIELD_CHANGED_TYPE  \`Change.argNode\` changed type from \`NamedIntrospectionArg\` to \`NamedIntrospectionValue\`
+FAIL    FIELD_REMOVED       \`Change.affectedClients\` was removed
 FAIL    FIELD_REMOVED       \`NamedIntrospectionValue.printedType\` was removed
 FAIL    TYPE_REMOVED        \`NamedIntrospectionArg\` removed
 

--- a/packages/apollo/src/commands/service/check.ts
+++ b/packages/apollo/src/commands/service/check.ts
@@ -78,7 +78,7 @@ export function formatMarkdown({
     );
   }
 
-  // This will always return a negative number of days. Use `-` to make it positive.
+  // This will always return a negative number. Use Math.abs to make it positive.
   const hours = Math.abs(
     moment()
       .add(validationConfig.from, "second")

--- a/packages/apollo/src/commands/service/check.ts
+++ b/packages/apollo/src/commands/service/check.ts
@@ -209,6 +209,9 @@ export default class ServiceCheck extends ProjectCommand {
     // @ts-ignore we're goign to populate `taskOutput` later
     const taskOutput: TasksOutput = {};
 
+    // Define this constant so we can throw it and compare against the same value.
+    const breakingChangesErrorMessage = "breaking changes found";
+
     try {
       await this.runTasks<TasksOutput>(
         ({ config, flags, project }) => [
@@ -323,7 +326,9 @@ export default class ServiceCheck extends ProjectCommand {
               }`;
 
               if (breakingSchemaChangeCount) {
-                throw new Error("breaking changes found");
+                // Throw an error here to produce a red X in the list of steps being taken. We're going to
+                // `catch` this error below and proceed with the reporting.
+                throw new Error(breakingChangesErrorMessage);
               }
             }
           }
@@ -337,7 +342,7 @@ export default class ServiceCheck extends ProjectCommand {
         })
       );
     } catch (error) {
-      if (error.message !== "breaking changes found") {
+      if (error.message !== breakingChangesErrorMessage) {
         throw error;
       }
     }

--- a/packages/apollo/src/commands/service/check.ts
+++ b/packages/apollo/src/commands/service/check.ts
@@ -131,15 +131,22 @@ export function formatHumanReadable({
   if (changes.length === 0) {
     result = "\nNo changes present between schemas";
   } else {
-    const breakingChanges = changes.filter(
+    // Create a sorted list of the changes. We'll then filter values from the sorted list, resulting in sorted
+    // filtered lists.
+    const sortedChanges = sortBy<typeof changes[0]>(changes, [
+      change => change.code,
+      change => change.description
+    ]);
+
+    const breakingChanges = sortedChanges.filter(
       change => change.type === ChangeType.FAILURE
     );
+
     sortBy(breakingChanges, change => change.type);
 
-    const nonBreakingChanges = changes.filter(
+    const nonBreakingChanges = sortedChanges.filter(
       change => change.type !== ChangeType.FAILURE
     );
-    sortBy(nonBreakingChanges, change => change.type);
 
     table(
       [

--- a/packages/apollo/src/commands/service/check.ts
+++ b/packages/apollo/src/commands/service/check.ts
@@ -12,6 +12,7 @@ import {
 } from "apollo-language-server/lib/graphqlTypes";
 import { ApolloConfig } from "apollo-language-server";
 import moment from "moment";
+import sortBy from "lodash.sortby";
 
 const formatChange = (change: Change) => {
   let color = (x: string): string => x;
@@ -23,8 +24,14 @@ const formatChange = (change: Change) => {
     color = chalk.yellow;
   }
 
+  const changeDictionary: Record<ChangeType, string> = {
+    [ChangeType.FAILURE]: "FAIL",
+    [ChangeType.WARNING]: "WARN",
+    [ChangeType.NOTICE]: "PASS"
+  };
+
   return {
-    type: color(change.type),
+    type: color(changeDictionary[change.type]),
     code: color(change.code),
     description: color(change.description)
   };
@@ -122,19 +129,38 @@ export function formatHumanReadable({
   const failures = changes.filter(({ type }) => type === ChangeType.FAILURE);
 
   if (changes.length === 0) {
-    return "No changes present between schemas";
-  }
+    result = "\nNo changes present between schemas";
+  } else {
+    const breakingChanges = changes.filter(
+      change => change.type === ChangeType.FAILURE
+    );
+    sortBy(breakingChanges, change => change.type);
 
-  table(changes.map(formatChange), {
-    columns: [
-      { key: "type", label: "Change" },
-      { key: "code", label: "Code" },
-      { key: "description", label: "Description" }
-    ],
-    printLine: line => {
-      result += `\n${line}`;
-    }
-  });
+    const nonBreakingChanges = changes.filter(
+      change => change.type !== ChangeType.FAILURE
+    );
+    sortBy(nonBreakingChanges, change => change.type);
+
+    table(
+      [
+        ...nonBreakingChanges.map(formatChange),
+        // Add an empty line between, but only if there are both breaking changes and non-breaking changes.
+        nonBreakingChanges.length && breakingChanges.length ? {} : null,
+        ...breakingChanges.map(formatChange)
+      ].filter(Boolean),
+      {
+        columns: [
+          { key: "type", label: "Change" },
+          { key: "code", label: "Code" },
+          { key: "description", label: "Description" }
+        ],
+        printHeader: () => {},
+        printLine: line => {
+          result += `\n${line}`;
+        }
+      }
+    );
+  }
 
   if (targetUrl) {
     result += `\n\nView full details at: ${targetUrl}`;
@@ -241,6 +267,7 @@ export default class ServiceCheck extends ProjectCommand {
             task: async (ctx: TasksOutput, task) => {
               const schemaChanges =
                 ctx.checkSchemaResult.diffToPrevious.changes;
+
               const numberOfCheckedOperations =
                 ctx.checkSchemaResult.diffToPrevious
                   .numberOfCheckedOperations || 0;

--- a/packages/apollo/src/commands/service/check.ts
+++ b/packages/apollo/src/commands/service/check.ts
@@ -278,11 +278,14 @@ export default class ServiceCheck extends ProjectCommand {
               const validationConfig =
                 ctx.checkSchemaResult.diffToPrevious.validationConfig;
 
-              const days = validationConfig
+              const hours = validationConfig
                 ? Math.abs(
                     moment()
                       .add(validationConfig.from, "second")
-                      .diff(moment().add(validationConfig.to, "second"), "days")
+                      .diff(
+                        moment().add(validationConfig.to, "second"),
+                        "hours"
+                      )
                   )
                 : null;
 
@@ -293,10 +296,8 @@ export default class ServiceCheck extends ProjectCommand {
               } against ${chalk.blue(numberOfCheckedOperations.toString())} ${
                 numberOfCheckedOperations === 1 ? "operation" : "operations"
               }${
-                days
-                  ? ` seen in the past ${chalk.blue(
-                      days === 1 ? "24 hours" : `${days} days`
-                    )}`
+                hours
+                  ? ` over the last ${chalk.blue(formatTimePeriod(hours))}`
                   : ""
               }`;
             }

--- a/packages/apollo/src/commands/service/check.ts
+++ b/packages/apollo/src/commands/service/check.ts
@@ -404,7 +404,7 @@ export default class ServiceCheck extends ProjectCommand {
         ({ type }) => type === ChangeType.FAILURE
       )
     ) {
-      this.exit();
+      this.exit(1);
     }
   }
 }

--- a/packages/apollo/src/commands/service/check.ts
+++ b/packages/apollo/src/commands/service/check.ts
@@ -154,7 +154,10 @@ export function formatHumanReadable({
           { key: "code", label: "Code" },
           { key: "description", label: "Description" }
         ],
+        // Override `printHeader` so we don't print a header
         printHeader: () => {},
+        // The default `printLine` will output to the console; we want to capture the output so we can test
+        // it.
         printLine: line => {
           result += `\n${line}`;
         }

--- a/packages/apollo/src/commands/service/check.ts
+++ b/packages/apollo/src/commands/service/check.ts
@@ -39,7 +39,7 @@ const formatChange = (change: Change) => {
 
 export function formatTimePeriod(hours: number): string {
   if (hours <= 24) {
-    return hours === 1 ? "hour" : `${hours} hours`;
+    return hours === 1 ? `${hours} hour` : `${hours} hours`;
   }
 
   const days = Math.floor(hours / 24);


### PR DESCRIPTION
We use `Listr` to output the progress list (✓s and ✖s). We must pre-fill the titles of the steps that have yet to run. I then change those titles into the correct output. I'd love some feedback on better titles:

```
  ✔ Loading Apollo Project
  ⠦ Validating local schema against tag prod on service engine
    → Validating schema
    Comparing schema changes
    Reporting result
```

---

TODO:

- [x] Update `CHANGELOG.md` with your change (include reference to issue & this PR)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass

---

- [x] Do some more testing on reporting with no errors
- [x] Add URL at the bottom