### PR TITLE
Import Foundation in codegen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 - `apollo-codegen-swift`
   - Ensure fields named `self` don't cause compilation errors in the generated code [#1533](https://github.com/apollographql/apollo-tooling/pull/1533)
   - Preserve leading/trailing underscores on field names [#1533](https://github.com/apollographql/apollo-tooling/pull/1533)
-  - Allow generated code to be compiled without a module umbrella header 1248](https://github.com/apollographql/apollo-tooling/pull/1248)
+  - Allow generated code to be compiled without a module umbrella header [#1248](https://github.com/apollographql/apollo-tooling/pull/1248)
 - `apollo-codegen-typescript`
   - <First `apollo-codegen-typescript` related entry goes here>
 - `apollo-env`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - `apollo-codegen-swift`
   - Ensure fields named `self` don't cause compilation errors in the generated code [#1533](https://github.com/apollographql/apollo-tooling/pull/1533)
   - Preserve leading/trailing underscores on field names [#1533](https://github.com/apollographql/apollo-tooling/pull/1533)
+  - Allow generated code to be compiled without a module umbrella header 1248](https://github.com/apollographql/apollo-tooling/pull/1248)
 - `apollo-codegen-typescript`
   - <First `apollo-codegen-typescript` related entry goes here>
 - `apollo-env`

--- a/packages/apollo-codegen-swift/src/codeGeneration.ts
+++ b/packages/apollo-codegen-swift/src/codeGeneration.ts
@@ -164,6 +164,7 @@ export class SwiftAPIGenerator extends SwiftGenerator<CompilerContext> {
     );
     this.printNewline();
     this.printOnNewline(swift`import Apollo`);
+    this.printOnNewline(swift`import Foundation`);
   }
 
   /**

--- a/packages/apollo/src/commands/client/__tests__/__snapshots__/generate.test.ts.snap
+++ b/packages/apollo/src/commands/client/__tests__/__snapshots__/generate.test.ts.snap
@@ -174,6 +174,7 @@ exports[`client:codegen writes swift types from local schema 1`] = `
 "//  This file was automatically generated and should not be edited.
 
 import Apollo
+import Foundation
 
 public final class SimpleQueryQuery: GraphQLQuery {
   /// The raw GraphQL definition of this operation.
@@ -223,6 +224,7 @@ exports[`client:codegen writes swift types from local schema in a graphql file 1
 "//  This file was automatically generated and should not be edited.
 
 import Apollo
+import Foundation
 
 public final class SimpleQueryQuery: GraphQLQuery {
   /// The raw GraphQL definition of this operation.


### PR DESCRIPTION
Hi folks! The Swift code-gen today requires that an Objective-C umbrella header be present that has an `import <UIKit/UIKit.h>` to compile. You can see this for yourself by running code-gen on any request/response that has a `Date` as a value or parameter. `Date` comes from `Foundation`, but there is no import of `Foundation`. Instead, the generated code implicitly relies on the `UIKit` import from an umbrella header to pull in `Foundation`.

This PR explicitly imports `Foundation` in the generated code, which allows consumers of Swift Apollo code-gen to no longer need an umbrella header.

TODO:

- [x] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass

\*Make sure changelog entries note which project(s) has been affected. See older entries for examples on what this looks like.