### PR TITLE
Fix defaultValue parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
 - `apollo-tools`
   - <First `apollo-tools` related entry goes here>
 - `vscode-apollo`
-  - <First `vscode-apollo` related entry goes here>
+  - Fix defaultValue syntax highlighting [#1269](https://github.com/apollographql/apollo-tooling/pull/1269)
 
 ## `apollo@2.11.1`, `apollo-language-server@1.8.1`, `vscode-apollo@1.6.9`
 

--- a/packages/vscode-apollo/syntaxes/graphql.json
+++ b/packages/vscode-apollo/syntaxes/graphql.json
@@ -267,7 +267,7 @@
     },
     "graphql-variable-assignment": {
       "begin": "\\s(=)",
-      "end": "(?=[\n.])",
+      "end": "(?=[\n,)])",
       "applyEndPatternLast": 1,
       "beginCaptures": {
         "1": { "name": "punctuation.assignment.graphql" }


### PR DESCRIPTION
Currently vscode highlighting breaks for the entire file when a
graphql defaultValue is used. This is because we don't accept a
close paren or comma as a possible terminator for the
`graphql-variable-assignment` token.

Replace the literal '.' with a closing paren and comma.

<!--
  Thanks for filing a pull request on Apollo Tooling!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [ ] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [ ] Make sure all of the significant new logic is covered by tests
- [ ] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests and linter rules pass

\*Make sure changelog entries note which project(s) has been affected. See older entries for examples on what this looks like.
