### PR TITLE
UI-317 Add clients and number of operations checked to markdown output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Upcoming
 
+- apollo
+  - Update `service:check`'s `--markdown` output to include clients affected, number of operations checked, pluralization improvements, and backticks around service and schema variant [#1164](https://github.com/apollographql/apollo-tooling/pull/1164)
+
 ## `apollo@2.8.1`
 
 - `apollo@2.8.1`

--- a/packages/apollo-language-server/src/engine/operations/checkSchema.ts
+++ b/packages/apollo-language-server/src/engine/operations/checkSchema.ts
@@ -20,6 +20,9 @@ export const CHECK_SCHEMA = gql`
         targetUrl
         diffToPrevious {
           type
+          affectedClients {
+            __typename
+          }
           affectedQueries {
             __typename
           }

--- a/packages/apollo-language-server/src/graphqlTypes.ts
+++ b/packages/apollo-language-server/src/graphqlTypes.ts
@@ -6,6 +6,10 @@
 // GraphQL mutation operation: CheckSchema
 // ====================================================
 
+export interface CheckSchema_service_checkSchema_diffToPrevious_affectedClients {
+  __typename: "AffectedClient";
+}
+
 export interface CheckSchema_service_checkSchema_diffToPrevious_affectedQueries {
   __typename: "AffectedQuery";
 }
@@ -44,6 +48,10 @@ export interface CheckSchema_service_checkSchema_diffToPrevious_validationConfig
 export interface CheckSchema_service_checkSchema_diffToPrevious {
   __typename: "SchemaDiff";
   type: ChangeType;
+  /**
+   * Clients affected by all changes in diff
+   */
+  affectedClients: CheckSchema_service_checkSchema_diffToPrevious_affectedClients[] | null;
   /**
    * Operations affected by all changes in diff
    */

--- a/packages/apollo/src/commands/service/__tests__/check.test.ts
+++ b/packages/apollo/src/commands/service/__tests__/check.test.ts
@@ -31,8 +31,8 @@ describe("service:check", () => {
 "
 ### Apollo Service Check
 🔄 Validated your local schema against schema tag 'staging' on service 'engine'.
-🔢 Compared **18 schema changes** against operations seen over the **last 24 hours**.
-❌ Found **7 breaking changes** that would affect **3 operations**
+🔢 Compared **18 schema changes** against **100 operations** seen over the **last 24 hours**.
+❌ Found **7 breaking changes** that would affect **3 operations** across **2 clients**
 
 🔗 [View your service check details](https://engine-dev.apollographql.com/service/engine/checks?schemaTag=Detached%3A%20d664f715645c5f0bb5ad4f2260cd6cb8d19bbc68&schemaTagId=f9f68e7e-1b5f-4eab-a3da-1fd8cd681111&from=2019-03-26T22%3A25%3A12.887Z).
 "
@@ -88,7 +88,7 @@ describe("service:check", () => {
 "
 ### Apollo Service Check
 🔄 Validated your local schema against schema tag 'staging' on service 'engine'.
-🔢 Compared **0 schema changes** against operations seen over the **last 24 hours**.
+🔢 Compared **0 schema changes** against **100 operations** seen over the **last 24 hours**.
 ✅ Found **no breaking changes**.
 
 🔗 [View your service check details](https://engine-dev.apollographql.com/service/engine/checks?schemaTag=Detached%3A%20d664f715645c5f0bb5ad4f2260cd6cb8d19bbc68&schemaTagId=f9f68e7e-1b5f-4eab-a3da-1fd8cd681111&from=2019-03-26T22%3A25%3A12.887Z).

--- a/packages/apollo/src/commands/service/__tests__/check.test.ts
+++ b/packages/apollo/src/commands/service/__tests__/check.test.ts
@@ -46,6 +46,9 @@ describe("service:check", () => {
             ...checkSchemaResult,
             diffToPrevious: {
               ...checkSchemaResult.diffToPrevious,
+              affectedClients: [
+                checkSchemaResult.diffToPrevious.affectedClients[0]
+              ],
               affectedQueries: [
                 checkSchemaResult.diffToPrevious.affectedQueries[0]
               ],
@@ -53,7 +56,8 @@ describe("service:check", () => {
                 checkSchemaResult.diffToPrevious.changes.find(
                   change => change.type === ChangeType.FAILURE
                 )
-              ]
+              ],
+              numberOfCheckedOperations: 1
             }
           }
         })
@@ -61,8 +65,8 @@ describe("service:check", () => {
 "
 ### Apollo Service Check
 🔄 Validated your local schema against schema tag 'staging' on service 'engine'.
-🔢 Compared **1 schema change** against operations seen over the **last 24 hours**.
-❌ Found **1 breaking change** that would affect **1 operation**
+🔢 Compared **1 schema change** against **1 operation** seen over the **last 24 hours**.
+❌ Found **1 breaking change** that would affect **1 operation** across **1 client**
 
 🔗 [View your service check details](https://engine-dev.apollographql.com/service/engine/checks?schemaTag=Detached%3A%20d664f715645c5f0bb5ad4f2260cd6cb8d19bbc68&schemaTagId=f9f68e7e-1b5f-4eab-a3da-1fd8cd681111&from=2019-03-26T22%3A25%3A12.887Z).
 "
@@ -79,6 +83,7 @@ describe("service:check", () => {
             diffToPrevious: {
               ...checkSchemaResult.diffToPrevious,
               type: ChangeType.NOTICE,
+              affectedClients: [],
               affectedQueries: [],
               changes: []
             }

--- a/packages/apollo/src/commands/service/__tests__/check.test.ts
+++ b/packages/apollo/src/commands/service/__tests__/check.test.ts
@@ -30,7 +30,7 @@ describe("service:check", () => {
       ).toMatchInlineSnapshot(`
 "
 ### Apollo Service Check
