### PR TITLE
apollo client:push update output to include more details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Upcoming
 
 - `apollo`
-  - <First `apollo` related entry goes here>
+  - Update client:push command with new resolver and more output [#1290](https://github.com/apollographql/apollo-tooling/pull/1290)
 - `apollo-codegen-core`
   - <First `apollo-codegen-core` related entry goes here>
 - `apollo-codegen-flow`

--- a/packages/apollo-language-server/src/engine/index.ts
+++ b/packages/apollo-language-server/src/engine/index.ts
@@ -232,10 +232,12 @@ export class ApolloEngineClient extends GraphQLDataSource {
         );
       }
 
-      if (!(data && data.service)) {
+      if (
+        !(data && data.service && data.service.registerOperationsWithResponse)
+      ) {
         throw new Error("Error in request from Engine");
       }
-      return data.service.registerOperations;
+      return data.service.registerOperationsWithResponse;
     });
   }
 

--- a/packages/apollo-language-server/src/engine/operations/registerOperations.ts
+++ b/packages/apollo-language-server/src/engine/operations/registerOperations.ts
@@ -8,11 +8,22 @@ export const REGISTER_OPERATIONS = gql`
     $manifestVersion: Int!
   ) {
     service(id: $id) {
-      registerOperations(
+      registerOperationsWithResponse(
         clientIdentity: $clientIdentity
         operations: $operations
         manifestVersion: $manifestVersion
-      )
+      ) {
+        invalidOperations {
+          errors {
+            message
+          }
+          signature
+        }
+        newOperations {
+          signature
+        }
+        registrationSuccess
+      }
     }
   }
 `;

