### PR TITLE
Resolve nested dir creation codegen bug

### DIFF
--- a/packages/apollo/__mocks__/apollo-cli-test.ts
+++ b/packages/apollo/__mocks__/apollo-cli-test.ts
@@ -4,6 +4,7 @@ import Nock from "@fancy-test/nock";
 import * as Test from "@oclif/test";
 export { expect } from "@oclif/test";
 import { mockConsole } from "heroku-cli-util";
+import { deleteFolderRecursive, makeNestedDir } from "../src/utils";
 
 const time = label => {
   let start = +new Date();
@@ -23,38 +24,6 @@ const debug = fn => {
     },
     finally() {}
   };
-};
-
-const deleteFolderRecursive = path => {
-  // don't relete files on azure CI
-  if (process.env.AZURE_HTTP_USER_AGENT) return;
-
-  if (fs.existsSync(path)) {
-    fs.readdirSync(path).forEach(function(file, index) {
-      var curPath = path + "/" + file;
-      if (fs.lstatSync(curPath).isDirectory()) {
-        // recurse
-        deleteFolderRecursive(curPath);
-      } else {
-        // delete file
-        fs.unlinkSync(curPath);
-      }
-    });
-    fs.rmdirSync(path);
-  }
-};
-
-const makeNestedDir = dir => {
-  if (fs.existsSync(dir)) return;
-
-  try {
-    fs.mkdirSync(dir);
-  } catch (err) {
-    if (err.code == "ENOENT") {
-      makeNestedDir(path.dirname(dir)); //create parent dir
-      makeNestedDir(dir); //create dir
-    }
-  }
 };
 
 const setupFS = (files: Record<string, string>) => {

--- a/packages/apollo/src/commands/client/__tests__/__snapshots__/generate.test.ts.snap
+++ b/packages/apollo/src/commands/client/__tests__/__snapshots__/generate.test.ts.snap
@@ -39,6 +39,157 @@ exports[`client:codegen generates operation IDs for swift files when flag is set
 }"
 `;
 
+exports[`client:codegen writes Flow types to a custom directory next to sources when output is set 1`] = `
+"/* @flow */
+/* eslint-disable */
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL query operation: SimpleQuery
+// ====================================================
+
+export type SimpleQuery = {
+  hello: string
+};/* @flow */
+/* eslint-disable */
+// This file was automatically generated and should not be edited.
+
+//==============================================================
+// START Enums and Input Objects
+//==============================================================
+
+//==============================================================
+// END Enums and Input Objects
+//=============================================================="
+`;
+
+exports[`client:codegen writes TypeScript global types to a custom path when globalTypesFile is set 1`] = `
+"/* tslint:disable */
+/* eslint-disable */
+// This file was automatically generated and should not be edited.
+
+import { SomeEnum } from \\"./../../__foo__/bar\\";
+
+// ====================================================
+// GraphQL query operation: SimpleQuery
+// ====================================================
+
+export interface SimpleQuery {
+  someEnum: SomeEnum;
+}
+"
+`;
+
+exports[`client:codegen writes TypeScript global types to a custom path when globalTypesFile is set 2`] = `
+"/* tslint:disable */
+/* eslint-disable */
+// This file was automatically generated and should not be edited.
+
+//==============================================================
+// START Enums and Input Objects
+//==============================================================
+
+export enum SomeEnum {
+  bar = \\"bar\\",
+  foo = \\"foo\\",
+}
+
+//==============================================================
+// END Enums and Input Objects
+//==============================================================
+"
+`;
+
+exports[`client:codegen writes TypeScript types into a __generated__ directory next to sources when no output is set 1`] = `
+"/* tslint:disable */
+/* eslint-disable */
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL query operation: SimpleQuery
+// ====================================================
+
+export interface SimpleQuery {
+  hello: string;
+}
+"
+`;
+
+exports[`client:codegen writes TypeScript types into a __generated__ directory next to sources when no output is set 2`] = `
+"/* tslint:disable */
+/* eslint-disable */
+// This file was automatically generated and should not be edited.
+
+//==============================================================
+// START Enums and Input Objects
+//==============================================================
+
+//==============================================================
+// END Enums and Input Objects
+//==============================================================
+"
+`;
+
+exports[`client:codegen writes TypeScript types next to sources when output is set to empty string 1`] = `
+"/* tslint:disable */
+/* eslint-disable */
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL query operation: SimpleQuery
+// ====================================================
+
+export interface SimpleQuery {
+  hello: string;
+}
+"
+`;
+
+exports[`client:codegen writes TypeScript types next to sources when output is set to empty string 2`] = `
+"/* tslint:disable */
+/* eslint-disable */
+// This file was automatically generated and should not be edited.
+
+//==============================================================
+// START Enums and Input Objects
+//==============================================================
+
+//==============================================================
+// END Enums and Input Objects
+//==============================================================
+"
+`;
+
+exports[`client:codegen writes TypeScript types to a custom directory next to sources when output is set 1`] = `
+"/* tslint:disable */
+/* eslint-disable */
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL query operation: SimpleQuery
+// ====================================================
+
+export interface SimpleQuery {
+  hello: string;
+}
+"
+`;
+
+exports[`client:codegen writes TypeScript types to a custom directory next to sources when output is set 2`] = `
+"/* tslint:disable */
+/* eslint-disable */
+// This file was automatically generated and should not be edited.
+
+//==============================================================
+// START Enums and Input Objects
+//==============================================================
+
+//==============================================================
+// END Enums and Input Objects
+//==============================================================
+"
+`;
+
 exports[`client:codegen writes exact Flow types when the useFlowExactObjects flag is set 1`] = `
 "/* @flow */
 /* eslint-disable */
@@ -64,6 +215,54 @@ export type SimpleQuery = {|
 `;
 
 exports[`client:codegen writes flow types 1`] = `
+"/* @flow */
+/* eslint-disable */
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL query operation: SimpleQuery
+// ====================================================
+
+export type SimpleQuery = {
+  hello: string
+};/* @flow */
+/* eslint-disable */
+// This file was automatically generated and should not be edited.
+
+//==============================================================
+// START Enums and Input Objects
+//==============================================================
+
+//==============================================================
+// END Enums and Input Objects
+//=============================================================="
+`;
+
+exports[`client:codegen writes flow types into a __generated__ directory next to sources when no output is set 1`] = `
+"/* @flow */
+/* eslint-disable */
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL query operation: SimpleQuery
+// ====================================================
+
+export type SimpleQuery = {
+  hello: string
+};/* @flow */
+/* eslint-disable */
+// This file was automatically generated and should not be edited.
+
+//==============================================================
+// START Enums and Input Objects
+//==============================================================
+
+//==============================================================
+// END Enums and Input Objects
+//=============================================================="
+`;
+
+exports[`client:codegen writes flow types next to sources when output is set to empty string 1`] = `
 "/* @flow */
 /* eslint-disable */
 // This file was automatically generated and should not be edited.

--- a/packages/apollo/src/commands/client/__tests__/generate.test.ts
+++ b/packages/apollo/src/commands/client/__tests__/generate.test.ts
@@ -376,9 +376,7 @@ describe("client:codegen", () => {
       expect(output).toMatchSnapshot();
     });
 
-  // TODO: fix UnhandledPromiseRejection
   test
-    .skip()
     .fs({
       "schema.json": fullSchemaJsonString,
       "components/component.tsx": `
@@ -412,9 +410,7 @@ describe("client:codegen", () => {
       }
     );
 
-  // TODO: fix
   test
-    .skip()
     .fs({
       "schema.json": fullSchemaJsonString,
       "components/component.jsx": `
@@ -445,9 +441,7 @@ describe("client:codegen", () => {
       }
     );
 
-  // TODO: fix
   test
-    .skip()
     .fs({
       "schema.json": fullSchemaJsonString,
       "components/component.tsx": `
@@ -477,14 +471,14 @@ describe("client:codegen", () => {
       () => {
         expect(
           fs.readFileSync("components/__foo__/SimpleQuery.ts").toString()
-        ).toEqual();
-        expect(fs.readFileSync("__foo__/globalTypes.ts").toString()).toEqual();
+        ).toMatchSnapshot();
+        expect(
+          fs.readFileSync("__foo__/globalTypes.ts").toString()
+        ).toMatchSnapshot();
       }
     );
 
-  // TODO: fix unhandled rejection
   test
-    .skip()
     .fs({
       "schema.json": fullSchemaJsonString,
       "components/component.tsx": `
@@ -519,9 +513,7 @@ describe("client:codegen", () => {
       }
     );
 
-  // fix
   test
-    .skip()
     .fs({
       "schema.json": fullSchemaJsonString,
       "components/component.jsx": `
@@ -555,9 +547,7 @@ describe("client:codegen", () => {
       }
     );
 
-  // fix
   test
-    .skip()
     .fs({
       "schema.json": fullSchemaJsonString,
       "components/component.tsx": `
@@ -592,9 +582,7 @@ describe("client:codegen", () => {
       }
     );
 
-  // fix
   test
-    .skip()
     .fs({
       "schema.json": fullSchemaJsonString,
       "components/component.jsx": `

--- a/packages/apollo/src/generate.ts
+++ b/packages/apollo/src/generate.ts
@@ -1,6 +1,6 @@
 import { fs } from "apollo-codegen-core/lib/localfs";
 import path from "path";
-import { GraphQLSchema, DocumentNode, print } from "graphql";
+import { GraphQLSchema, DocumentNode } from "graphql";
 import URI from "vscode-uri";
 
 import {
@@ -25,6 +25,7 @@ import { generateSource as generateScalaSource } from "apollo-codegen-scala";
 
 import { FlowCompilerOptions } from "../../apollo-codegen-flow/lib/language";
 import { validateQueryDocument } from "apollo-language-server/lib/errors/validation";
+import { makeNestedDir } from "./utils";
 
 export type TargetType =
   | "json"
@@ -60,7 +61,7 @@ export default function generate(
 
   const { rootPath = process.cwd() } = options;
   if (outputPath.split(".").length <= 1 && !fs.existsSync(outputPath)) {
-    fs.mkdirSync(outputPath);
+    makeNestedDir(outputPath);
   }
 
   if (target === "swift") {
@@ -98,9 +99,8 @@ export default function generate(
           path.dirname(path.posix.relative(rootPath, toPath(sourcePath))),
           outputPath
         );
-        if (!fs.existsSync(dir)) {
-          fs.mkdirSync(dir);
-        }
+
+        makeNestedDir(dir);
 
         outFiles[path.join(dir, fileName)] = {
           output: content.fileContents + common
@@ -147,10 +147,10 @@ export default function generate(
       if (options.globalTypesFile) {
         const globalTypesDir = path.dirname(options.globalTypesFile);
         if (!fs.existsSync(globalTypesDir)) {
-          fs.mkdirSync(globalTypesDir);
+          makeNestedDir(globalTypesDir);
         }
       } else if (nextToSources && !fs.existsSync(outputPath)) {
-        fs.mkdirSync(outputPath);
+        makeNestedDir(outputPath);
       }
 
       const globalSourcePath =
@@ -166,9 +166,8 @@ export default function generate(
             path.dirname(path.relative(rootPath, toPath(sourcePath))),
             dir
           );
-          if (!fs.existsSync(dir)) {
-            fs.mkdirSync(dir);
-          }
+
+          makeNestedDir(dir);
         }
 
         const outFilePath = path.join(dir, fileName);

--- a/packages/apollo/src/utils/folderOperations.ts
+++ b/packages/apollo/src/utils/folderOperations.ts
@@ -1,0 +1,41 @@
+import { dirname } from "path";
+import {
+  mkdirSync,
+  existsSync,
+  readdirSync,
+  lstatSync,
+  unlinkSync,
+  rmdirSync
+} from "fs";
+
+export const deleteFolderRecursive = path => {
+  // don't relete files on azure CI
+  if (process.env.AZURE_HTTP_USER_AGENT) return;
+
+  if (existsSync(path)) {
+    readdirSync(path).forEach(function(file, index) {
+      var curPath = path + "/" + file;
+      if (lstatSync(curPath).isDirectory()) {
+        // recurse
+        deleteFolderRecursive(curPath);
+      } else {
+        // delete file
+        unlinkSync(curPath);
+      }
+    });
+    rmdirSync(path);
+  }
+};
+
+export const makeNestedDir = dir => {
+  if (existsSync(dir)) return;
+
+  try {
+    mkdirSync(dir);
+  } catch (err) {
+    if (err.code == "ENOENT") {
+      makeNestedDir(dirname(dir)); //create parent dir
+      makeNestedDir(dir); //create dir
+    }
+  }
+};

--- a/packages/apollo/src/utils/folderOperations.ts
+++ b/packages/apollo/src/utils/folderOperations.ts
@@ -9,9 +9,6 @@ import {
 } from "fs";
 
 export const deleteFolderRecursive = path => {
-  // don't relete files on azure CI
-  if (process.env.AZURE_HTTP_USER_AGENT) return;
-
   if (existsSync(path)) {
     readdirSync(path).forEach(function(file, index) {
       var curPath = path + "/" + file;

--- a/packages/apollo/src/utils/index.ts
+++ b/packages/apollo/src/utils/index.ts
@@ -1,1 +1,3 @@
 export * from "./validateHistoricParams";
+
+export * from "./folderOperations";


### PR DESCRIPTION
This resolves a bug in codegen where directory creation will fail / throw errors if we try to created a nested dir that doesn't exist. This case may only occur in a testing scenario, however this does allow us to re-enable our tests that exercise nested functionality.

<!--
  Thanks for filing a pull request on Apollo Tooling!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [ ] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass

\*Make sure changelog entries note which project(s) has been affected. See older entries for examples on what this looks like.
