### PR TITLE
Fix bug causing completion handlers to sometimes return old results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@
 - `apollo-tools`
   - <First `apollo-tools` related entry goes here>
 - `vscode-apollo`
-  - <First `vscode-apollo` related entry goes here>
+  - Fix bug causing some editor features to sometimes give stale results [#1361](https://github.com/apollographql/apollo-tooling/pull/1361)
 
 ## `apollo@2.13.1`, `apollo-graphql@0.3.2`
 

--- a/packages/apollo-language-server/src/utilities/debouncer.ts
+++ b/packages/apollo-language-server/src/utilities/debouncer.ts
@@ -1,5 +1,5 @@
 import debounce from "lodash.debounce";
 
 export function debounceHandler(handler: (...args: any[]) => any) {
-  return debounce(handler, 400, { trailing: true });
+  return debounce(handler, 400, { leading: true });
 }


### PR DESCRIPTION
Previously the debouncer was configured as `trailing`, which meant that the first `n-1` calls in a batch of `n` calls would get old data, and the last one would get new data.

Practically speaking, this meant that a new call for completion items would give the results of the last call for completion items, and a user could only get updated completion items after calling for them twice, more than 400ms apart.

This fixes that by setting the debouncer to be `leading`, which means that the first call in a new batch executes, and the remaining calls in the batch get it's results.

TODO:

- [x] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass

\*Make sure changelog entries note which project(s) has been affected. See older entries for examples on what this looks like.
