### PR TITLE
Fix logging to the correct operations variable

### DIFF
--- a/packages/apollo/src/commands/client/push.ts
+++ b/packages/apollo/src/commands/client/push.ts
@@ -49,7 +49,7 @@ export default class ServicePush extends ClientCommand {
           this.debug("Variables sent to Engine:");
           this.debug(restVariables);
           this.debug("Operations sent to Engine:");
-          this.debug(operations);
+          this.debug(operationManifest);
 
           await project.engine.registerOperations(variables);
 


### PR DESCRIPTION
Recent logging introduced a runtime error for `client:push` by attempting to log an undefined variable. This PR simply logs the correct variable as was previously intended.

<!--
  Thanks for filing a pull request on Apollo Tooling!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [ ] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [ ] Make sure all of the significant new logic is covered by tests
- [ ] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests and linter rules pass

\*Make sure changelog entries note which project(s) has been affected. See older entries for examples on what this looks like.
