### PR TITLE
Fix issue with operation id doesn't match query document for swift (#1362) 

### DIFF
--- a/packages/apollo-codegen-swift/src/codeGeneration.ts
+++ b/packages/apollo-codegen-swift/src/codeGeneration.ts
@@ -207,9 +207,9 @@ export class SwiftAPIGenerator extends SwiftGenerator<CompilerContext> {
           );
           fragmentsReferenced.forEach(fragmentName => {
             this.print(
-              `.appending(${this.helpers.structNameForFragmentName(
+              `.appending("\n\(${this.helpers.structNameForFragmentName(
                 fragmentName
-              )}.fragmentDefinition)`
+              )}.fragmentDefinition)")`
             );
           });
           this.print(" }");


### PR DESCRIPTION
Added back `n` to each fragment in codeGeneration.ts 

#1362 