### PR TITLE
[language server/vscode] Add Ruby support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,12 @@
 - `apollo-graphql`
   - <First `apollo-graphql` related entry goes here>
 - `apollo-language-server`
+<<<<<<< HEAD
   - <First `apollo-language-server` related entry goes here>
+=======
+  - Allow template literal placeholders that span multiple rows[#1299](https://github.com/apollographql/apollo-tooling/pull/1299)
+  - Add support for extracting GraphQL documents from Ruby source files using `<<-GRAPHQL...GRAPHQL` heredoc. [#1304](https://github.com/apollographql/apollo-tooling/pull/1304)
+>>>>>>> [language server] Extract GraphQL documents from Ruby source
 - `apollo-tools`
   - <First `apollo-tools` related entry goes here>
 - `vscode-apollo`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@
 - `apollo-tools`
   - <First `apollo-tools` related entry goes here>
 - `vscode-apollo`
-  - <First `vscode-apollo` related entry goes here>
+  - Add support for Ruby source files using `<<-GRAPHQL...GRAPHQL` heredoc. [#1304](https://github.com/apollographql/apollo-tooling/pull/1304)
 
 ## `apollo-graphql@0.3.3`
 

--- a/packages/apollo-language-server/src/project/base.ts
+++ b/packages/apollo-language-server/src/project/base.ts
@@ -40,7 +40,8 @@ const fileAssociations: { [extension: string]: string } = {
   ".jsx": "javascriptreact",
   ".tsx": "typescriptreact",
   ".vue": "vue",
-  ".py": "python"
+  ".py": "python",
+  ".rb": "ruby"
 };
 
 export interface GraphQLProjectConfig {

--- a/packages/vscode-apollo/package.json
+++ b/packages/vscode-apollo/package.json
@@ -100,6 +100,16 @@
         "embeddedLanguages": {
           "meta.embedded.block.graphql": "graphql"
         }
+      },
+      {
+        "injectTo": [
+          "source.ruby"
+        ],
+        "scopeName": "inline.graphql.ruby",
+        "path": "./syntaxes/graphql.rb.json",
+        "embeddedLanguages": {
+          "meta.embedded.block.graphql": "graphql"
+        }
       }
     ],
     "commands": [

--- a/packages/vscode-apollo/src/languageServerClient.ts
+++ b/packages/vscode-apollo/src/languageServerClient.ts
@@ -47,12 +47,15 @@ export function getLanguageServerClient(
       "javascriptreact",
       "typescriptreact",
       "vue",
-      "python"
+      "python",
+      "ruby"
     ],
     synchronize: {
       fileEvents: [
         workspace.createFileSystemWatcher("**/.env"),
-        workspace.createFileSystemWatcher("**/*.{graphql,js,ts,jsx,tsx,vue,py}")
+        workspace.createFileSystemWatcher(
+          "**/*.{graphql,js,ts,jsx,tsx,vue,py,rb}"
+        )
       ]
     },
     outputChannel

--- a/packages/vscode-apollo/syntaxes/graphql.rb.json
+++ b/packages/vscode-apollo/syntaxes/graphql.rb.json
@@ -1,0 +1,23 @@
+{
+  "fileTypes": ["rb"],
+  "injectionSelector": "L:source -string -comment",
+  "patterns": [
+    {
+      "contentName": "meta.embedded.block.graphql",
+      "begin": "(?=(?><<[-~](['\"]?)((?:[_\\w]+_|)GRAPHQL)\\b\\1))",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.ruby"
+        }
+      },
+      "end": "\\s*\\2$\\n?",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.ruby"
+        }
+      },
+      "patterns": [{ "include": "source.graphql" }]
+    }
+  ],
+  "scopeName": "inline.graphql.ruby"
+}


### PR DESCRIPTION
As the title says, this adds support for Ruby projects that use `<<-GRAPHQL…GRAPHQL` heredoc strings to define GraphQL documents.

An example can be found here https://github.com/artsy/exchange/pull/413

<img width="1496" alt="Screenshot 2019-05-29 at 14 05 32" src="https://user-images.githubusercontent.com/2320/58557218-29987d80-821e-11e9-8c40-16e0d7011ec6.png">