-🔄 Validated your local schema against schema tag 'staging' on service 'engine'.
+🔄 Validated your local schema against schema tag \`staging\` on service \`engine\`.
 🔢 Compared **18 schema changes** against **100 operations** seen over the **last 24 hours**.
 ❌ Found **7 breaking changes** that would affect **3 operations** across **2 clients**
 
@@ -64,7 +64,7 @@ describe("service:check", () => {
       ).toMatchInlineSnapshot(`
 "
 ### Apollo Service Check
-🔄 Validated your local schema against schema tag 'staging' on service 'engine'.
+🔄 Validated your local schema against schema tag \`staging\` on service \`engine\`.
 🔢 Compared **1 schema change** against **1 operation** seen over the **last 24 hours**.
 ❌ Found **1 breaking change** that would affect **1 operation** across **1 client**
 
@@ -92,7 +92,7 @@ describe("service:check", () => {
       ).toMatchInlineSnapshot(`
 "
 ### Apollo Service Check
-🔄 Validated your local schema against schema tag 'staging' on service 'engine'.
+🔄 Validated your local schema against schema tag \`staging\` on service \`engine\`.
 🔢 Compared **0 schema changes** against **100 operations** seen over the **last 24 hours**.
 ✅ Found **no breaking changes**.
 

--- a/packages/apollo/src/commands/service/__tests__/check.test.ts
+++ b/packages/apollo/src/commands/service/__tests__/check.test.ts
@@ -37,6 +37,36 @@ describe("service:check", () => {
 🔗 [View your service check details](https://engine-dev.apollographql.com/service/engine/checks?schemaTag=Detached%3A%20d664f715645c5f0bb5ad4f2260cd6cb8d19bbc68&schemaTagId=f9f68e7e-1b5f-4eab-a3da-1fd8cd681111&from=2019-03-26T22%3A25%3A12.887Z).
 "
 `);
