### PR TITLE
Add vue as supported language to extract gql

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,12 @@
 
 ## Upcoming
 
+## `apollo-language-server`
+
 - apollo-language-server
   - Stop loadConfig from looking up the tree when a --config location is defined [#1059](https://github.com/apollographql/apollo-tooling/pull/1059)
   - Refactored/documented/tested loadConfig [#1059](https://github.com/apollographql/apollo-tooling/pull/1059)
+  - Add `.vue` file support for codegen:generate [#1160](https://github.com/apollographql/apollo-tooling/pull/1160)
 
 ## `apollo-codegen-flow@0.32.11`
 

--- a/packages/apollo-language-server/src/document.ts
+++ b/packages/apollo-language-server/src/document.ts
@@ -64,6 +64,7 @@ export function extractGraphQLDocuments(
     case "javascriptreact":
     case "typescript":
     case "typescriptreact":
+    case "vue":
       return extractGraphQLDocumentsFromJSTemplateLiterals(document, tagName);
     case "python":
       return extractGraphQLDocumentsFromPythonStrings(document, tagName);

--- a/packages/apollo-language-server/src/project/base.ts
+++ b/packages/apollo-language-server/src/project/base.ts
@@ -39,6 +39,7 @@ const fileAssociations: { [extension: string]: string } = {
   ".ts": "typescript",
   ".jsx": "javascriptreact",
   ".tsx": "typescriptreact",
+  ".vue": "vue",
   ".py": "python"
 };
 

--- a/packages/vscode-apollo/src/languageServerClient.ts
+++ b/packages/vscode-apollo/src/languageServerClient.ts
@@ -51,7 +51,7 @@ export function getLanguageServerClient(
     synchronize: {
       fileEvents: [
         workspace.createFileSystemWatcher("**/.env"),
-        workspace.createFileSystemWatcher("**/*.{graphql,js,ts,jsx,tsx,py}")
+        workspace.createFileSystemWatcher("**/*.{graphql,js,ts,jsx,tsx,vue,py}")
       ]
     },
     outputChannel

--- a/packages/vscode-apollo/src/languageServerClient.ts
+++ b/packages/vscode-apollo/src/languageServerClient.ts
@@ -45,6 +45,7 @@ export function getLanguageServerClient(
       "typescript",
       "javascriptreact",
       "typescriptreact",
+      "vue",
       "python"
     ],
     synchronize: {


### PR DESCRIPTION
Adds support for vue.  Uses the same extracter as `typescript`/`javacript`/ `___react`.

Just works by adding to list of supported languages.


### TODO:

- [x] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [X] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [X] Make sure all tests and linter rules pass
