### PR TITLE
add header to service list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - `apollo`
   - Relax graphql version, resolve missing types "Boolean", "String" [#1355](https://github.com/apollographql/apollo-tooling/pull/1355)
-  - Add `service:list` and tests [#1358](https://github.com/apollographql/apollo-tooling/pull/1358)
+  - Add `service:list` and tests [#1358](https://github.com/apollographql/apollo-tooling/pull/1358) and header [#1377](https://github.com/apollographql/apollo-tooling/pull/1377)
   - Update `service:list` test to use a simulated time to prevent relative dates causing snapshot failures [#1374](https://github.com/apollographql/apollo-tooling/pull/1374)
 - `apollo-codegen-core`
   - <First `apollo-codegen-core` related entry goes here>

--- a/packages/apollo/src/commands/service/__tests__/__snapshots__/list.test.ts.snap
+++ b/packages/apollo/src/commands/service/__tests__/__snapshots__/list.test.ts.snap
@@ -16,6 +16,8 @@ Loading Apollo Project [completed]
 Fetching list of services for graph engine [started]
 Fetching list of services for graph engine [completed]
 
+name       URL                            last updated
+─────────  ─────────────────────────────  ─────────────────────────
 accounts   http://localhost:4001/graphql  13 May 2019 (a month ago)
 inventory  http://localhost:4002/graphql  16 May 2019 (a month ago)
 products   http://localhost:4003/graphql  16 May 2019 (a month ago)

--- a/packages/apollo/src/commands/service/list.ts
+++ b/packages/apollo/src/commands/service/list.ts
@@ -70,9 +70,9 @@ function formatHumanReadable({
         .filter(Boolean),
       {
         columns: [
-          { key: "name", label: "Name" },
+          { key: "name", label: "name" },
           { key: "url", label: "URL" },
-          { key: "updatedAt", label: "Last Updated At" }
+          { key: "updatedAt", label: "last updated" }
         ],
         // The default `printLine` will output to the console; we want to capture the output so we can test
         // it.

--- a/packages/apollo/src/commands/service/list.ts
+++ b/packages/apollo/src/commands/service/list.ts
@@ -74,8 +74,6 @@ function formatHumanReadable({
           { key: "url", label: "URL" },
           { key: "updatedAt", label: "Last Updated At" }
         ],
-        // Override `printHeader` so we don't print a header
-        printHeader: () => {},
         // The default `printLine` will output to the console; we want to capture the output so we can test
         // it.
         printLine: line => {

--- a/packages/apollo/src/commands/service/list.ts
+++ b/packages/apollo/src/commands/service/list.ts
@@ -67,6 +67,9 @@ function formatHumanReadable({
             process.env.NODE_ENV === "test" ? new Date("2019-06-13") : undefined
           )
         )
+        .sort((s1, s2) =>
+          s1.name.toUpperCase() > s2.name.toUpperCase() ? 1 : -1
+        )
         .filter(Boolean),
       {
         columns: [


### PR DESCRIPTION
As I was writing docs, I realized that `service:list` has no list headers. I think these are necessary for understanding. Added in this PR. 

Also sorting alphabetically as requested in the [federation docs](https://github.com/apollographql/apollo/pull/504)

TODO:

- [x] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass

\*Make sure changelog entries note which project(s) has been affected. See older entries for examples on what this looks like.
