### PR TITLE
Add service:push debuggability

### DIFF
--- a/packages/apollo/src/commands/service/push.ts
+++ b/packages/apollo/src/commands/service/push.ts
@@ -1,9 +1,9 @@
 import { flags } from "@oclif/command";
 import { table } from "heroku-cli-util";
-import { introspectionFromSchema } from "graphql";
-
+import { introspectionFromSchema, printSchema } from "graphql";
 import { gitInfo } from "../../git";
 import { ProjectCommand } from "../../Command";
+import { UploadSchemaVariables } from "apollo-language-server/lib/graphqlTypes";
 
 export default class ServicePush extends ProjectCommand {
   static aliases = ["schema:publish"];
@@ -35,21 +35,30 @@ export default class ServicePush extends ProjectCommand {
           const schema = await project.resolveSchema({ tag: flags.tag });
           gitContext = await gitInfo(this.log);
 
-          const { tag, code } = await project.engine.uploadSchema({
+          const variables: UploadSchemaVariables = {
             id: config.name,
             // @ts-ignore
             // XXX Looks like TS should be generating ReadonlyArrays instead
             schema: introspectionFromSchema(schema).__schema,
             tag: flags.tag,
             gitContext
-          });
-
-          result = {
-            service: config.name,
-            hash: tag.schema.hash,
-            tag: tag.tag,
-            code
           };
+
+          const response = await project.engine.uploadSchema(variables);
+          if (response) {
+            result = {
+              service: config.name,
+              hash: response.tag ? response.tag.schema.hash : null,
+              tag: response.tag ? response.tag.tag : null,
+              code: response.code
+            };
+          }
+
+          const { schema: _, ...restVariables } = variables;
+          this.debug("Variables sent to Engine:");
+          this.debug(restVariables);
+          this.debug("SDL of introspection sent to Engine:");
+          this.debug(printSchema(schema));
         }
       }
     ]);


### PR DESCRIPTION
Leverage oclif debug logger to add visibility into variables sent to Engine during service:push.

<!--
  Thanks for filing a pull request on Apollo Tooling!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [x] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [ ] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass

\*Make sure changelog entries note which project(s) has been affected. See older entries for examples on what this looks like.
