### PR TITLE
Add debug print statements around calls to Apollo GraphQL api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Upcoming
 
 - `apollo`
-  - <First `apollo` related entry goes here>
+  - Add debugging logs to `apollo client:push` and `apollo service:push` [# 1273](https://github.com/apollographql/apollo-tooling/pull/1273)
 - `apollo-codegen-core`
   - <First `apollo-codegen-core` related entry goes here>
 - `apollo-codegen-flow`

--- a/packages/apollo/src/commands/client/push.ts
+++ b/packages/apollo/src/commands/client/push.ts
@@ -43,6 +43,11 @@ export default class ServicePush extends ClientCommand {
             operations: operationManifest,
             manifestVersion: 2
           };
+          const { operations: _, ...restVariables } = variables;
+          this.debug("Variables sent to Engine:");
+          this.debug(restVariables);
+          this.debug("Operations sent to Engine:");
+          this.debug(operations);
 
           await project.engine.registerOperations(variables);
 

--- a/packages/apollo/src/commands/service/push.ts
+++ b/packages/apollo/src/commands/service/push.ts
@@ -134,6 +134,8 @@ export default class ServicePush extends ProjectCommand {
               tag: response.tag ? response.tag.tag : null,
               code: response.code
             };
+            this.debug("Result received from Engine:");
+            this.debug(result);
           }
         }
       }


### PR DESCRIPTION
This PR adds some debugging statements around the call to our GraphQL api, which will allow us to understand what portions of the stack are misbehaving

- [x] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [ ] Make sure all of the significant new logic is covered by tests
- [ ] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests and linter rules pass
