### PR TITLE
Fix service:list snapshot relative time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - `apollo`
   - Relax graphql version, resolve missing types "Boolean", "String" [#1355](https://github.com/apollographql/apollo-tooling/pull/1355)
   - Add `service:list` and tests [#1358](https://github.com/apollographql/apollo-tooling/pull/1358)
+  - Update `service:list` test to use a simulated time to prevent relative dates causing snapshot failures [#1374](https://github.com/apollographql/apollo-tooling/pull/1374)
 - `apollo-codegen-core`
   - <First `apollo-codegen-core` related entry goes here>
 - `apollo-codegen-flow`

--- a/packages/apollo/src/commands/service/list.ts
+++ b/packages/apollo/src/commands/service/list.ts
@@ -21,14 +21,15 @@ interface TasksOutput {
 }
 
 const formatImplementingService = (
-  implementingService: ListServices_service_implementingServices_FederatedImplementingServices_services
+  implementingService: ListServices_service_implementingServices_FederatedImplementingServices_services,
+  effectiveDate: Date = new Date()
 ) => {
   return {
     name: implementingService.name,
     url: implementingService.url || "",
     updatedAt: `${moment(implementingService.updatedAt).format(
       "D MMMM YYYY"
-    )} (${moment(implementingService.updatedAt).fromNow()})`
+    )} (${moment(implementingService.updatedAt).from(effectiveDate)})`
   };
 };
 
@@ -57,7 +58,16 @@ function formatHumanReadable({
     >(implementingServices.services, [service => service.name.toUpperCase()]);
 
     table(
-      sortedImplementingServices.map(formatImplementingService).filter(Boolean),
+      sortedImplementingServices
+        .map(sortedImplementingService =>
+          formatImplementingService(
+            sortedImplementingService,
+            // Force the time to a specific value if we're running tests. Otherwise the snapshots will break
+            // when the relative time changes.
+            process.env.NODE_ENV === "test" ? new Date("2019-06-13") : undefined
+          )
+        )
+        .filter(Boolean),
       {
         columns: [
           { key: "name", label: "Name" },


### PR DESCRIPTION
The time is relative; over time the value changes, causing the snapshot to
fail.

<!--
  Thanks for filing a pull request on Apollo Tooling!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [x] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass

\*Make sure changelog entries note which project(s) has been affected. See older entries for examples on what this looks like.
