### PR TITLE
Update @oclif/config dependency resolution

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1545,9 +1545,9 @@
       }
     },
     "@oclif/config": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@oclif/config/-/config-1.12.0.tgz",
-      "integrity": "sha512-RB6A+N7Dq5DcFOQEhPpB8DdXtMQm2VDgdtgBKUdot815tj4gW7nDmRZBEwU85x4Xhep7Dx3tpaXobA6bFlSOWg==",
+      "version": "1.12.12",
+      "resolved": "https://registry.npmjs.org/@oclif/config/-/config-1.12.12.tgz",
+      "integrity": "sha512-0vlX5VYvOfF9QbkCqMyPSzH9GMp6at4Mbqn8CxCskxhKvNZoPD5ocda2ku0zEnoqxGAQ4VfQP7NCqJthuiStfg==",
       "requires": {
         "debug": "^4.1.1",
         "tslib": "^1.9.3"
@@ -1749,17 +1749,6 @@
         "http-call": "^5.2.2",
         "lodash.template": "^4.4.0",
         "semver": "^5.6.0"
-      },
-      "dependencies": {
-        "@oclif/config": {
-          "version": "1.12.10",
-          "resolved": "https://registry.npmjs.org/@oclif/config/-/config-1.12.10.tgz",
-          "integrity": "sha512-AQYFA72ktXgmrY4hjRtBQRfKLDKXPG4WGSLUgWn0KencNuqnmbiKS6zfKXf1umfZ26zoDOEfCdqZjm3aNZnIaw==",
-          "requires": {
-            "debug": "^4.1.1",
-            "tslib": "^1.9.3"
-          }
-        }
       }
     },
     "@oclif/screen": {
@@ -2305,17 +2294,10 @@
         "vscode-uri": "1.0.6"
       },
       "dependencies": {
-        "@oclif/config": {
-          "version": "1.12.12",
-          "bundled": true,
-          "requires": {
-            "debug": "^4.1.1",
-            "tslib": "^1.9.3"
-          }
-        },
         "@oclif/plugin-plugins": {
           "version": "1.7.8",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/@oclif/plugin-plugins/-/plugin-plugins-1.7.8.tgz",
+          "integrity": "sha512-GxLxaf8Lk1RqHVAIBZyA7hmhU7u5oV97i/OsWgFPdjPaT+BmWlWXR8IpmtA8giNo6atR+JpfgDmYndMU75zYUQ==",
           "requires": {
             "@oclif/color": "^0.0.0",
             "@oclif/command": "^1.5.12",
@@ -2333,7 +2315,8 @@
           "dependencies": {
             "cli-ux": {
               "version": "5.2.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/cli-ux/-/cli-ux-5.2.1.tgz",
+              "integrity": "sha512-zG1012o7U4ZsCuIST1t2yrHPADv16J81RAGYjY9X1yABEFK40oyjRchD5ffVZaG44BjizmLvu677zbVIypRuxw==",
               "requires": {
                 "@oclif/command": "^1.5.1",
                 "@oclif/errors": "^1.2.1",
@@ -2365,22 +2348,26 @@
         },
         "clean-stack": {
           "version": "2.0.0",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.0.0.tgz",
+          "integrity": "sha512-VEoL9Qh7I8s8iHnV53DaeWSt8NJ0g3khMfK6NiCPB7H657juhro+cSw2O88uo3bo0c0X5usamtXk0/Of0wXa5A=="
         },
         "npm-run-path": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-3.0.0.tgz",
+          "integrity": "sha512-42wmNM/F44tq5pDfDDwYWh30JbQokeUn79/6qNyoEvCSOMy0Q2iHe7unLRzRWQL5JLrOoQT6WzSuc6ylvEMmNg==",
           "requires": {
             "path-key": "^3.0.0"
           }
         },
         "path-key": {
           "version": "3.0.0",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.0.0.tgz",
+          "integrity": "sha512-zLY/S2T5y8zv1vEpx4VHguUgmtgkewofGKSpa7VmzdU3Jbu8JonUvt5hzjBpJvamSnusynqJiYwkbi22aTo7Rw=="
         },
         "string-width": {
           "version": "3.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
           "requires": {
             "emoji-regex": "^7.0.1",
             "is-fullwidth-code-point": "^2.0.0",
@@ -2389,7 +2376,8 @@
         },
         "yarn": {
           "version": "1.15.2",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/yarn/-/yarn-1.15.2.tgz",
+          "integrity": "sha512-DhqaGe2FcYKduO42d2hByXk7y8k2k42H3uzYdWBMTvcNcgWKx7xCkJWsVAQikXvaEQN2GyJNrz8CboqUmaBRrw=="
         }
       }
     },
@@ -2445,7 +2433,8 @@
       "dependencies": {
         "@babel/generator": {
           "version": "7.4.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.4.0.tgz",
+          "integrity": "sha512-/v5I+a1jhGSKLgZDcmAUZ4K/VePi43eRkUs3yePW1HB1iANOD5tqJXwGSG4BZhSksP8J9ejSlwGeTiiOFZOrXQ==",
           "requires": {
             "@babel/types": "^7.4.0",
             "jsesc": "^2.5.1",
@@ -2456,7 +2445,8 @@
           "dependencies": {
             "@babel/types": {
               "version": "7.4.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.0.tgz",
+              "integrity": "sha512-aPvkXyU2SPOnztlgo8n9cEiXW755mgyvueUPcpStqdzoSPm0fjO0vQBjLkt3JKJW7ufikfcnMTTPsN1xaTsBPA==",
               "requires": {
                 "esutils": "^2.0.2",
                 "lodash": "^4.17.11",
@@ -2467,7 +2457,8 @@
         },
         "@babel/types": {
           "version": "7.4.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.0.tgz",
+          "integrity": "sha512-aPvkXyU2SPOnztlgo8n9cEiXW755mgyvueUPcpStqdzoSPm0fjO0vQBjLkt3JKJW7ufikfcnMTTPsN1xaTsBPA==",
           "requires": {
             "esutils": "^2.0.2",
             "lodash": "^4.17.11",
@@ -2490,7 +2481,8 @@
       "dependencies": {
         "@babel/generator": {
           "version": "7.4.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.4.0.tgz",
+          "integrity": "sha512-/v5I+a1jhGSKLgZDcmAUZ4K/VePi43eRkUs3yePW1HB1iANOD5tqJXwGSG4BZhSksP8J9ejSlwGeTiiOFZOrXQ==",
           "requires": {
             "@babel/types": "^7.4.0",
             "jsesc": "^2.5.1",
@@ -2501,7 +2493,8 @@
           "dependencies": {
             "@babel/types": {
               "version": "7.4.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.0.tgz",
+              "integrity": "sha512-aPvkXyU2SPOnztlgo8n9cEiXW755mgyvueUPcpStqdzoSPm0fjO0vQBjLkt3JKJW7ufikfcnMTTPsN1xaTsBPA==",
               "requires": {
                 "esutils": "^2.0.2",
                 "lodash": "^4.17.11",
@@ -2512,7 +2505,8 @@
         },
         "@babel/types": {
           "version": "7.4.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.0.tgz",
+          "integrity": "sha512-aPvkXyU2SPOnztlgo8n9cEiXW755mgyvueUPcpStqdzoSPm0fjO0vQBjLkt3JKJW7ufikfcnMTTPsN1xaTsBPA==",
           "requires": {
             "esutils": "^2.0.2",
             "lodash": "^4.17.11",
@@ -2555,7 +2549,8 @@
       "dependencies": {
         "@babel/generator": {
           "version": "7.4.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.4.0.tgz",
+          "integrity": "sha512-/v5I+a1jhGSKLgZDcmAUZ4K/VePi43eRkUs3yePW1HB1iANOD5tqJXwGSG4BZhSksP8J9ejSlwGeTiiOFZOrXQ==",
           "requires": {
             "@babel/types": "^7.4.0",
             "jsesc": "^2.5.1",
@@ -2566,7 +2561,8 @@
           "dependencies": {
             "@babel/types": {
               "version": "7.4.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.0.tgz",
+              "integrity": "sha512-aPvkXyU2SPOnztlgo8n9cEiXW755mgyvueUPcpStqdzoSPm0fjO0vQBjLkt3JKJW7ufikfcnMTTPsN1xaTsBPA==",
               "requires": {
                 "esutils": "^2.0.2",
                 "lodash": "^4.17.11",
@@ -2577,7 +2573,8 @@
         },
         "@babel/types": {
           "version": "7.4.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.0.tgz",
+          "integrity": "sha512-aPvkXyU2SPOnztlgo8n9cEiXW755mgyvueUPcpStqdzoSPm0fjO0vQBjLkt3JKJW7ufikfcnMTTPsN1xaTsBPA==",
           "requires": {
             "esutils": "^2.0.2",
             "lodash": "^4.17.11",
@@ -2665,7 +2662,8 @@
       "dependencies": {
         "dotenv": {
           "version": "7.0.0",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-7.0.0.tgz",
+          "integrity": "sha512-M3NhsLbV1i6HuGzBUH8vXrtxOk+tWmzWKDMbAVSUp3Zsjm7ywFeuwrUXhmhQyRK1q5B5GGy7hcXPbj3bnfZg2g=="
         }
       }
     },
@@ -11953,7 +11951,8 @@
       "dependencies": {
         "dotenv": {
           "version": "7.0.0",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-7.0.0.tgz",
+          "integrity": "sha512-M3NhsLbV1i6HuGzBUH8vXrtxOk+tWmzWKDMbAVSUp3Zsjm7ywFeuwrUXhmhQyRK1q5B5GGy7hcXPbj3bnfZg2g=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "scripts": {
     "azure": "npm ci && npm run test:ci",
-    "clean": "git clean -dfqX -- ./node_modules **/{lib,node_modules}/",
+    "clean": "git clean -dfqX -- ./node_modules **/{lib,node_modules}/ ./packages/*/tsconfig.tsbuildinfo",
     "postinstall": "npm run build",
     "build": "lerna run build --stream --scope apollo-env && npm run compile && lerna run build --stream --ignore apollo-env",
     "compile": "tsc --build tsconfig.json",


### PR DESCRIPTION
Fixes entries in the package-lock file related to @oclif/config. A subsequent `npm install` also cleaned up the `bundled: true` entries which were a result of #1150.

Added `tsconfig.tsbuildinfo` files to the `clean` npm-script, since there's some weirdness with leaving the cache files across `npm install`s that leaves the developer in a bad state.

`npm run clean && npm install`
Fixes #1157

<!--
  Thanks for filing a pull request on Apollo Tooling!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [ ] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [ ] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass

\*Make sure changelog entries note which project(s) has been affected. See older entries for examples on what this looks like.
