### PR TITLE
service:check add git info back

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Upcoming
 
+- `apollo`
+  - Add git info back to `checkSchema` to fix detail links[#1165](https://github.com/apollographql/apollo-tooling/pull/1165)
+
 ## `apollo@2.8.0`
 
 - `apollo@2.8.0`

--- a/packages/apollo-language-server/src/graphqlTypes.ts
+++ b/packages/apollo-language-server/src/graphqlTypes.ts
@@ -77,9 +77,14 @@ export interface CheckSchema_service_checkSchema {
 export interface CheckSchema_service {
   __typename: "ServiceMutation";
   /**
-   * Validate, diff, and store a schema so the diff
-   * can be viewed by users in the UI. This mutation
-   * will not mark the schema as "published"
+   * Validate, diff, and store a schema so the diff can be viewed by users in the UI.
+   * This mutation will not mark the schema as "published".
+   * 
+   * One of "proposedSchema" or "proposedSchemaHash" must be provided.
+   * If both are provided, the computed schema hash will be compared with the input hash,
+   * an error will be returned if the hashes don't match.
+   * 
+   * If the "proposedSchemaHash" is specified, the already stored schema will be loaded.
    */
   checkSchema: CheckSchema_service_checkSchema;
 }

--- a/packages/apollo/src/commands/service/check.ts
+++ b/packages/apollo/src/commands/service/check.ts
@@ -49,7 +49,6 @@ export function formatTimePeriod(hours: number): string {
 
 interface TasksOutput {
   config: ApolloConfig;
-  gitContext?: GitContext;
   checkSchemaResult: CheckSchema_service_checkSchema;
   shouldOutputJson: boolean;
   shouldOutputMarkdown: boolean;
@@ -237,6 +236,7 @@ export default class ServiceCheck extends ProjectCommand {
               task.output = "Resolving schema";
 
               const schema = await project.resolveSchema({ tag });
+              await gitInfo(this.log);
 
               const historicParameters = validateHistoricParams({
                 validationPeriod: flags.validationPeriod,
@@ -254,12 +254,11 @@ export default class ServiceCheck extends ProjectCommand {
                   // XXX Looks like TS should be generating ReadonlyArrays instead
                   schema: introspectionFromSchema(schema).__schema,
                   tag: flags.tag,
-                  gitContext: ctx.gitContext,
+                  gitContext: await gitInfo(this.log),
                   frontend: flags.frontend || config.engine.frontend,
                   ...(historicParameters && { historicParameters })
                 }),
                 config,
-                gitContext: await gitInfo(this.log),
                 shouldOutputJson: !!flags.json,
                 shouldOutputMarkdown: !!flags.markdown
               };
@@ -355,7 +354,6 @@ export default class ServiceCheck extends ProjectCommand {
     }
 
     const {
-      gitContext,
       checkSchemaResult,
       config,
       shouldOutputJson,


### PR DESCRIPTION
In order to have the check details show up, we need to add the git
information to `checkSchema`. This PR adds that back in

- [x] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass

![image](https://user-images.githubusercontent.com/5565407/55522524-393e8000-563a-11e9-8228-6b9a821cc991.png)