### PR TITLE
Only write generated code once

### DIFF
--- a/packages/apollo/src/commands/client/codegen.ts
+++ b/packages/apollo/src/commands/client/codegen.ts
@@ -198,11 +198,6 @@ export default class Generate extends ClientCommand {
                 );
               };
 
-              // project.validationDidFinish(write);
-              project.onDiagnostics(({ uri }) => {
-                write();
-              });
-
               const writtenFiles = write();
 
               task.title = `Generating query files with '${inferredTarget}' target - wrote ${writtenFiles} files`;


### PR DESCRIPTION
Fixes https://github.com/apollographql/apollo-tooling/issues/1180 by to only write generated code once by dropping the hook on `onDiagnostics`

This is probably not the right fix for this issue as I don't understand very well what diagnostics are meant for ... 

TODO:

- [ ] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [ ] Make sure all of the significant new logic is covered by tests
- [x ] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass

\*Make sure changelog entries note which project(s) has been affected. See older entries for examples on what this looks like.