+      // Check when all the values are singluar
+      expect(
+        formatMarkdown({
+          serviceName: "engine",
+          tag: "staging",
+          checkSchemaResult: {
+            ...checkSchemaResult,
+            diffToPrevious: {
+              ...checkSchemaResult.diffToPrevious,
+              affectedQueries: [
+                checkSchemaResult.diffToPrevious.affectedQueries[0]
+              ],
+              changes: [
+                checkSchemaResult.diffToPrevious.changes.find(
+                  change => change.type === ChangeType.FAILURE
+                )
+              ]
+            }
+          }
+        })
+      ).toMatchInlineSnapshot(`
+"
+### Apollo Service Check
+🔄 Validated your local schema against schema tag 'staging' on service 'engine'.
+🔢 Compared **1 schema change** against operations seen over the **last 24 hours**.
+❌ Found **1 breaking change** that would affect **1 operation**
+
+🔗 [View your service check details](https://engine-dev.apollographql.com/service/engine/checks?schemaTag=Detached%3A%20d664f715645c5f0bb5ad4f2260cd6cb8d19bbc68&schemaTagId=f9f68e7e-1b5f-4eab-a3da-1fd8cd681111&from=2019-03-26T22%3A25%3A12.887Z).
+"
+`);
     });
 
     it("is correct with no breaking changes", () => {

--- a/packages/apollo/src/commands/service/__tests__/fixtures/check-schema-result.json
+++ b/packages/apollo/src/commands/service/__tests__/fixtures/check-schema-result.json
@@ -2,6 +2,15 @@
   "targetUrl": "https://engine-dev.apollographql.com/service/engine/checks?schemaTag=Detached%3A%20d664f715645c5f0bb5ad4f2260cd6cb8d19bbc68&schemaTagId=f9f68e7e-1b5f-4eab-a3da-1fd8cd681111&from=2019-03-26T22%3A25%3A12.887Z",
   "diffToPrevious": {
     "type": "FAILURE",
+    "numberOfCheckedOperations": 100,
+    "affectedClients": [
+      {
+        "__typename": "AffectedClient"
+      },
+      {
+        "__typename": "AffectedClient"
+      }
+    ],
     "affectedQueries": [
       {
         "__typename": "AffectedQuery"

--- a/packages/apollo/src/commands/service/check.ts
+++ b/packages/apollo/src/commands/service/check.ts
@@ -14,6 +14,14 @@ import { ApolloConfig } from "apollo-language-server";
 import moment from "moment";
 import sortBy from "lodash.sortby";
 
+function pluralize(
+  quantity: number | null,
+  singular: string,
+  plural: string = `${singular}s`
+) {
+  return `${quantity} ${quantity === 1 ? singular : plural}`;
+}
+
 const formatChange = (change: Change) => {
   let color = (x: string): string => x;
   if (change.type === ChangeType.FAILURE) {
@@ -39,12 +47,10 @@ const formatChange = (change: Change) => {
 
 export function formatTimePeriod(hours: number): string {
   if (hours <= 24) {
-    return hours === 1 ? `${hours} hour` : `${hours} hours`;
+    return pluralize(hours, "hour");
   }
 
-  const days = Math.floor(hours / 24);
-
-  return days === 1 ? `${days} day` : `${days} days`;
+  return pluralize(Math.floor(hours / 24), "day");
 }
 
 interface TasksOutput {
@@ -88,26 +94,24 @@ export function formatMarkdown({
     change => change.type === "FAILURE"
   );
 
+  const affectedQueryCount = diffToPrevious.affectedQueries
+    ? diffToPrevious.affectedQueries.length
+    : 0;
+
   return `
 ### Apollo Service Check
 🔄 Validated your local schema against schema tag \'${tag}\' on service \'${serviceName}\'.
-🔢 Compared **${
-    diffToPrevious.changes.length
-  } schema changes** against operations seen over the **last ${formatTimePeriod(
-    hours
-  )}**.
+🔢 Compared **${pluralize(
+    diffToPrevious.changes.length,
+    "schema change"
+  )}** against operations seen over the **last ${formatTimePeriod(hours)}**.
 ${
   breakingChanges.length > 0
-    ? `❌ Found **${
+    ? `❌ Found **${pluralize(
         diffToPrevious.changes.filter(change => change.type === "FAILURE")
-          .length
-      } breaking changes** that would affect **${
-        diffToPrevious.affectedQueries
-          ? // Our schema allows `affectedQueries` to be `null` even if we have `breakingChanges`, so we have to
-            // check for it :shrug:
-            diffToPrevious.affectedQueries.length
-          : "no"
-      } operations**`
+          .length,
+        "breaking change"
+      )}** that would affect **${pluralize(affectedQueryCount, "operation")}**`
     : `✅ Found **no breaking changes**.`
 }
 
@@ -300,11 +304,12 @@ export default class ServiceCheck extends ProjectCommand {
 
               task.title = `Compared ${chalk.blue(
                 schemaChanges.length.toString()
-              )} schema ${
-                schemaChanges.length === 1 ? "change" : "changes"
-              } against ${chalk.blue(numberOfCheckedOperations.toString())} ${
-                numberOfCheckedOperations === 1 ? "operation" : "operations"
-              }${
+              )} schema ${pluralize(
+                schemaChanges.length,
+                "change"
+              )} against ${chalk.blue(
+                numberOfCheckedOperations.toString()
+              )} ${pluralize(numberOfCheckedOperations, "operation")}${
                 hours
                   ? ` over the last ${chalk.blue(formatTimePeriod(hours))}`
                   : ""
@@ -323,13 +328,15 @@ export default class ServiceCheck extends ProjectCommand {
 
               task.title = `Found ${chalk.blue(
                 breakingSchemaChangeCount.toString()
-              )} breaking ${
-                breakingSchemaChangeCount === 1 ? "change" : "changes"
-              } and ${chalk.blue(
+              )} breaking ${pluralize(
+                breakingSchemaChangeCount,
+                "change"
+              )} and ${chalk.blue(
                 nonBreakingSchemaChangeCount.toString()
-              )} compatible ${
-                nonBreakingSchemaChangeCount === 1 ? "change" : "changes"
-              }`;
+              )} compatible ${pluralize(
+                nonBreakingSchemaChangeCount,
+                "change"
+              )}`;
 
               if (breakingSchemaChangeCount) {
                 // Throw an error here to produce a red X in the list of steps being taken. We're going to

--- a/packages/apollo/src/commands/service/check.ts
+++ b/packages/apollo/src/commands/service/check.ts
@@ -100,7 +100,7 @@ export function formatMarkdown({
 
   return `
 ### Apollo Service Check
-🔄 Validated your local schema against schema tag \'${tag}\' on service \'${serviceName}\'.
+🔄 Validated your local schema against schema tag \`${tag}\` on service \`${serviceName}\`.
 🔢 Compared **${pluralize(
     diffToPrevious.changes.length,
     "schema change"

--- a/packages/apollo/src/commands/service/check.ts
+++ b/packages/apollo/src/commands/service/check.ts
@@ -104,14 +104,23 @@ export function formatMarkdown({
 🔢 Compared **${pluralize(
     diffToPrevious.changes.length,
     "schema change"
-  )}** against operations seen over the **last ${formatTimePeriod(hours)}**.
+  )}** against **${pluralize(
+    diffToPrevious.numberOfCheckedOperations,
+    "operation"
+  )}** seen over the **last ${formatTimePeriod(hours)}**.
 ${
   breakingChanges.length > 0
     ? `❌ Found **${pluralize(
         diffToPrevious.changes.filter(change => change.type === "FAILURE")
           .length,
         "breaking change"
-      )}** that would affect **${pluralize(affectedQueryCount, "operation")}**`
+      )}** that would affect **${pluralize(
+        affectedQueryCount,
+        "operation"
+      )}** across **${pluralize(
+        diffToPrevious.affectedClients && diffToPrevious.affectedClients.length,
+        "client"
+      )}**`
     : `✅ Found **no breaking changes**.`
 }
 


### PR DESCRIPTION
This also:

- Adds tests for the singular version of nouns in the markdown. Some were not being pluralized correctly, now we're checking it.
- Replace `'` with backticks in some places


TODO:

- [x] ~Update CHANGELOG.md\* with your change (include reference to issue & this PR)~

    This piggybacks on other related PRs; this doesn't need to change the changelog

- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
