### PR TITLE
Add ability to skip codegen for inline documents with `// @codegen-ignore` (typescript only)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Upcoming
 
 - `apollo`
-  - <First `apollo` related entry goes here>
+  - Add ability to ignore some inline documents in typescript codegen by prefixing with a `// @codegen-ignore` comment. [#1191](https://github.com/apollographql/apollo-tooling/pull/1191)
 - `apollo-codegen-core`
   - <First `apollo-codegen-core` related entry goes here>
 - `apollo-codegen-flow`

--- a/packages/apollo-language-server/package.json
+++ b/packages/apollo-language-server/package.json
@@ -41,6 +41,7 @@
     "moment": "^2.22.2",
     "recursive-readdir": "^2.2.2",
     "subscriptions-transport-ws": "^0.9.15",
+    "typescript": "^3.4.3",
     "vscode-languageserver": "^5.1.0",
     "vscode-uri": "^1.0.6",
     "ws": "^6.1.0"

--- a/packages/apollo-language-server/src/utilities/typescript/__tests__/extraction.ts
+++ b/packages/apollo-language-server/src/utilities/typescript/__tests__/extraction.ts
@@ -26,7 +26,7 @@ describe("Typescript code extraction", () => {
       expect(templates[0]).toBe("considered");
     });
 
-    it("processes anonymously declared documents ", () => {
+    it("processes anonymously declared documents", () => {
       const source = `
         bar(foo\`foo in function call\`);
 

--- a/packages/apollo-language-server/src/utilities/typescript/__tests__/extraction.ts
+++ b/packages/apollo-language-server/src/utilities/typescript/__tests__/extraction.ts
@@ -1,0 +1,43 @@
+import { extractTemplateLiterals } from "../extraction";
+
+describe("Typescript code extraction", () => {
+  describe("extractTemplateLiterals", () => {
+    it("filters out templates with wrong tag", () => {
+      const source = `
+        const foo = foo\`foo code\`;
+        const bar = bar\`bar code\`;
+      `;
+      const templates = extractTemplateLiterals("foo", source);
+      expect(templates.length).toEqual(1);
+      expect(templates[0]).toBe("foo code");
+    });
+
+    it("filters out codegen ignored tags", () => {
+      const source = `
+        const consiered = gql\`considered\`;
+
+        // some comments here
+        // as long as @codegen-ignore is contained
+        // and there
+        const ignored = gql\`ignored\`;
+      `;
+      const templates = extractTemplateLiterals("gql", source);
+      expect(templates.length).toEqual(1);
+      expect(templates[0]).toBe("considered");
+    });
+
+    it("processes anonymously declared documents ", () => {
+      const source = `
+        bar(foo\`foo in function call\`);
+
+        function fn(thing: DocumentNode = foo\`foo in default arg\`) {
+          // body
+        }
+      `;
+      const templates = extractTemplateLiterals("foo", source);
+      expect(templates.length).toEqual(2);
+      expect(templates[0]).toBe("foo in function call");
+      expect(templates[1]).toBe("foo in default arg");
+    });
+  });
+});

--- a/packages/apollo-language-server/src/utilities/typescript/extraction.ts
+++ b/packages/apollo-language-server/src/utilities/typescript/extraction.ts
@@ -1,0 +1,79 @@
+import * as ts from "typescript";
+
+function findClosestParent(node: ts.Node, kind: ts.SyntaxKind): ts.Node | null {
+  let current: ts.Node | null = node;
+  while (current && current.kind !== kind) {
+    current = current.parent;
+  }
+
+  return current;
+}
+
+function getCommentText(code: string, range: ts.CommentRange): string {
+  return code.substring(range.pos, range.end);
+}
+
+function shouldProcessNode(
+  tagName: string,
+  sourceCode: string,
+  node: ts.Node
+): node is ts.TaggedTemplateExpression {
+  if (!ts.isTaggedTemplateExpression(node) || node.tag.getText() !== tagName) {
+    return false;
+  }
+
+  const variableNode = findClosestParent(
+    node,
+    ts.SyntaxKind.VariableDeclarationList
+  );
+
+  // document not declared via const/let
+  // don't try finding leading comments and just process the node
+  if (!variableNode) {
+    return true;
+  }
+
+  const comments = ts.getLeadingCommentRanges(
+    sourceCode,
+    variableNode.getFullStart()
+  );
+
+  const ignored =
+    comments &&
+    comments.some(
+      c => getCommentText(sourceCode, c).indexOf("@codegen-ignore") > -1
+    );
+
+  return !ignored;
+}
+
+function reduceTemplateLiterals(
+  tagName: string,
+  sourceCode: string,
+  result: string[],
+  node: ts.Node
+): void {
+  if (shouldProcessNode(tagName, sourceCode, node)) {
+    result.push(node.template.getText().slice(1, -1));
+  }
+  node.forEachChild(child =>
+    reduceTemplateLiterals(tagName, sourceCode, result, child)
+  );
+}
+
+function extractTemplateLiterals(
+  tagName: string,
+  sourceCode: string
+): string[] {
+  const sourceFile = ts.createSourceFile(
+    "dummy.ts",
+    sourceCode,
+    ts.ScriptTarget.Latest,
+    true
+  );
+  const contents: string[] = [];
+  reduceTemplateLiterals(tagName, sourceCode, contents, sourceFile);
+  return contents;
+}
+
+export { extractTemplateLiterals };


### PR DESCRIPTION
This adds the ability to skip codegen for some inline documents with a `// @codegen-ignore` comment which leads document variable declaration in typescript only eg:

```
  // @codegen-ignore
  const document = gql`
    ...
  `;
```

This might be a bit weird/out of scope, but this is something our team would benefit from since we use apollo also for queries against a rest api (apollo-link-rest) for which we don't have schema, hence can't be codegen.

There is a much easy/obvious workaround which is to simply create a runtime alias for our tagName tagged template function (eg: gqlNoGen) so those don't get picked up by codegen but I wanted to try see if we could have a solution that doesn't involve changing runtime. 

To do so this updates parsing of template literals in typescript code to use typescript parser instead of regexp, which may be a bit more robust but requires adding typescript as runtime dependency. 

TODO:

- [x] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass

\*Make sure changelog entries note which project(s) has been affected. See older entries for examples on what this looks like.
