### PR TITLE
Debug log before the call out to Engine

### DIFF
--- a/packages/apollo/src/commands/service/push.ts
+++ b/packages/apollo/src/commands/service/push.ts
@@ -44,6 +44,12 @@ export default class ServicePush extends ProjectCommand {
             gitContext
           };
 
+          const { schema: _, ...restVariables } = variables;
+          this.debug("Variables sent to Engine:");
+          this.debug(restVariables);
+          this.debug("SDL of introspection sent to Engine:");
+          this.debug(printSchema(schema));
+
           const response = await project.engine.uploadSchema(variables);
           if (response) {
             result = {
@@ -53,12 +59,6 @@ export default class ServicePush extends ProjectCommand {
               code: response.code
             };
           }
-
-          const { schema: _, ...restVariables } = variables;
-          this.debug("Variables sent to Engine:");
-          this.debug(restVariables);
-          this.debug("SDL of introspection sent to Engine:");
-          this.debug(printSchema(schema));
         }
       }
     ]);


### PR DESCRIPTION
Move logging above the call to engine so that logs are still produced in the event of a runtime error

TODO:

- [ ] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [ ] Make sure all of the significant new logic is covered by tests
- [ ] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests and linter rules pass

\*Make sure changelog entries note which project(s) has been affected. See older entries for examples on what this looks like.
