### PR TITLE
feat: support importing existing enums instead of generating them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - `apollo-codegen-swift`
   - <First `apollo-codegen-swift` related entry goes here>
 - `apollo-codegen-typescript`
+  - Allow referring to existing enum instead of generating new one [#1253](https://github.com/apollographql/apollo-tooling/pull/1253)
   - <First `apollo-codegen-typescript` related entry goes here>
 - `apollo-env`
   - <First `apollo-env` related entry goes here>

--- a/packages/apollo-codegen-typescript/src/__tests__/__snapshots__/codeGeneration.ts.snap
+++ b/packages/apollo-codegen-typescript/src/__tests__/__snapshots__/codeGeneration.ts.snap
@@ -646,6 +646,66 @@ export interface HeroNameVariables {
 }
 `;
 
+exports[`Typescript codeGeneration local / global custom enum 1`] = `
+Array [
+  Object {
+    "content": TypescriptGeneratedFile {
+      "fileContents": "/* tslint:disable */
+/* eslint-disable */
+// This file was automatically generated and should not be edited.
+
+import { EnumCommentTestCase, Duplicate } from \\"./../../__generated__/globalTypes\\";
+
+// ====================================================
+// GraphQL mutation operation: duplicates
+// ====================================================
+
+export interface duplicates_duplicates {
+  propA: EnumCommentTestCase[][];
+  propB: ((EnumCommentTestCase | null)[] | null)[] | null;
+}
+
+export interface duplicates {
+  duplicates: duplicates_duplicates;
+}
+
+export interface duplicatesVariables {
+  a: EnumCommentTestCase;
+  b: EnumCommentTestCase;
+  c: Duplicate;
+}
+",
+    },
+    "fileName": "duplicates.ts",
+    "sourcePath": "GraphQL request",
+  },
+]
+`;
+
+exports[`Typescript codeGeneration local / global custom enum 2`] = `
+TypescriptGeneratedFile {
+  "fileContents": "/* tslint:disable */
+/* eslint-disable */
+// This file was automatically generated and should not be edited.
+
+//==============================================================
+// START Enums and Input Objects
+//==============================================================
+
+export { EnumCommentTestCase } from \\"my-types-lib\\";
+
+export interface Duplicate {
+  propA: EnumCommentTestCase;
+  propB: EnumCommentTestCase[];
+}
+
+//==============================================================
+// END Enums and Input Objects
+//==============================================================
+",
+}
+`;
+
 exports[`Typescript codeGeneration local / global duplicates 1`] = `
 Array [
   Object {

--- a/packages/apollo-codegen-typescript/src/__tests__/codeGeneration.ts
+++ b/packages/apollo-codegen-typescript/src/__tests__/codeGeneration.ts
@@ -19,6 +19,7 @@ import {
   generateLocalSource,
   generateGlobalSource
 } from "../codeGeneration";
+import { TypescriptCompilerOptions } from "../language";
 
 function compile(
   source: string,
@@ -33,7 +34,7 @@ function compile(
 
 function compileMisc(
   source: string,
-  options: CompilerOptions = {
+  options: TypescriptCompilerOptions = {
     mergeInFieldsFromFragmentSpreads: true,
     addTypename: true
   }
@@ -623,6 +624,34 @@ describe("Typescript codeGeneration local / global", () => {
         }
       }
     `);
+
+    const output = generateLocalSource(context).map(f => ({
+      ...f,
+      content: f.content({
+        outputPath: "/some/file/ComponentA.tsx",
+        globalSourcePath: "/__generated__/globalTypes.ts"
+      })
+    }));
+    expect(output).toMatchSnapshot();
+    expect(generateGlobalSource(context)).toMatchSnapshot();
+  });
+
+  test("custom enum", () => {
+    const context = compileMisc(
+      `
+    mutation duplicates($a: EnumCommentTestCase!, $b: EnumCommentTestCase!, $c: Duplicate!) {
+      duplicates(a: $a, b: $b, c: $c) {
+        propA
+        propB
+      }
+    }
+    `,
+      {
+        enums: {
+          EnumCommentTestCase: "my-types-lib#EnumCommentTestCase"
+        }
+      }
+    );
 
     const output = generateLocalSource(context).map(f => ({
       ...f,

--- a/packages/apollo-codegen-typescript/src/language.ts
+++ b/packages/apollo-codegen-typescript/src/language.ts
@@ -17,7 +17,7 @@ export type ObjectProperty = {
 };
 
 export interface TypescriptCompilerOptions extends CompilerOptions {
-  // Leaving this open for Typescript only compiler options
+  enums?: { [enumName: string]: string };
 }
 
 export default class TypescriptGenerator {
@@ -34,6 +34,19 @@ export default class TypescriptGenerator {
 
   public enumerationDeclaration(type: GraphQLEnumType) {
     const { name, description } = type;
+    if (this.options.enums && name in this.options.enums) {
+      const [importPath, importName] = this.options.enums[name].split("#");
+      return t.exportNamedDeclaration(
+        undefined,
+        [
+          t.exportSpecifier(
+            t.identifier(importName || "default"),
+            t.identifier(name)
+          )
+        ],
+        t.stringLiteral(importPath)
+      );
+    }
     const enumMembers = sortEnumValues(type.getValues()).map(({ value }) => {
       return t.TSEnumMember(t.identifier(value), t.stringLiteral(value));
     });

--- a/packages/apollo/src/commands/client/codegen.ts
+++ b/packages/apollo/src/commands/client/codegen.ts
@@ -103,6 +103,19 @@ export default class Generate extends ClientCommand {
   - a file will be written for each query (if "output" is a directory)
   - all generated types will be written
 - For all other types, this defines a file (absolute or relative to the current working directory) to which all generated types are written.`
+    },
+    {
+      name: "enums",
+      description: `Tell codegen where to find existing TypeScript enums. e.g.
+
+  --enums '{"MyEnum": "types#MyE"}'
+
+woulrd result in
+
+  export {MyE as MyEnum} from 'types';
+
+instead of generating a "MyEnum" type from the GraphQL schema. This is useful because TypeScript treates identical enums as different types.
+`
     }
   ];
 
@@ -193,7 +206,11 @@ export default class Generate extends ClientCommand {
                       flags.mergeInFieldsFromFragmentSpreads,
                     useFlowExactObjects: flags.useFlowExactObjects,
                     useFlowReadOnlyTypes: flags.useFlowReadOnlyTypes,
-                    globalTypesFile: flags.globalTypesFile
+                    globalTypesFile: flags.globalTypesFile,
+                    enums:
+                      args.enums && typeof args.enums === "string"
+                        ? JSON.parse(args.enums)
+                        : args.enums
                   }
                 );
               };

--- a/packages/apollo/src/generate.ts
+++ b/packages/apollo/src/generate.ts
@@ -25,6 +25,7 @@ import { generateSource as generateScalaSource } from "apollo-codegen-scala";
 
 import { FlowCompilerOptions } from "../../apollo-codegen-flow/lib/language";
 import { validateQueryDocument } from "apollo-language-server/lib/errors/validation";
+import { TypescriptCompilerOptions } from "../../apollo-codegen-typescript/lib/language";
 
 export type TargetType =
   | "json"
@@ -36,7 +37,8 @@ export type TargetType =
 
 export type GenerationOptions = CompilerOptions &
   LegacyCompilerOptions &
-  FlowCompilerOptions & {
+  FlowCompilerOptions &
+  TypescriptCompilerOptions & {
     globalTypesFile?: string;
     rootPath?: string;
   };


### PR DESCRIPTION
This is useful because TypeScript does not see two identical enums in different files as being the same type.  If you already have a library that's expecting an enum from a different package, this lets you explicilty refer to that in place of the auto-generated enum.

<!--
  Thanks for filing a pull request on Apollo Tooling!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [x] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass

\*Make sure changelog entries note which project(s) has been affected. See older entries for examples on what this looks like.