--- a/packages/apollo-language-server/src/graphqlTypes.ts
+++ b/packages/apollo-language-server/src/graphqlTypes.ts
@@ -211,9 +211,56 @@ export interface CheckSchemaVariables {
 // GraphQL mutation operation: RegisterOperations
 // ====================================================
 
+export interface RegisterOperations_service_registerOperationsWithResponse_invalidOperations_errors {
+  __typename: "OperationValidationError";
+  /**
+   * Reason for validation failure
+   */
+  message: string;
+}
+
+export interface RegisterOperations_service_registerOperationsWithResponse_invalidOperations {
+  __typename: "InvalidOperation";
+  /**
+   * Validation errors
+   */
+  errors: RegisterOperations_service_registerOperationsWithResponse_invalidOperations_errors[] | null;
+  /**
+   * Signature of operation sent by the client
+   */
+  signature: string;
+}
+
+export interface RegisterOperations_service_registerOperationsWithResponse_newOperations {
+  __typename: "RegisteredOperation";
+  /**
+   * Signature of operation sent by the client
+   */
+  signature: string;
+}
+
+export interface RegisterOperations_service_registerOperationsWithResponse {
+  __typename: "RegisterOperationsMutationResponse";
+  /**
+   * Operations that failed to validate against the schema
+   */
+  invalidOperations: RegisterOperations_service_registerOperationsWithResponse_invalidOperations[] | null;
+  /**
+   * New operations added to the registry(subset of input operations)
+   */
+  newOperations: RegisterOperations_service_registerOperationsWithResponse_newOperations[] | null;
+  /**
+   * True if operations were registered, false if not
+   */
+  registrationSuccess: boolean;
+}
+
 export interface RegisterOperations_service {
   __typename: "ServiceMutation";
-  registerOperations: any | null;
+  /**
+   * Register operations with diagnostic information about the result of the mutation
+   */
+  registerOperationsWithResponse: RegisterOperations_service_registerOperationsWithResponse | null;
 }
 
 export interface RegisterOperations {

--- a/packages/apollo/src/commands/client/push.ts
+++ b/packages/apollo/src/commands/client/push.ts
@@ -6,7 +6,7 @@ import { getOperationManifestFromProject } from "../../utils/getOperationManifes
 import {
   operationHash,
   defaultOperationRegistrySignature
-} from "../../../../apollo-graphql/lib";
+} from "apollo-graphql";
 import chalk from "chalk";
 
 export default class ClientPush extends ClientCommand {

--- a/packages/apollo/src/commands/client/push.ts
+++ b/packages/apollo/src/commands/client/push.ts
@@ -50,7 +50,7 @@ export default class ClientPush extends ClientCommand {
             task: async () => {}
           },
           {
-            title: "Adding operations to Apollo Platform",
+            title: "Pushing operations to operation registry",
             task: async (_, task) => {
               if (!config.name) {
                 throw new Error(
@@ -136,16 +136,25 @@ export default class ClientPush extends ClientCommand {
                         ({ message }) => (result += `\n\t${message}`)
                       );
                   });
-                  task.title = `Failed to register operations, due to ${
+                  task.title = `Failed to push operations, due to ${
                     invalidOperations.length
                   } invalid operations`;
-                  throw Error(invalidOperationsErrorMessage);
+                  throw new Error(invalidOperationsErrorMessage);
+                } else {
+                  task.title = `Failed to register operations`;
+                  throw new Error(
+                    [
+                      "Registration failed and did not receive invalid operations.",
+                      "This should not occur, so please open a GitHub issue on:",
+                      "https://github.com/apollographql/apollo-tooling/"
+                    ].join("\n")
+                  );
                 }
               } else {
                 if (newOperations && newOperations.length) {
-                  task.title = `Added ${
+                  task.title = `Successfully pushed ${
                     newOperations.length
-                  } to Apollo Platform`;
+                  } operations to the operation registry`;
 
                   table(
                     newOperations.map(operation => {
@@ -175,7 +184,7 @@ export default class ClientPush extends ClientCommand {
                     }
                   );
                 } else {
-                  task.title = `All operations already registered with Apollo Platform`;
+                  task.title = `All operations were already found in the operation registry`;
                 }
               }
             }

--- a/packages/apollo/src/commands/client/push.ts
+++ b/packages/apollo/src/commands/client/push.ts
@@ -1,70 +1,195 @@
 import { ClientCommand } from "../../Command";
+import { table } from "heroku-cli-util";
+import { relative } from "path";
+import URI from "vscode-uri";
+import { getOperationManifestFromProject } from "../../utils/getOperationManifestFromProject";
 import {
-  getOperationManifestFromProject,
-  ManifestEntry
-} from "../../utils/getOperationManifestFromProject";
-import { ClientIdentity } from "apollo-language-server";
+  operationHash,
+  defaultOperationRegistrySignature
+} from "../../../../apollo-graphql/lib";
+import chalk from "chalk";
 
-export default class ServicePush extends ClientCommand {
-  static description = "Push a service to Engine";
+export default class ClientPush extends ClientCommand {
+  static description =
+    "Register operations with Apollo, adding them to the safelist";
   static flags = {
     ...ClientCommand.flags
   };
 
   async run() {
-    const { clientIdentity, operations, serviceName } = await this.runTasks<{
-      clientIdentity: ClientIdentity;
-      operations: ManifestEntry[];
-      serviceName: string;
-    }>(({ flags, project, config }) => [
-      {
-        title: "Pushing client information to Engine",
-        task: async ctx => {
-          if (!config.name) {
-            throw new Error(
-              "No service found to link to Engine. Engine is required for this command."
-            );
+    const invalidOperationsErrorMessage = "encountered invalid operations";
+    let result = "";
+    try {
+      await this.runTasks(({ flags, project, config }) => {
+        const clientBundleInfo = `${chalk.blue(
+          (config.client && config.client.name) || flags
+        )}${chalk.blue(
+          (config.client &&
+            config.client.version &&
+            `@${config.client.version}`) ||
+            ""
+        )}`;
+
+        return [
+          {
+            title: `Extracting operation from client, ${clientBundleInfo}`,
+            task: async (ctx, task) => {
+              const operationManifest = getOperationManifestFromProject(
+                this.project
+              );
+              ctx.operationManifest = operationManifest;
+              task.title = `Extracted ${
+                operationManifest.length
+              } operations from client, ${clientBundleInfo}`;
+            }
+          },
+          {
+            title: `Checked operations against ${chalk.blue(
+              config.name || ""
+            )}@${chalk.blue(config.tag)}`,
+            task: async () => {}
+          },
+          {
+            title: "Adding operations to Apollo Platform",
+            task: async (_, task) => {
+              if (!config.name) {
+                throw new Error(
+                  "No service found to link to Engine. Engine is required for this command."
+                );
+              }
+
+              const operationManifest = getOperationManifestFromProject(
+                this.project
+              );
+
+              const signatureToOperation = Object.fromEntries(
+                Object.entries(
+                  this.project.mergedOperationsAndFragmentsForService
+                ).map(([operationName, document]) => {
+                  const operationDefinition = document.definitions.find(
+                    ({ kind }) => kind === "OperationDefinition"
+                  );
+                  const relativePath =
+                    operationDefinition &&
+                    operationDefinition.loc &&
+                    relative(
+                      config.configURI ? config.configURI.fsPath : "",
+                      URI.parse(operationDefinition.loc.source.name).fsPath
+                    );
+                  const line =
+                    operationDefinition &&
+                    operationDefinition.loc &&
+                    operationDefinition.loc.source.locationOffset.line;
+                  return [
+                    operationHash(
+                      defaultOperationRegistrySignature(document, operationName)
+                    ),
+                    {
+                      operationName,
+                      document,
+                      file: line
+                        ? `${relativePath}:${line}`
+                        : relativePath || ""
+                    }
+                  ];
+                })
+              );
+
+              const { name, referenceID, version } = config.client!;
+              if (!name) {
+                throw new Error("Client name is required to push");
+              }
+
+              const variables = {
+                clientIdentity: {
+                  name: name,
+                  identifier: referenceID || name,
+                  version
+                },
+                id: config.name,
+                operations: operationManifest,
+                manifestVersion: 2
+              };
+              const { operations: _op, ...restVariables } = variables;
+              this.debug("Variables sent to Engine:");
+              this.debug(restVariables);
+              this.debug("Operations sent to Engine:");
+              this.debug(operationManifest);
+
+              const {
+                invalidOperations,
+                newOperations,
+                registrationSuccess
+              } = await project.engine.registerOperations(variables);
+
+              if (!registrationSuccess) {
+                if (invalidOperations) {
+                  invalidOperations.forEach(operation => {
+                    const { operationName, file } = signatureToOperation[
+                      operation.signature
+                    ];
+                    result += `\n${chalk.red(
+                      "FAIL"
+                    )}\t${operationName} ${chalk.blue(file)}`;
+                    operation.errors &&
+                      operation.errors.forEach(
+                        ({ message }) => (result += `\n\t${message}`)
+                      );
+                  });
+                  task.title = `Failed to register operations, due to ${
+                    invalidOperations.length
+                  } invalid operations`;
+                  throw Error(invalidOperationsErrorMessage);
+                }
+              } else {
+                if (newOperations && newOperations.length) {
+                  task.title = `Added ${
+                    newOperations.length
+                  } to Apollo Platform`;
+
+                  table(
+                    newOperations.map(operation => {
+                      const { operationName, file } = signatureToOperation[
+                        operation.signature
+                      ];
+
+                      return {
+                        added: chalk.green("ADDED"),
+                        name: operationName,
+                        file: chalk.blue(file)
+                      };
+                    }),
+                    {
+                      columns: [
+                        { key: "added", label: "Added" },
+                        { key: "name", label: "Operation Name" },
+                        { key: "file", label: "File Path" }
+                      ],
+                      // Override `printHeader` so we don't print a header
+                      printHeader: () => {},
+                      // The default `printLine` will output to the console; we want to capture the output so we can test
+                      // it.
+                      printLine: line => {
+                        result += `\n${line}`;
+                      }
+                    }
+                  );
+                } else {
+                  task.title = `All operations already registered with Apollo Platform`;
+                }
+              }
+            }
           }
-
-          const operationManifest = getOperationManifestFromProject(
-            this.project
-          );
-
-          const { name, referenceID, version } = config.client!;
-          if (!name) {
-            throw new Error("Client name is required to push");
-          }
-
-          const variables = {
-            clientIdentity: {
-              name: name,
-              identifier: referenceID || name,
-              version
-            },
-            id: config.name,
-            operations: operationManifest,
-            manifestVersion: 2
-          };
-          const { operations: _, ...restVariables } = variables;
-          this.debug("Variables sent to Engine:");
-          this.debug(restVariables);
-          this.debug("Operations sent to Engine:");
-          this.debug(operationManifest);
-
-          await project.engine.registerOperations(variables);
-
-          // store data for logging
-          ctx.operations = operationManifest;
-          ctx.serviceName = variables.id;
-          ctx.clientIdentity = variables.clientIdentity;
-        }
+        ];
+      });
+    } catch (e) {
+      // Print operation registry
+      if (e.message === invalidOperationsErrorMessage) {
+        this.log(result);
+        this.exit(1);
       }
-    ]);
-
-    this.log(
-      `Successfully pushed ${operations.length} operations from the ${
-        clientIdentity.name
-      } client to the ${serviceName} service in Engine`
-    );
+      throw e;
+    }
+    this.log(result);
   }
 }

--- a/packages/apollo/src/commands/client/push.ts
+++ b/packages/apollo/src/commands/client/push.ts
@@ -7,6 +7,7 @@ import {
   operationHash,
   defaultOperationRegistrySignature
 } from "apollo-graphql";
+import { pluralize } from "../../utils";
 import chalk from "chalk";
 
 export default class ClientPush extends ClientCommand {
@@ -38,9 +39,10 @@ export default class ClientPush extends ClientCommand {
                 this.project
               );
               ctx.operationManifest = operationManifest;
-              task.title = `Extracted ${
-                operationManifest.length
-              } operations from client, ${clientBundleInfo}`;
+              task.title = `Extracted ${pluralize(
+                operationManifest.length,
+                "operation"
+              )} from client, ${clientBundleInfo}`;
             }
           },
           {
@@ -136,9 +138,10 @@ export default class ClientPush extends ClientCommand {
                         ({ message }) => (result += `\n\t${message}`)
                       );
                   });
-                  task.title = `Failed to push operations, due to ${
-                    invalidOperations.length
-                  } invalid operations`;
+                  task.title = `Failed to push operations, due to ${pluralize(
+                    invalidOperations.length,
+                    "invalid operation"
+                  )}`;
                   throw new Error(invalidOperationsErrorMessage);
                 } else {
                   task.title = `Failed to register operations`;
@@ -152,9 +155,10 @@ export default class ClientPush extends ClientCommand {
                 }
               } else {
                 if (newOperations && newOperations.length) {
-                  task.title = `Successfully pushed ${
-                    newOperations.length
-                  } operations to the operation registry`;
+                  task.title = `Successfully pushed ${pluralize(
+                    newOperations.length,
+                    "operation"
+                  )} to the operation registry`;
 
                   table(
                     newOperations.map(operation => {

--- a/packages/apollo/src/commands/service/check.ts
+++ b/packages/apollo/src/commands/service/check.ts
@@ -4,7 +4,7 @@ import { introspectionFromSchema, printSchema } from "graphql";
 import chalk from "chalk";
 import { gitInfo } from "../../git";
 import { ProjectCommand } from "../../Command";
-import { validateHistoricParams } from "../../utils";
+import { validateHistoricParams, pluralize } from "../../utils";
 import {
   CheckSchema_service_checkSchema,
   CheckSchema_service_checkSchema_diffToPrevious_changes as Change,
@@ -14,19 +14,6 @@ import {
 import { ApolloConfig, GraphQLServiceProject } from "apollo-language-server";
 import moment from "moment";
 import sortBy from "lodash.sortby";
-import stripANSI from "strip-ansi";
-
-function pluralize(
-  quantity: string | number | null,
-  singular: string,
-  plural: string = `${singular}s`
-) {
-  // Strip ansi color from `quantity` if it's a string
-  const strippedQuantity =
-    typeof quantity === "string" ? parseInt(stripANSI(quantity), 0) : quantity;
-
-  return `${quantity} ${strippedQuantity === 1 ? singular : plural}`;
-}
 
 const formatChange = (change: Change) => {
   let color = (x: string): string => x;

--- a/packages/apollo/src/utils/index.ts
+++ b/packages/apollo/src/utils/index.ts
@@ -1,1 +1,3 @@
 export * from "./validateHistoricParams";
+
+export * from "./pluralize";

--- a/packages/apollo/src/utils/pluralize.ts
+++ b/packages/apollo/src/utils/pluralize.ts
@@ -1,0 +1,13 @@
+import stripANSI from "strip-ansi";
+
+export function pluralize(
+  quantity: string | number | null,
+  singular: string,
+  plural: string = `${singular}s`
+) {
+  // Strip ansi color from `quantity` if it's a string
+  const strippedQuantity =
+    typeof quantity === "string" ? parseInt(stripANSI(quantity), 0) : quantity;
+
+  return `${quantity} ${strippedQuantity === 1 ? singular : plural}`;
+}


### PR DESCRIPTION
This updates the operation registration command to use the new resolver
that returns more information, namely added operations and invalidation
messages associated with the operation. The `apollo client:push` command
then outputs this information

Happy path:
![image](https://user-images.githubusercontent.com/5565407/58210101-491f2b80-7c9d-11e9-92d9-5663c085fb42.png)

Sad path:
![image](https://user-images.githubusercontent.com/5565407/58210123-605e1900-7c9d-11e9-8374-919363bfacca.png)


<!--
  Thanks for filing a pull request on Apollo Tooling!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [x] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [ ] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass

\*Make sure changelog entries note which project(s) has been affected. See older entries for examples on what this looks like.
