### PR TITLE
buildSchemaFromSDL - support meta fields on abstract types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 - `apollo-env`
   - <First `apollo-env` related entry goes here>
 - `apollo-graphql`
-  - <First `apollo-graphql` related entry goes here>
+  - buildSchemaFromSDL - support meta fields on abstract types [#1330](https://github.com/apollographql/apollo-tooling/pull/1330)
 - `apollo-language-server`
   - <First `apollo-codegen-core` related entry goes here>
 - `apollo-tools`

--- a/packages/apollo-graphql/src/schema/buildSchemaFromSDL.ts
+++ b/packages/apollo-graphql/src/schema/buildSchemaFromSDL.ts
@@ -13,7 +13,8 @@ import {
   SchemaDefinitionNode,
   SchemaExtensionNode,
   OperationTypeNode,
-  GraphQLObjectType
+  GraphQLObjectType,
+  isAbstractType
 } from "graphql";
 import { validateSDL } from "graphql/validation/validate";
 import { isDocumentNode, isNode } from "../utilities/graphql";
@@ -206,6 +207,15 @@ export function addResolversToSchema(
 ) {
   for (const [typeName, fieldConfigs] of Object.entries(resolvers)) {
     const type = schema.getType(typeName);
+
+    if (isAbstractType(type)) {
+      for (const [fieldName, fieldConfig] of Object.entries(fieldConfigs)) {
+        if (fieldName.startsWith("__")) {
+          (type as any)[fieldName.substring(2)] = fieldConfig;
+        }
+      }
+    }
+
     if (!isObjectType(type)) continue;
 
     const fieldMap = type.getFields();


### PR DESCRIPTION
Add support for meta resolvers on abstract types.

Fixes: https://github.com/apollographql/apollo-server/issues/2781

<!--
  Thanks for filing a pull request on Apollo Tooling!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [x] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass

\*Make sure changelog entries note which project(s) has been affected. See older entries for examples on what this looks like.
