### PR TITLE
Fix __typename addition for InlineFragments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
 - `apollo-graphql`
   - <First `apollo-graphql` related entry goes here>
 - `apollo-language-server`
-  - <First `apollo-language-server` related entry goes here>
+  - Fix \_\_typename addition for InlineFragments [#1286](https://github.com/apollographql/apollo-tooling/pull/1286)
 - `apollo-tools`
   - <First `apollo-tools` related entry goes here>
 - `vscode-apollo`

--- a/apollo.config.js
+++ b/apollo.config.js
@@ -2,7 +2,8 @@ module.exports = {
   client: {
     name: "Apollo CLI",
     service: "engine@master",
-    includes: ["./packages/apollo-language-server/**/*.ts"]
+    includes: ["./packages/apollo-language-server/**/*.ts"],
+    excludes: ["**/*.test.ts", "**/__tests__/*"]
   },
   engine: {
     frontend: "https://engine-staging.apollographql.com",

--- a/packages/apollo-language-server/src/utilities/__tests__/graphql.test.ts
+++ b/packages/apollo-language-server/src/utilities/__tests__/graphql.test.ts
@@ -1,0 +1,75 @@
+import gql from "graphql-tag";
+import { print } from "graphql";
+import { withTypenameFieldAddedWhereNeeded } from "../graphql";
+
+describe("withTypenameFieldAddedWhereNeeded", () => {
+  it("properly adds __typename to each selectionSet", () => {
+    const query = gql`
+      query Product {
+        product {
+          sku
+          color {
+            id
+            value
+          }
+        }
+      }
+    `;
+
+    const withTypenames = withTypenameFieldAddedWhereNeeded(query);
+
+    expect(print(withTypenames)).toMatchInlineSnapshot(`
+      "query Product {
+        product {
+          __typename
+          sku
+          color {
+            __typename
+            id
+            value
+          }
+        }
+      }
+      "
+    `);
+  });
+
+  it("adds __typename to InlineFragment nodes (as ApolloClient does)", () => {
+    const query = gql`
+      query CartItems {
+        product {
+          items {
+            ... on Table {
+              material
+            }
+            ... on Paint {
+              color
+            }
+          }
+        }
+      }
+    `;
+
+    const withTypenames = withTypenameFieldAddedWhereNeeded(query);
+
+    expect(print(withTypenames)).toMatchInlineSnapshot(`
+      "query CartItems {
+        product {
+          __typename
+          items {
+            __typename
+            ... on Table {
+              __typename
+              material
+            }
+            ... on Paint {
+              __typename
+              color
+            }
+          }
+        }
+      }
+      "
+    `);
+  });
+});

--- a/packages/apollo-language-server/src/utilities/graphql.ts
+++ b/packages/apollo-language-server/src/utilities/graphql.ts
@@ -136,8 +136,15 @@ export function withTypenameFieldAddedWhereNeeded(ast: ASTNode) {
       }
     },
     leave(node: ASTNode) {
-      if (!(node.kind === "Field" || node.kind === "FragmentDefinition"))
+      if (
+        !(
+          node.kind === "Field" ||
+          node.kind === "FragmentDefinition" ||
+          node.kind === "InlineFragment"
+        )
+      ) {
         return undefined;
+      }
       if (!node.selectionSet) return undefined;
 
       if (true) {

--- a/packages/apollo-language-server/src/utilities/graphql.ts
+++ b/packages/apollo-language-server/src/utilities/graphql.ts
@@ -138,9 +138,9 @@ export function withTypenameFieldAddedWhereNeeded(ast: ASTNode) {
     leave(node: ASTNode) {
       if (
         !(
-          node.kind === "Field" ||
-          node.kind === "FragmentDefinition" ||
-          node.kind === "InlineFragment"
+          node.kind === Kind.FIELD ||
+          node.kind === Kind.FRAGMENT_DEFINITION ||
+          node.kind === Kind.INLINE_FRAGMENT
         )
       ) {
         return undefined;


### PR DESCRIPTION
We need operation registration (client:push) `__typename`
adding to match how Apollo Client does this in order for query 
hashes to match.

In order to achieve parity here, I've added the `__typename` field
to InlineFragments as well. While the `__typename` on an interface
may be redundant (see new tests for example), it's also a safer
change for me to recommend than anything within Apollo Client.

<!--
  Thanks for filing a pull request on Apollo Tooling!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [x] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass

\*Make sure changelog entries note which project(s) has been affected. See older entries for examples on what this looks like.
