### PR TITLE
Update federated service:check output

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2225,6 +2225,7 @@
         "heroku-cli-util": "8.0.11",
         "listr": "0.14.3",
         "lodash": "4.17.11",
+        "strip-ansi": "5.2.0",
         "tty": "1.0.1",
         "vscode-uri": "1.0.6"
       },

--- a/packages/apollo-language-server/src/engine/operations/checkPartialSchema.ts
+++ b/packages/apollo-language-server/src/engine/operations/checkPartialSchema.ts
@@ -13,7 +13,7 @@ export const CHECK_PARTIAL_SCHEMA = gql`
         implementingServiceName: $implementingServiceName
         partialSchema: $partialSchema
       ) {
-        compositionConfig {
+        compositionValidationDetails {
           schemaHash
         }
         errors {
@@ -22,7 +22,6 @@ export const CHECK_PARTIAL_SCHEMA = gql`
         warnings {
           message
         }
-        didUpdateGateway: updatedGateway
       }
     }
   }

--- a/packages/apollo-language-server/src/graphqlTypes.ts
+++ b/packages/apollo-language-server/src/graphqlTypes.ts
@@ -6,8 +6,8 @@
 // GraphQL mutation operation: CheckPartialSchema
 // ====================================================
 
-export interface CheckPartialSchema_service_validatePartialSchemaOfImplementingServiceAgainstGraph_compositionConfig {
-  __typename: "CompositionConfig";
+export interface CheckPartialSchema_service_validatePartialSchemaOfImplementingServiceAgainstGraph_compositionValidationDetails {
+  __typename: "CompositionValidationDetails";
   /**
    * Hash of the composed schema
    */
@@ -25,11 +25,13 @@ export interface CheckPartialSchema_service_validatePartialSchemaOfImplementingS
 }
 
 export interface CheckPartialSchema_service_validatePartialSchemaOfImplementingServiceAgainstGraph {
-  __typename: "CompositionResult";
+  __typename: "CompositionValidationResult";
   /**
-   * The produced composition config. Will be null if there are any errors
+   * Akin to a composition config, represents the partial schemas and implementing services that were used
+   * in running composition. Will be null if any errors are encountered. Also may contain a schema hash if
+   * one could be computed, which can be used for schema validation.
    */
-  compositionConfig: CheckPartialSchema_service_validatePartialSchemaOfImplementingServiceAgainstGraph_compositionConfig | null;
+  compositionValidationDetails: CheckPartialSchema_service_validatePartialSchemaOfImplementingServiceAgainstGraph_compositionValidationDetails | null;
   /**
    * List of errors during composition. Errors mean that Apollo was unable to compose the
    * graph's implementing services into a GraphQL schema. This partial schema should not be
@@ -44,10 +46,6 @@ export interface CheckPartialSchema_service_validatePartialSchemaOfImplementingS
    * in its composition result will result in updating the composition config.
    */
   warnings: (CheckPartialSchema_service_validatePartialSchemaOfImplementingServiceAgainstGraph_warnings | null)[];
-  /**
-   * Whether the gateway link was updated.
-   */
-  didUpdateGateway: boolean;
 }
 
 export interface CheckPartialSchema_service {

--- a/packages/apollo/package.json
+++ b/packages/apollo/package.json
@@ -60,6 +60,7 @@
     "heroku-cli-util": "8.0.11",
     "listr": "0.14.3",
     "lodash": "4.17.11",
+    "strip-ansi": "5.2.0",
     "tty": "1.0.1",
     "vscode-uri": "1.0.6"
   },

--- a/packages/apollo/src/commands/service/check.ts
+++ b/packages/apollo/src/commands/service/check.ts
@@ -13,13 +13,18 @@ import {
 import { ApolloConfig, GraphQLServiceProject } from "apollo-language-server";
 import moment from "moment";
 import sortBy from "lodash.sortby";
+import stripANSI from "strip-ansi";
 
 function pluralize(
-  quantity: number | null,
+  quantity: string | number | null,
   singular: string,
   plural: string = `${singular}s`
 ) {
-  return `${quantity} ${quantity === 1 ? singular : plural}`;
+  // Strip ansi color from `quantity` if it's a string
+  const strippedQuantity =
+    typeof quantity === "string" ? parseInt(stripANSI(quantity), 0) : quantity;
+
+  return `${quantity} ${strippedQuantity === 1 ? singular : plural}`;
 }
 
 const formatChange = (change: Change) => {


### PR DESCRIPTION
The purpose of this PR is to update how we display output from the federated `service:check` command. The style of this output resembles recent updates to the output of the standard `service:check` command.

![image](https://user-images.githubusercontent.com/29644393/56169126-05485080-5f92-11e9-9867-c21dcd0d5340.png)

![image](https://user-images.githubusercontent.com/29644393/56172475-7ee63b80-5f9e-11e9-9095-d89169216ee1.png)

<!--
  Thanks for filing a pull request on Apollo Tooling!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [ ] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [ ] Make sure all of the significant new logic is covered by tests
- [ ] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests and linter rules pass

\*Make sure changelog entries note which project(s) has been affected. See older entries for examples on what this looks like.
