### PR TITLE
Update types / remove federation warnings

### DIFF
--- a/packages/apollo-language-server/src/engine/operations/checkPartialSchema.ts
+++ b/packages/apollo-language-server/src/engine/operations/checkPartialSchema.ts
@@ -19,9 +19,6 @@ export const CHECK_PARTIAL_SCHEMA = gql`
         errors {
           message
         }
-        warnings {
-          message
-        }
       }
     }
   }

--- a/packages/apollo-language-server/src/engine/operations/removeServiceAndCompose.ts
+++ b/packages/apollo-language-server/src/engine/operations/removeServiceAndCompose.ts
@@ -24,13 +24,6 @@ export const REMOVE_SERVICE_AND_COMPOSE = gql`
           }
           message
         }
-        warnings {
-          locations {
-            column
-            line
-          }
-          message
-        }
         updatedGateway
       }
     }

--- a/packages/apollo-language-server/src/engine/operations/uploadAndComposePartialSchema.ts
+++ b/packages/apollo-language-server/src/engine/operations/uploadAndComposePartialSchema.ts
@@ -23,9 +23,6 @@ export const UPLOAD_AND_COMPOSE_PARTIAL_SCHEMA = gql`
         errors {
           message
         }
-        warnings {
-          message
-        }
         didUpdateGateway: updatedGateway
         serviceWasCreated: wasCreated
       }

--- a/packages/apollo-language-server/src/graphqlTypes.ts
+++ b/packages/apollo-language-server/src/graphqlTypes.ts
@@ -19,11 +19,6 @@ export interface CheckPartialSchema_service_validatePartialSchemaOfImplementingS
   message: string;
 }
 
-export interface CheckPartialSchema_service_validatePartialSchemaOfImplementingServiceAgainstGraph_warnings {
-  __typename: "SchemaCompositionWarning";
-  message: string;
-}
-
 export interface CheckPartialSchema_service_validatePartialSchemaOfImplementingServiceAgainstGraph {
   __typename: "CompositionValidationResult";
   /**
@@ -38,14 +33,6 @@ export interface CheckPartialSchema_service_validatePartialSchemaOfImplementingS
    * published to the implementing service if there were any errors encountered
    */
   errors: (CheckPartialSchema_service_validatePartialSchemaOfImplementingServiceAgainstGraph_errors | null)[];
-  /**
-   * List of warnings encountered during composing implementing services into a complete schema.
-   * Though a schema was composed for the graph with the proposed partial schema,
-   * these warnings may indicate undesired behavior or lost information. We recommend that no service
-   * is pushed with warnings that are not fully understood. Pushing an implementing service with warnings
-   * in its composition result will result in updating the composition config.
-   */
-  warnings: (CheckPartialSchema_service_validatePartialSchemaOfImplementingServiceAgainstGraph_warnings | null)[];
 }
 
 export interface CheckPartialSchema_service {
@@ -315,18 +302,6 @@ export interface RemoveServiceAndCompose_service_removeImplementingServiceAndTri
   message: string;
 }
 
-export interface RemoveServiceAndCompose_service_removeImplementingServiceAndTriggerComposition_warnings_locations {
-  __typename: "SourceLocation";
-  column: number;
-  line: number;
-}
-
-export interface RemoveServiceAndCompose_service_removeImplementingServiceAndTriggerComposition_warnings {
-  __typename: "SchemaCompositionWarning";
-  locations: (RemoveServiceAndCompose_service_removeImplementingServiceAndTriggerComposition_warnings_locations | null)[];
-  message: string;
-}
-
 export interface RemoveServiceAndCompose_service_removeImplementingServiceAndTriggerComposition {
   __typename: "CompositionAndRemoveResult";
   /**
@@ -339,14 +314,6 @@ export interface RemoveServiceAndCompose_service_removeImplementingServiceAndTri
    * published to the implementing service if there were any errors encountered
    */
   errors: (RemoveServiceAndCompose_service_removeImplementingServiceAndTriggerComposition_errors | null)[];
-  /**
-   * List of warnings encountered during composing implementing services into a complete schema.
-   * Though a schema was composed for the graph with the proposed partial schema,
-   * these warnings may indicate undesired behavior or lost information. We recommend that no service
-   * is pushed with warnings that are not fully understood. Pushing an implementing service with warnings
-   * in its composition result will result in updating the composition config.
-   */
-  warnings: (RemoveServiceAndCompose_service_removeImplementingServiceAndTriggerComposition_warnings | null)[];
   /**
    * Whether the gateway link was updated.
    */
@@ -457,11 +424,6 @@ export interface UploadAndComposePartialSchema_service_upsertImplementingService
   message: string;
 }
 
-export interface UploadAndComposePartialSchema_service_upsertImplementingServiceAndTriggerComposition_warnings {
-  __typename: "SchemaCompositionWarning";
-  message: string;
-}
-
 export interface UploadAndComposePartialSchema_service_upsertImplementingServiceAndTriggerComposition {
   __typename: "CompositionAndUpsertResult";
   /**
@@ -474,14 +436,6 @@ export interface UploadAndComposePartialSchema_service_upsertImplementingService
    * published to the implementing service if there were any errors encountered
    */
   errors: (UploadAndComposePartialSchema_service_upsertImplementingServiceAndTriggerComposition_errors | null)[];
-  /**
-   * List of warnings encountered during composing implementing services into a complete schema.
-   * Though a schema was composed for the graph with the proposed partial schema,
-   * these warnings may indicate undesired behavior or lost information. We recommend that no service
-   * is pushed with warnings that are not fully understood. Pushing an implementing service with warnings
-   * in its composition result will result in updating the composition config.
-   */
-  warnings: (UploadAndComposePartialSchema_service_upsertImplementingServiceAndTriggerComposition_warnings | null)[];
   /**
    * Whether the gateway link was updated.
    */

--- a/packages/apollo/src/commands/service/check.ts
+++ b/packages/apollo/src/commands/service/check.ts
@@ -65,7 +65,6 @@ interface TasksOutput {
   shouldOutputMarkdown: boolean;
   federation?: {
     errors: ({ message: string } | null)[];
-    warnings: ({ message: string } | null)[];
     schemaHash?: string | null;
   };
 }
@@ -289,7 +288,6 @@ export default class ServiceCheck extends ProjectCommand {
                   task.output = "Creating composed schema against the graph";
                   const {
                     errors,
-                    warnings,
                     compositionValidationDetails
                   } = await project.engine.checkPartialSchema({
                     id: configName,
@@ -303,8 +301,7 @@ export default class ServiceCheck extends ProjectCommand {
                   // FIXME: reformat to match other check results
 
                   taskOutput.federation = {
-                    errors,
-                    warnings
+                    errors
                   };
 
                   if (compositionValidationDetails) {
@@ -476,12 +473,6 @@ export default class ServiceCheck extends ProjectCommand {
           error ? error.message : ""
         )
       );
-      const warnings = taskOutput.federation.warnings.map(error =>
-        reshapeGraphQLErrorToChange(
-          ChangeSeverity.WARNING,
-          error ? error.message : ""
-        )
-      );
 
       // if we had composition errors, set the change type to failure if it isn't already
       if (
@@ -492,7 +483,6 @@ export default class ServiceCheck extends ProjectCommand {
       }
 
       checkSchemaResult.diffToPrevious.changes.push(...errors);
-      checkSchemaResult.diffToPrevious.changes.push(...warnings);
     }
 
     if (shouldOutputJson) {

--- a/packages/apollo/src/commands/service/delete.ts
+++ b/packages/apollo/src/commands/service/delete.ts
@@ -44,7 +44,6 @@ export default class ServiceDelete extends ProjectCommand {
 
           const {
             errors,
-            warnings,
             updatedGateway
           } = await project.engine.removeServiceAndCompose({
             id: config.name,
@@ -56,7 +55,6 @@ export default class ServiceDelete extends ProjectCommand {
             serviceName: flags.serviceName,
             graphVariant,
             graphName: config.name,
-            warnings,
             errors,
             updatedGateway
           };
@@ -70,10 +68,6 @@ export default class ServiceDelete extends ProjectCommand {
 
     if (result.errors && result.errors.length) {
       this.error(result.errors.map(error => error.message).join("\n"));
-    }
-
-    if (result.warnings && result.warnings.length) {
-      this.warn(result.warnings.map(warning => warning.message).join("\n"));
     }
 
     if (result.updatedGateway) {

--- a/packages/apollo/src/commands/service/push.ts
+++ b/packages/apollo/src/commands/service/push.ts
@@ -78,7 +78,6 @@ export default class ServicePush extends ProjectCommand {
             const {
               compositionConfig,
               errors,
-              warnings,
               didUpdateGateway,
               serviceWasCreated
             } = await project.engine.uploadAndComposePartialSchema({
@@ -99,7 +98,6 @@ export default class ServicePush extends ProjectCommand {
               service: flags.serviceName || info.name,
               hash: compositionConfig && compositionConfig.schemaHash,
               tag: config.tag,
-              warnings,
               errors,
               serviceWasCreated,
               didUpdateGateway,
@@ -146,19 +144,13 @@ export default class ServicePush extends ProjectCommand {
       this.log("No change in schema from previous version\n");
     }
 
-    const { errors, warnings } = result;
-    if ((errors && errors.length) || (warnings && warnings.length)) {
+    const { errors } = result;
+    if (errors && errors.length) {
       let printed = "";
 
       const messages = [
         ...errors.map(({ message }) => ({
           type: chalk.red("Error"),
-          description: message
-        })),
-        // Add an empty line between, but only if there are both breaking changes and non-breaking changes.
-        warnings.length && errors.length ? {} : null,
-        ...warnings.map(({ message }) => ({
-          type: chalk.yellow("Warning"),
           description: message
         }))
       ].filter(x => x !== null);


### PR DESCRIPTION
Warnings have been removed from federation composition results. Update CLI and generated types accordingly.

<!--
  Thanks for filing a pull request on Apollo Tooling!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [x] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [ ] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass

\*Make sure changelog entries note which project(s) has been affected. See older entries for examples on what this looks like.
