### PR TITLE
Add tag awareness to client:push

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Upcoming
 
 - `apollo`
-  - <First `apollo` related entry goes here>
+  - update `client:push` to pass the tag / graphVariant [#1307](https://github.com/apollographql/apollo-tooling/pull/1307)
 - `apollo-codegen-core`
   - <First `apollo-codegen-core` related entry goes here>
 - `apollo-codegen-flow`

--- a/packages/apollo-language-server/src/engine/operations/registerOperations.ts
+++ b/packages/apollo-language-server/src/engine/operations/registerOperations.ts
@@ -6,12 +6,14 @@ export const REGISTER_OPERATIONS = gql`
     $clientIdentity: RegisteredClientIdentityInput!
     $operations: [RegisteredOperationInput!]!
     $manifestVersion: Int!
+    $graphVariant: String
   ) {
     service(id: $id) {
       registerOperationsWithResponse(
         clientIdentity: $clientIdentity
         operations: $operations
         manifestVersion: $manifestVersion
+        graphVariant: $graphVariant
       ) {
         invalidOperations {
           errors {

--- a/packages/apollo-language-server/src/graphqlTypes.ts
+++ b/packages/apollo-language-server/src/graphqlTypes.ts
@@ -272,6 +272,7 @@ export interface RegisterOperationsVariables {
   clientIdentity: RegisteredClientIdentityInput;
   operations: RegisteredOperationInput[];
   manifestVersion: number;
+  graphVariant?: string | null;
 }
 
 /* tslint:disable */

--- a/packages/apollo/src/commands/client/push.ts
+++ b/packages/apollo/src/commands/client/push.ts
@@ -87,7 +87,8 @@ export default class ClientPush extends ClientCommand {
                 },
                 id: config.name,
                 operations: operationManifest,
-                manifestVersion: 2
+                manifestVersion: 2,
+                graphVariant: config.tag
               };
               const { operations: _op, ...restVariables } = variables;
               this.debug("Variables sent to Apollo");


### PR DESCRIPTION
This PR passes the `graphVariant` argument to the `registerOperations` mutation

TODO:

- [x] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [ ] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass

\*Make sure changelog entries note which project(s) has been affected. See older entries for examples on what this looks like.

(https://github.com/mdg-private/monorepo/pull/2338 need to be released to prod before this can be released)