### PR TITLE
Pin graphql to the ~14.2.x range

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2313,7 +2313,7 @@
         "git-parse": "1.0.3",
         "git-rev-sync": "1.12.0",
         "glob": "7.1.4",
-        "graphql": "^14.2.1",
+        "graphql": "~14.2.1",
         "graphql-tag": "2.10.1",
         "heroku-cli-util": "8.0.11",
         "listr": "0.14.3",
@@ -2485,7 +2485,7 @@
         "cosmiconfig": "^5.0.6",
         "dotenv": "^8.0.0",
         "glob": "^7.1.3",
-        "graphql": "^14.2.1",
+        "graphql": "~14.2.1",
         "graphql-tag": "^2.10.1",
         "lodash.debounce": "^4.0.8",
         "lodash.merge": "^4.6.1",
@@ -6486,9 +6486,9 @@
       "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA=="
     },
     "graphql": {
-      "version": "14.3.0",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-14.3.0.tgz",
-      "integrity": "sha512-MdfI4v7kSNC3NhB7cF8KNijDsifuWO2XOtzpyququqaclO8wVuChYv+KogexDwgP5sp7nFI9Z6N4QHgoLkfjrg==",
+      "version": "14.2.1",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-14.2.1.tgz",
+      "integrity": "sha512-2PL1UbvKeSjy/lUeJqHk+eR9CvuErXoCNwJI4jm3oNFEeY+9ELqHNKO1ZuSxAkasPkpWbmT/iMRMFxd3cEL3tQ==",
       "requires": {
         "iterall": "^1.2.2"
       }

--- a/packages/apollo-language-server/package.json
+++ b/packages/apollo-language-server/package.json
@@ -32,7 +32,7 @@
     "cosmiconfig": "^5.0.6",
     "dotenv": "^8.0.0",
     "glob": "^7.1.3",
-    "graphql": "^14.2.1",
+    "graphql": "~14.2.1",
     "graphql-tag": "^2.10.1",
     "lodash.debounce": "^4.0.8",
     "lodash.merge": "^4.6.1",

--- a/packages/apollo/package.json
+++ b/packages/apollo/package.json
@@ -54,7 +54,7 @@
     "git-parse": "1.0.3",
     "git-rev-sync": "1.12.0",
     "glob": "7.1.4",
-    "graphql": "^14.2.1",
+    "graphql": "~14.2.1",
     "graphql-tag": "2.10.1",
     "heroku-cli-util": "8.0.11",
     "listr": "0.14.3",


### PR DESCRIPTION
An incoming graphql release (14.3.1) is going to break at least
`apollo client:check` as it did in the past with `14.2.0` (confirmed this
manually with graphql's master branch). This dependency restriction
will prevent this for now, without us needing to find the root of
the issue. This is preventative until we have the resources
to investigate and resolve the actual cause of the problem.

For more details and full context, see:
https://github.com/graphql/graphql-js/commit/183ff32bee4bc23eb23657f79f414c2400ecb06a#r32971387

cc @abernix @martijnwalraven

<!--
  Thanks for filing a pull request on Apollo Tooling!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [ ] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [ ] Make sure all of the significant new logic is covered by tests
- [ ] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests and linter rules pass

\*Make sure changelog entries note which project(s) has been affected. See older entries for examples on what this looks like.
