### PR TITLE
Change Slack to Spectrum in README.md

### DIFF
--- a/packages/apollo/README.md
+++ b/packages/apollo/README.md
@@ -1,6 +1,6 @@
 # Apollo CLI
 
-[![GitHub license](https://img.shields.io/badge/license-MIT-lightgrey.svg?maxAge=2592000)](https://raw.githubusercontent.com/apollographql/apollo-tooling/master/LICENSE) [![npm](https://img.shields.io/npm/v/apollo.svg)](https://www.npmjs.com/package/apollo) [![Get on Slack](https://img.shields.io/badge/slack-join-orange.svg)](http://www.apollostack.com/#slack)
+[![GitHub license](https://img.shields.io/badge/license-MIT-lightgrey.svg?maxAge=2592000)](https://raw.githubusercontent.com/apollographql/apollo-tooling/master/LICENSE) [![npm](https://img.shields.io/npm/v/apollo.svg)](https://www.npmjs.com/package/apollo) [![Get on Slack](https://img.shields.io/badge/spectrum-join-orange.svg)](https://spectrum.chat/apollo?tab=posts)
 
 Apollo CLI brings together your GraphQL clients and servers with tools for validating your schema, linting your operations for compatibility with your server, and generating static types for improved client-side type safety.
 


### PR DESCRIPTION
This PR changes the Slack badge to Spectrum badge

Old:
<img width="382" alt="Screenshot 2019-05-07 at 19 48 15" src="https://user-images.githubusercontent.com/29886766/57321187-1a338200-7101-11e9-9626-9a9f6eef7cea.png">

New:
<img width="378" alt="Screenshot 2019-05-07 at 19 49 27" src="https://user-images.githubusercontent.com/29886766/57321262-45b66c80-7101-11e9-9756-589f42ed2a96.png">

