### PR TITLE
Skip redundant modifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 - `apollo-codegen-scala`
   - <First `apollo-codegen-scala` related entry goes here>
 - `apollo-codegen-swift`
-  - <First `apollo-codegen-swift` related entry goes here>
+  - Prevent compiler warnings for redundant access-level modifiers when using `--namespace` [1241](https://github.com/apollographql/apollo-tooling/pull/1241)
 - `apollo-codegen-typescript`
   - <First `apollo-codegen-typescript` related entry goes here>
 - `apollo-env`

--- a/packages/apollo-codegen-swift/src/__tests__/language.ts
+++ b/packages/apollo-codegen-swift/src/__tests__/language.ts
@@ -29,6 +29,26 @@ describe("Swift code generation: Basic language constructs", () => {
     `);
   });
 
+  it(`should generate a class declaration matching modifiers`, () => {
+    generator.classDeclaration(
+      { className: "Hero", modifiers: ["final"] },
+      () => {
+        generator.propertyDeclaration({
+          propertyName: "name",
+          typeName: "String"
+        });
+        generator.propertyDeclaration({ propertyName: "age", typeName: "Int" });
+      }
+    );
+
+    expect(generator.output).toBe(stripIndent`
+      final class Hero {
+        public var name: String
+        public var age: Int
+      }
+    `);
+  });
+
   it(`should generate a struct declaration`, () => {
     generator.structDeclaration({ structName: "Hero" }, () => {
       generator.propertyDeclaration({
@@ -40,6 +60,30 @@ describe("Swift code generation: Basic language constructs", () => {
 
     expect(generator.output).toBe(stripIndent`
       public struct Hero {
+        public var name: String
+        public var age: Int
+      }
+    `);
+  });
+
+  it(`should generate a namespaced fragment`, () => {
+    generator.structDeclaration(
+      {
+        structName: "Hero",
+        adoptedProtocols: ["GraphQLFragment"],
+        namespace: "StarWars"
+      },
+      () => {
+        generator.propertyDeclaration({
+          propertyName: "name",
+          typeName: "String"
+        });
+        generator.propertyDeclaration({ propertyName: "age", typeName: "Int" });
+      }
+    );
+
+    expect(generator.output).toBe(stripIndent`
+      struct Hero: GraphQLFragment {
         public var name: String
         public var age: Int
       }

--- a/packages/apollo-codegen-swift/src/language.ts
+++ b/packages/apollo-codegen-swift/src/language.ts
@@ -13,6 +13,7 @@ export interface Struct {
   structName: string;
   adoptedProtocols?: string[];
   description?: string;
+  namespace?: string;
 }
 
 export interface Protocol {
@@ -136,13 +137,23 @@ export class SwiftGenerator<Context> extends CodeGenerator<
   }
 
   structDeclaration(
-    { structName, description, adoptedProtocols = [] }: Struct,
+    {
+      structName,
+      description,
+      adoptedProtocols = [],
+      namespace = undefined
+    }: Struct,
     closure: Function
   ) {
     this.printNewlineIfNeeded();
     this.comment(description);
+
+    const isRedundant =
+      adoptedProtocols.includes("GraphQLFragment") && !!namespace;
+    const modifier = isRedundant ? "" : "public ";
+
     this.printOnNewline(
-      `public struct ${escapeIdentifierIfNeeded(structName)}`
+      `${modifier}struct ${escapeIdentifierIfNeeded(structName)}`
     );
     this.print(wrap(": ", join(adoptedProtocols, ", ")));
     this.pushScope({ typeName: structName });


### PR DESCRIPTION
Resolves #1177. The goal is to prevent compiler warnings for redundant access-level modifiers when using `--namespace`.

It covers queries and fragments, according to basic testing at least, resolving the initial issue. Are there more types affected by this? @martijnwalraven 

- [x] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass