### PR TITLE
Append terminating newline to output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 - `apollo-codegen-scala`
   - <First `apollo-codegen-scala` related entry goes here>
 - `apollo-codegen-swift`
-  - <First `apollo-codegen-swift` related entry goes here>
+  - Append terminating newline character to generated files [#531](https://github.com/apollographql/apollo-ios/issues/531)
 - `apollo-codegen-typescript`
   - <First `apollo-codegen-typescript` related entry goes here>
 - `apollo-env`

--- a/packages/apollo/src/commands/client/__tests__/__snapshots__/generate.test.ts.snap
+++ b/packages/apollo/src/commands/client/__tests__/__snapshots__/generate.test.ts.snap
@@ -208,7 +208,8 @@ public final class SimpleQueryQuery: GraphQLQuery {
       }
     }
   }
-}"
+}
+"
 `;
 
 exports[`client:codegen writes swift types from local schema in a graphql file 1`] = `
@@ -249,7 +250,8 @@ public final class SimpleQueryQuery: GraphQLQuery {
       }
     }
   }
-}"
+}
+"
 `;
 
 exports[`client:codegen writes types for query with only client-side data 1`] = `

--- a/packages/apollo/src/generate.ts
+++ b/packages/apollo/src/generate.ts
@@ -73,10 +73,10 @@ export default function generate(
     const generator = generateSwiftSource(context, outputIndividualFiles, only);
 
     if (outputIndividualFiles) {
-      writeGeneratedFiles(generator.generatedFiles, outputPath);
+      writeGeneratedFiles(generator.generatedFiles, outputPath, "\n");
       writtenFiles += Object.keys(generator.generatedFiles).length;
     } else {
-      fs.writeFileSync(outputPath, generator.output);
+      fs.writeFileSync(outputPath, generator.output.concat("\n"));
       writtenFiles += 1;
     }
 
@@ -215,12 +215,13 @@ export default function generate(
 
 function writeGeneratedFiles(
   generatedFiles: { [fileName: string]: BasicGeneratedFile },
-  outputDirectory: string
+  outputDirectory: string,
+  terminator: string = ""
 ) {
   for (const [fileName, generatedFile] of Object.entries(generatedFiles)) {
     fs.writeFileSync(
       path.join(outputDirectory, fileName),
-      generatedFile.output
+      generatedFile.output.concat(terminator)
     );
   }
 }


### PR DESCRIPTION
Xcode expects newline terminated files as noted in https://github.com/apollographql/apollo-ios/issues/531. I found this related PR https://github.com/apollographql/apollo-tooling/pull/525/, so maybe a more generic solution should be considered.

This is my first contribution to this project, let alone my first lines of TypeScript, but I hope its intention comes across.