### PR TITLE
[language server] Allow configuration of validation rules.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
   - <First `apollo-graphql` related entry goes here>
 - `apollo-language-server`
   - update stats window types [#1292](https://github.com/apollographql/apollo-tooling/pull/1292)
+  - Allow configuration of validation rules [#1288](https://github.com/apollographql/apollo-tooling/pull/1288)
 - `apollo-tools`
   - <First `apollo-tools` related entry goes here>
 - `vscode-apollo`

--- a/packages/apollo-codegen-core/src/loading.ts
+++ b/packages/apollo-codegen-core/src/loading.ts
@@ -87,7 +87,7 @@ function extractDocumentsWithAST(
         // This currently ignores the anti-pattern of including an interpolated
         // string as anything other than a fragment definition, for example a
         // literal(these cases could be covered during the replacement of
-        // literals in the signature calcluation)
+        // literals in the signature calculation)
         finished.push(
           (path.value.quasi.quasis as Array<{
             value: { cooked: string; raw: string };

--- a/packages/apollo-language-server/src/config/config.ts
+++ b/packages/apollo-language-server/src/config/config.ts
@@ -72,13 +72,28 @@ export interface ClientConfigFormat extends ConfigBase {
   /**
    * Rules that will be applied when validating GraphQL documents.
    *
-   * If you wish to modify the default list of validation rules, import them from the apollo package:
+   * If you wish to modify the default list of validation rules, import them from the apollo package and
+   * assign your custom list:
    *
    * ```js
    * const { defaultValidationRules } = require("apollo/lib/defaultValidationRules");
+   *
+   * module.exports = {
+   *   // ...
+   *   validationRules: [...defaultValidationRules, ...customRules]
+   * }
+   * ```
+   *
+   * Or, if you simply wish to filter out some rules from the default list, you can specify a filter function:
+   *
+   * ```js
+   * module.exports = {
+   *   // ...
+   *   validationRules: rule => rule.name !== "NoAnonymousQueries"
+   * }
    * ```
    */
-  validationRules?: ValidationRule[];
+  validationRules?: ValidationRule[] | ((rule: ValidationRule) => boolean);
 }
 
 export const DefaultClientConfig = {

--- a/packages/apollo-language-server/src/config/config.ts
+++ b/packages/apollo-language-server/src/config/config.ts
@@ -4,6 +4,7 @@ import { ServiceID, ServiceSpecifier, ClientID } from "../engine";
 import URI from "vscode-uri";
 import { WithRequired } from "apollo-env";
 import { getServiceName, parseServiceSpecifier } from "./utils";
+import { ValidationRule } from "graphql/validation/ValidationContext";
 
 export interface EngineStatsWindow {
   to: number;
@@ -67,6 +68,17 @@ export interface ClientConfigFormat extends ConfigBase {
   tagName?: string;
   // stats window config
   statsWindow?: EngineStatsWindow;
+
+  /**
+   * Rules that will be applied when validating GraphQL documents.
+   *
+   * If you wish to modify the default list of validation rules, import them from the apollo package:
+   *
+   * ```js
+   * const { defaultValidationRules } = require("apollo/lib/defaultValidationRules");
+   * ```
+   */
+  validationRules?: ValidationRule[];
 }
 
 export const DefaultClientConfig = {

--- a/packages/apollo-language-server/src/config/loadConfig.ts
+++ b/packages/apollo-language-server/src/config/loadConfig.ts
@@ -184,7 +184,7 @@ export async function loadConfig({
 
   let { config, filepath } = loadedConfig;
 
-  // selectivly apply defaults when loading the config
+  // selectively apply defaults when loading the config
   // this is just the includes/excludes defaults.
   // These need to go on _all_ configs. That's why this is last.
   if (config.client) config = merge({ client: DefaultClientConfig }, config);

--- a/packages/apollo-language-server/src/diagnostics.ts
+++ b/packages/apollo-language-server/src/diagnostics.ts
@@ -14,6 +14,7 @@ import { rangeForASTNode } from "./utilities/source";
 
 import { getValidationErrors } from "./errors/validation";
 import { DocumentUri } from "./project/base";
+import { ValidationRule } from "graphql/validation/ValidationContext";
 
 /**
  * Build an array of code diagnostics for all executable definitions in a document.
@@ -21,7 +22,8 @@ import { DocumentUri } from "./project/base";
 export function collectExecutableDefinitionDiagnositics(
   schema: GraphQLSchema,
   queryDocument: GraphQLDocument,
-  fragments: { [fragmentName: string]: FragmentDefinitionNode } = {}
+  fragments: { [fragmentName: string]: FragmentDefinitionNode } = {},
+  rules?: ValidationRule[]
 ): Diagnostic[] {
   const ast = queryDocument.ast;
   if (!ast) return queryDocument.syntaxErrors;
@@ -36,7 +38,8 @@ export function collectExecutableDefinitionDiagnositics(
   for (const error of getValidationErrors(
     schema,
     astWithExecutableDefinitions,
-    fragments
+    fragments,
+    rules
   )) {
     diagnostics.push(
       ...diagnosticsFromError(error, DiagnosticSeverity.Error, "Validation")

--- a/packages/apollo-language-server/src/errors/validation.ts
+++ b/packages/apollo-language-server/src/errors/validation.ts
@@ -16,23 +16,22 @@ import {
 } from "graphql";
 
 import { ToolError, logError } from "./logger";
+import { ValidationRule } from "graphql/validation/ValidationContext";
+
+const specifiedRulesToBeRemoved = [NoUnusedFragmentsRule, KnownDirectivesRule];
+
+export const defaultValidationRules: ValidationRule[] = [
+  NoAnonymousQueries,
+  NoTypenameAlias,
+  ...specifiedRules.filter(rule => !specifiedRulesToBeRemoved.includes(rule))
+];
 
 export function getValidationErrors(
   schema: GraphQLSchema,
   document: DocumentNode,
-  fragments?: { [fragmentName: string]: FragmentDefinitionNode }
+  fragments?: { [fragmentName: string]: FragmentDefinitionNode },
+  rules: ValidationRule[] = defaultValidationRules
 ) {
-  const specifiedRulesToBeRemoved = [
-    NoUnusedFragmentsRule,
-    KnownDirectivesRule
-  ];
-
-  const rules = [
-    NoAnonymousQueries,
-    NoTypenameAlias,
-    ...specifiedRules.filter(rule => !specifiedRulesToBeRemoved.includes(rule))
-  ];
-
   const typeInfo = new TypeInfo(schema);
   const context = new ValidationContext(schema, document, typeInfo);
 

--- a/packages/apollo-language-server/src/project/client.ts
+++ b/packages/apollo-language-server/src/project/client.ts
@@ -237,7 +237,8 @@ export class GraphQLClientProject extends GraphQLProject {
           collectExecutableDefinitionDiagnositics(
             this.schema,
             document,
-            fragments
+            fragments,
+            this.config.client.validationRules
           )
         );
       }

--- a/packages/apollo/src/defaultValidationRules.ts
+++ b/packages/apollo/src/defaultValidationRules.ts
@@ -1,0 +1,3 @@
+export {
+  defaultValidationRules
+} from "apollo-language-server/lib/errors/validation";


### PR DESCRIPTION
Closes #1056

(I didn’t find any test coverage for the areas I touched, but am pretty sure my additions are backwards compatible.)

### Before

<img width="1136" alt="vscode-apollo before" src="https://user-images.githubusercontent.com/2320/58118318-d8c2cc80-7c00-11e9-89e8-a4856ce5b619.png">

### Config

<img width="1496" alt="vscode-apollo config" src="https://user-images.githubusercontent.com/2320/58118381-f7c15e80-7c00-11e9-8128-bdedda470f48.png">

### After

<img width="1496" alt="vscode-apollo after" src="https://user-images.githubusercontent.com/2320/58118392-fd1ea900-7c00-11e9-8082-57ece4ed6865.png">
