### PR TITLE
Add support for custom enum resolvers and scalar types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 - `apollo-env`
   - <First `apollo-env` related entry goes here>
 - `apollo-graphql`
-  - <First `apollo-graphql` related entry goes here>
+  - buildSchemaFromSDL - Add support for merging Scalar and Enum resolvers to schema [#1345](https://github.com/apollographql/apollo-tooling/pull/1345)
 - `apollo-language-server`
   - <First `apollo-language-server` related entry goes here>
 - `apollo-tools`

--- a/packages/apollo-graphql/src/schema/__tests__/buildSchemaFromSDL.test.ts
+++ b/packages/apollo-graphql/src/schema/__tests__/buildSchemaFromSDL.test.ts
@@ -10,7 +10,8 @@ import {
   GraphQLScalarTypeConfig,
   GraphQLEnumType,
   Kind,
-  execute
+  execute,
+  ExecutionResult
 } from "graphql";
 
 import astSerializer from "./snapshotSerializers/astSerializer";
@@ -467,7 +468,7 @@ type MutationRoot {
 
         type Query {
           favoriteColor: AllowedColor
-          avatar(borderColor: AllowedColor): String # As an argument
+          avatar(borderColor: AllowedColor): String
         }
       `;
 
@@ -488,15 +489,17 @@ type MutationRoot {
       const schema = buildSchemaFromSDL([{ typeDefs, resolvers }]);
       const colorEnum = schema.getType("AllowedColor") as GraphQLEnumType;
 
-      execute(
+      let result = execute(
         schema,
         gql`
           query {
+            favoriteColor
             avatar(borderColor: RED)
           }
         `
       );
 
+      expect((result as ExecutionResult).data!.favoriteColor).toBe("RED");
       expect(colorEnum.getValue("RED")!.value).toBe("#f00");
       expect(mockResolver).toBeCalledWith(undefined, { borderColor: "#f00" });
     });

--- a/packages/apollo-graphql/src/schema/__tests__/buildSchemaFromSDL.test.ts
+++ b/packages/apollo-graphql/src/schema/__tests__/buildSchemaFromSDL.test.ts
@@ -8,7 +8,9 @@ import {
   GraphQLAbstractType,
   GraphQLScalarType,
   GraphQLScalarTypeConfig,
-  Kind
+  GraphQLEnumType,
+  Kind,
+  execute
 } from "graphql";
 
 import astSerializer from "./snapshotSerializers/astSerializer";
@@ -453,6 +455,50 @@ type MutationRoot {
       expect(custom.parseLiteral).toBe(CustomType.parseLiteral);
       expect(custom.parseValue).toBe(CustomType.parseValue);
       expect(custom.serialize).toBe(CustomType.serialize);
+    });
+
+    it(`should add resolvers to enum types`, () => {
+      const typeDefs = gql`
+        enum AllowedColor {
+          RED
+          GREEN
+          BLUE
+        }
+
+        type Query {
+          favoriteColor: AllowedColor
+          avatar(borderColor: AllowedColor): String # As an argument
+        }
+      `;
+
+      const mockResolver = jest.fn();
+
+      const resolvers = {
+        AllowedColor: {
+          RED: "#f00",
+          GREEN: "#0f0",
+          BLUE: "#00f"
+        },
+        Query: {
+          favoriteColor: () => "#f00",
+          avatar: (_: any, params: any) => mockResolver(_, params)
+        }
+      };
+
+      const schema = buildSchemaFromSDL([{ typeDefs, resolvers }]);
+      const colorEnum = schema.getType("AllowedColor") as GraphQLEnumType;
+
+      execute(
+        schema,
+        gql`
+          query {
+            avatar(borderColor: RED)
+          }
+        `
+      );
+
+      expect(colorEnum.getValue("RED")!.value).toBe("#f00");
+      expect(mockResolver).toBeCalledWith(undefined, { borderColor: "#f00" });
     });
   });
 });

--- a/packages/apollo-graphql/src/schema/buildSchemaFromSDL.ts
+++ b/packages/apollo-graphql/src/schema/buildSchemaFromSDL.ts
@@ -224,6 +224,22 @@ export function addResolversToSchema(
       }
     }
 
+    if (isEnumType(type)) {
+      let getValue = type.getValue.bind(type);
+      type.getValue = x => {
+        if (x in fieldConfigs) {
+          let old = getValue(x);
+          if (!old) {
+            return old;
+          }
+          old.value = (fieldConfigs as any)[x];
+          return old;
+        } else {
+          return getValue(x);
+        }
+      };
+    }
+
     if (!isObjectType(type)) continue;
 
     const fieldMap = type.getFields();

--- a/packages/apollo-graphql/src/schema/buildSchemaFromSDL.ts
+++ b/packages/apollo-graphql/src/schema/buildSchemaFromSDL.ts
@@ -14,7 +14,9 @@ import {
   SchemaExtensionNode,
   OperationTypeNode,
   GraphQLObjectType,
-  isAbstractType
+  isAbstractType,
+  isScalarType,
+  isEnumType
 } from "graphql";
 import { validateSDL } from "graphql/validation/validate";
 import { isDocumentNode, isNode } from "../utilities/graphql";
@@ -213,6 +215,12 @@ export function addResolversToSchema(
         if (fieldName.startsWith("__")) {
           (type as any)[fieldName.substring(2)] = fieldConfig;
         }
+      }
+    }
+
+    if (isScalarType(type)) {
+      for (const fn in fieldConfigs) {
+        (type as any)[fn] = (fieldConfigs as any)[fn];
       }
     }
 

--- a/packages/apollo-graphql/src/schema/buildSchemaFromSDL.ts
+++ b/packages/apollo-graphql/src/schema/buildSchemaFromSDL.ts
@@ -17,7 +17,8 @@ import {
   GraphQLEnumType,
   isAbstractType,
   isScalarType,
-  isEnumType
+  isEnumType,
+  GraphQLEnumValue
 } from "graphql";
 import { validateSDL } from "graphql/validation/validate";
 import { isDocumentNode, isNode } from "../utilities/graphql";
@@ -208,8 +209,6 @@ export function addResolversToSchema(
   schema: GraphQLSchema,
   resolvers: GraphQLResolverMap<any>
 ) {
-  const enumValueMap = Object.create(null);
-
   for (const [typeName, fieldConfigs] of Object.entries(resolvers)) {
     const type = schema.getType(typeName);
 
@@ -229,14 +228,15 @@ export function addResolversToSchema(
 
     if (isEnumType(type)) {
       const values = type.getValues();
-      const newValues = {};
+      const newValues: { [key: string]: GraphQLEnumValue } = {};
       values.forEach(value => {
         const newValue = (fieldConfigs as any)[value.name] || value.name;
-        (newValues as any)[value.name] = {
+        newValues[value.name] = {
           value: newValue,
           deprecationReason: value.deprecationReason,
           description: value.description,
-          astNode: value.astNode
+          astNode: value.astNode,
+          name: value.name
         };
       });
 

--- a/packages/apollo-graphql/src/schema/buildSchemaFromSDL.ts
+++ b/packages/apollo-graphql/src/schema/buildSchemaFromSDL.ts
@@ -245,9 +245,7 @@ export function addResolversToSchema(
       Object.assign(
         type,
         new GraphQLEnumType({
-          name: type.name,
-          description: type.description,
-          astNode: type.astNode,
+          ...type.toConfig(),
           values: newValues
         })
       );

--- a/packages/apollo-graphql/src/schema/resolverMap.ts
+++ b/packages/apollo-graphql/src/schema/resolverMap.ts
@@ -1,12 +1,17 @@
-import { GraphQLFieldResolver } from "graphql";
+import { GraphQLFieldResolver, GraphQLScalarType } from "graphql";
 
 export interface GraphQLResolverMap<TContext = {}> {
-  [typeName: string]: {
-    [fieldName: string]:
-      | GraphQLFieldResolver<any, TContext>
-      | {
-          requires?: string;
-          resolve: GraphQLFieldResolver<any, TContext>;
-        };
-  };
+  [typeName: string]:
+    | {
+        [fieldName: string]:
+          | GraphQLFieldResolver<any, TContext>
+          | {
+              requires?: string;
+              resolve: GraphQLFieldResolver<any, TContext>;
+            };
+      }
+    | GraphQLScalarType
+    | {
+        [enumValue: string]: string | number;
+      };
 }


### PR DESCRIPTION
As described in #1343 and #1344, it is better to use `addResolveFunctionsToSchema` from graphql-tools to add the resolvers to the new schema, as it is how the resolvers are added normally in apolo-server, so that both scalars and enums are handled properly. As a TODO, it might be sensible to use more functionality from https://github.com/apollographql/graphql-tools/blob/84e77ac7d7e06f149019c5a42dd2e86907e27ac1/src/makeExecutableSchema.ts when generating the new schema.

TODO:

- [x] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass

\*Make sure changelog entries note which project(s) has been affected. See older entries for examples on what this looks like.
