### PR TITLE
Add documentation for the --header flag

### DIFF
--- a/packages/apollo-language-server/src/graphqlTypes.ts
+++ b/packages/apollo-language-server/src/graphqlTypes.ts
@@ -32,7 +32,21 @@ export interface CheckSchema_service_checkSchema_diffToPrevious_changes {
 
 export interface CheckSchema_service_checkSchema_diffToPrevious_validationConfig {
   __typename: "SchemaDiffValidationConfig";
+  /**
+   * delta in seconds from current time that determines the start of the
+   * window for reported metrics included in a schema diff. A day window
+   * from the present day would have a \`from\` value of -86400. In rare
+   * cases, this could be an ISO timestamp if the user passed one in on diff
+   * creation
+   */
   from: any | null;
+  /**
+   * delta in seconds from current time that determines the end of the
+   * window for reported metrics included in a schema diff. A day window
+   * from the present day would have a \`to\` value of -0. In rare
+   * cases, this could be an ISO timestamp if the user passed one in on diff
+   * creation
+   */
   to: any | null;
   /**
    * Minimum number of requests within the window for a query to be considered.

--- a/packages/apollo/src/Command.ts
+++ b/packages/apollo/src/Command.ts
@@ -71,7 +71,8 @@ export abstract class ProjectCommand extends Command {
         const value = header.substring(separatorIndex + 1).trim();
         return JSON.stringify({ [key]: value });
       },
-      description: "Additional headers to send to server for introspectionQuery"
+      description:
+        "Additional header to send to server for introspectionQuery. May be used multiple times to add multiple headers. NOTE: The `--endpoint` flag is REQUIRED if using the `--header` flag."
     }),
     endpoint: flags.string({
       description: "The url of your service"


### PR DESCRIPTION
The `--header` flag is supported for all `service` commands that use introspection, but it is required that you use the endpoint flag in order to use the headers. This just adds docs for that.

Related to #700 

<!--
  Thanks for filing a pull request on Apollo Tooling!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [ ] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [ ] Make sure all of the significant new logic is covered by tests
- [ ] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests and linter rules pass

\*Make sure changelog entries note which project(s) has been affected. See older entries for examples on what this looks like.
