### PR TITLE
apollo: add debug statements to service:check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Upcoming
 
 - `apollo`
-  - <First `apollo` related entry goes here>
+  - Add service:check debuggability [#1250](https://github.com/apollographql/apollo-tooling/pull/1250)
 - `apollo-codegen-core`
   - <First `apollo-codegen-core` related entry goes here>
 - `apollo-codegen-flow`


### PR DESCRIPTION
Currently there isn't an easy way to determine the variables sent to
engine by the apollo service:check command. This adds the ability to
turn on debug mode and print out those commands.

In order to show the statements, run `DEBUG=* apollo service:check`


<!--
  Thanks for filing a pull request on Apollo Tooling!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [x] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass

\*Make sure changelog entries note which project(s) has been affected. See older entries for examples on what this looks like.