### PR TITLE
Update core-js dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2367,9 +2367,16 @@
     "apollo-env": {
       "version": "file:packages/apollo-env",
       "requires": {
-        "core-js": "3.0.0-beta.13",
+        "core-js": "^3.0.1",
         "node-fetch": "^2.2.0",
         "sha.js": "^2.4.11"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.0.1.tgz",
+          "integrity": "sha512-sco40rF+2KlE0ROMvydjkrVMMG1vYilP2ALoRXcYR4obqbYIuV3Bg+51GEDW+HF8n7NRA+iaA4qD0nD9lo9mew=="
+        }
       }
     },
     "apollo-graphql": {

--- a/packages/apollo-env/package.json
+++ b/packages/apollo-env/package.json
@@ -20,7 +20,7 @@
     "node": ">=8"
   },
   "dependencies": {
-    "core-js": "3.0.0-beta.13",
+    "core-js": "^3.0.1",
     "node-fetch": "^2.2.0",
     "sha.js": "^2.4.11"
   }

--- a/renovate.json
+++ b/renovate.json
@@ -15,11 +15,6 @@
     {
       "packageNames": ["@types/node"],
       "allowedVersions": "8.x"
-    },
-    {
-      "packageNames": ["core-js"],
-      "rangeStrategy": "pin",
-      "allowedVersions": ["=3.0.0-beta.13"]
     }
   ]
 }


### PR DESCRIPTION
core-js has officially released v3.x, and the array polyfills we
depend on are marked as stable. We should be able to safely move
away from the beta and unpin the dependency in our renovate config.

See: https://github.com/zloirock/core-js/releases/tag/v3.0.0

Noteworthy change in release notes:
Mark ES2016, ES2017, ES2018, ES2019 features as stable:
Array#{ flat, flatMap }

<!--
  Thanks for filing a pull request on Apollo Tooling!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [ ] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [ ] Make sure all of the significant new logic is covered by tests
- [ ] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests and linter rules pass

\*Make sure changelog entries note which project(s) has been affected. See older entries for examples on what this looks like.
