### PR TITLE
Recognize .graphqls as graphql file

### DIFF
--- a/packages/apollo-language-server/src/project/base.ts
+++ b/packages/apollo-language-server/src/project/base.ts
@@ -34,6 +34,7 @@ export type DocumentUri = string;
 
 const fileAssociations: { [extension: string]: string } = {
   ".graphql": "graphql",
+  ".graphqls": "graphql",
   ".gql": "graphql",
   ".js": "javascript",
   ".ts": "typescript",


### PR DESCRIPTION
The team I work in intends to use the `.graphqls` file extension to declare queries, mutations and fragments, because some of its developers claimed it has wider support in some extensions for IDEs like Webstorm. 

I noticed that apollo-codegen does not select `.graphqls` files to generate types, but the extension does get mentioned at several places in the apollo-tooling repo, including apollo-codegen-core and apollo-language-server - right beside the extensions `.graphql` and `.gql`. 

Including this change (simulated with node + devtools) will make apollo codegen select `.graphqls` files. Is there a particular reason not to include this extension here? When I googled the use of the extensions, I did not get a clear or official answer on when to use which. 

If not, may this change be merged?

<!--
  Thanks for filing a pull request on Apollo Tooling!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [ ] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [ ] Make sure all of the significant new logic is covered by tests
- [ ] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests and linter rules pass

\*Make sure changelog entries note which project(s) has been affected. See older entries for examples on what this looks like.
