### PR TITLE
Update renovate config for graphql

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,14 +3,11 @@
   "packageRules": [
     {
       "paths": ["packages/apollo/package.json"],
-      "extends": [":pinAllExceptPeerDependencies"],
-      "packageRules": [
-        {
-          "packageNames": ["graphql"],
-          "rangeStrategy": "widen",
-          "allowedVersions": "^14.0.0"
-        }
-      ]
+      "extends": [":pinAllExceptPeerDependencies"]
+    },
+    {
+      "packageNames": ["graphql"],
+      "allowedVersions": "~14.2.1"
     },
     {
       "packageNames": ["@types/node"],


### PR DESCRIPTION
Pending further investigation into graphql changes, we want the
graphql version of apollo and the language server to be "pinned"
to ~14.2.1.

For reference on _why_ we want this (for now), see: https://github.com/apollographql/apollo-tooling/pull/1291

This PR should close the renovate's PR: #1303 (automatically,
not via GitHub)

<!--
  Thanks for filing a pull request on Apollo Tooling!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [ ] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [ ] Make sure all of the significant new logic is covered by tests
- [ ] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests and linter rules pass

\*Make sure changelog entries note which project(s) has been affected. See older entries for examples on what this looks like.
