### PR TITLE
Support --json and --markdown for federated schema:check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   - Relax graphql version, resolve missing types "Boolean", "String" [#1355](https://github.com/apollographql/apollo-tooling/pull/1355)
   - Add `service:list` and tests [#1358](https://github.com/apollographql/apollo-tooling/pull/1358)
   - Update `service:list` test to use a simulated time to prevent relative dates causing snapshot failures [#1374](https://github.com/apollographql/apollo-tooling/pull/1374)
+  - Update `service:check` to support `--markdown` and `--json` flags for federated schema [#1378](https://github.com/apollographql/apollo-tooling/pull/1378)
 - `apollo-codegen-core`
   - <First `apollo-codegen-core` related entry goes here>
 - `apollo-codegen-flow`

--- a/packages/apollo/src/commands/service/__tests__/__snapshots__/check.test.ts.snap
+++ b/packages/apollo/src/commands/service/__tests__/__snapshots__/check.test.ts.snap
@@ -45,6 +45,44 @@ No changes present between schemas
 View full details at: https://engine-dev.apollographql.com/service/engine/checks?schemaTag=Detached%3A%20d664f715645c5f0bb5ad4f2260cd6cb8d19bbc68&schemaTagId=f9f68e7e-1b5f-4eab-a3da-1fd8cd681111&from=2019-03-26T22%3A25%3A12.887Z"
 `;
 
+exports[`service:check integration federated should report composition errors correctly --json 1`] = `
+"{
+  \\"errors\\": [
+    {
+      \\"service\\": \\"reviews\\",
+      \\"field\\": \\"User.id\\",
+      \\"message\\": \\"marked @external but it does not have a matching field on on the base service (accounts)\\"
+    },
+    {
+      \\"service\\": \\"reviews\\",
+      \\"field\\": \\"User\\",
+      \\"message\\": \\"A @key selects id, but User.id could not be found\\"
+    },
+    {
+      \\"service\\": \\"accounts\\",
+      \\"field\\": \\"User\\",
+      \\"message\\": \\"A @key selects id, but User.id could not be found\\"
+    }
+  ]
+}
+"
+`;
+
+exports[`service:check integration federated should report composition errors correctly --markdown 1`] = `
+"
+### Apollo Service Check
+🔄 Validated graph composition on schema tag \`master\` for service \`accounts\` on graph \`engine\`.
+❌ Found **3 composition errors**
+
+| Service   | Field     | Message   |
+| --------- | --------- | --------- |
+| reviews | User.id | marked @external but it does not have a matching field on on the base service (accounts) |
+| reviews | User | A @key selects id, but User.id could not be found |
+| accounts | User | A @key selects id, but User.id could not be found |
+
+"
+`;
+
 exports[`service:check integration federated should report composition errors correctly vanilla 1`] = `
 "Loading Apollo Project [started]
 Loading Apollo Project [completed]
@@ -60,6 +98,38 @@ Service   Field    Message
 reviews   User.id  marked @external but it does not have a matching field on on the base service (accounts)
 reviews   User     A @key selects id, but User.id could not be found
 accounts  User     A @key selects id, but User.id could not be found
+"
+`;
+
+exports[`service:check integration federated should report composition success correctly --json 1`] = `
+"{
+  \\"targetUrl\\": \\"https://engine-staging.apollographql.com/service/justin-fullstack-tutorial/check/3acd7765-61b2-4f1a-9227-8b288e42bfdc\\",
+  \\"changes\\": [
+    {
+      \\"severity\\": \\"NOTICE\\",
+      \\"code\\": \\"ARG_CHANGED_TYPE\\",
+      \\"description\\": \\"\`Query.launches\` argument \`after\` has changed type from \`String\` to \`String!\`\\"
+    }
+  ],
+  \\"validationConfig\\": {
+    \\"from\\": \\"-47347200\\",
+    \\"to\\": \\"-0\\",
+    \\"queryCountThreshold\\": 1,
+    \\"queryCountThresholdPercentage\\": 0
+  }
+}
+"
+`;
+
+exports[`service:check integration federated should report composition success correctly --markdown 1`] = `
+"
+### Apollo Service Check
+🔄 Validated your local schema against schema tag \`master\` for service \`accounts\` on graph \`engine\`.
+🔢 Compared **1 schema change** against **0 operations** seen over the **last 548 days**.
+✅ Found **no breaking changes**.
+
+🔗 [View your service check details](https://engine-staging.apollographql.com/service/justin-fullstack-tutorial/check/3acd7765-61b2-4f1a-9227-8b288e42bfdc).
+
 "
 `;
 

--- a/packages/apollo/src/commands/service/__tests__/check.test.ts
+++ b/packages/apollo/src/commands/service/__tests__/check.test.ts
@@ -406,15 +406,13 @@ describe("service:check", () => {
           expect(uncaptureApplicationOutput()).toMatchSnapshot();
         });
 
-        // This feature is not yet available. Adding markdown and json output support for federated services
-        // will require a minor refactor. Work can be tracked at
-        // https://apollographql.atlassian.net/browse/AP-491
-        it.skip("--markdown", async () => {
+        it("--markdown", async () => {
           captureApplicationOutput();
           mockCompositionFailure();
 
           expect.assertions(2);
 
+          // markdown formatted output should not throw
           await expect(
             ServiceCheck.run([
               ...cliKeyParameter,
@@ -422,21 +420,19 @@ describe("service:check", () => {
               `--endpoint=${localURL}/graphql`,
               "--markdown"
             ])
-          ).rejects.toThrow();
+          ).resolves.not.toThrow();
 
           // Inline snapshots don't work here due to https://github.com/facebook/jest/issues/6744.
           expect(uncaptureApplicationOutput()).toMatchSnapshot();
         });
 
-        // This feature is not yet available. Adding markdown and json output support for federated services
-        // will require a minor refactor. Work can be tracked at
-        // https://apollographql.atlassian.net/browse/AP-491
-        it.skip("--json", async () => {
+        it("--json", async () => {
           captureApplicationOutput();
           mockCompositionFailure();
 
           expect.assertions(2);
 
+          // JSON formatted output should not throw
           await expect(
             ServiceCheck.run([
               ...cliKeyParameter,
@@ -444,7 +440,7 @@ describe("service:check", () => {
               `--endpoint=${localURL}/graphql`,
               "--json"
             ])
-          ).rejects.toThrow();
+          ).resolves.not.toThrow();
 
           // Inline snapshots don't work here due to https://github.com/facebook/jest/issues/6744.
           expect(uncaptureApplicationOutput()).toMatchSnapshot();
@@ -470,10 +466,7 @@ describe("service:check", () => {
           expect(uncaptureApplicationOutput()).toMatchSnapshot();
         });
 
-        // This feature is not yet available. Adding markdown and json output support for federated services
-        // will require a minor refactor. Work can be tracked at
-        // https://apollographql.atlassian.net/browse/AP-491
-        it.skip("--markdown", async () => {
+        it("--markdown", async () => {
           captureApplicationOutput();
           mockCompositionSuccess();
 
@@ -492,10 +485,7 @@ describe("service:check", () => {
           expect(uncaptureApplicationOutput()).toMatchSnapshot();
         });
 
-        // This feature is not yet available. Adding markdown and json output support for federated services
-        // will require a minor refactor. Work can be tracked at
-        // https://apollographql.atlassian.net/browse/AP-491
-        it.skip("--json", async () => {
+        it("--json", async () => {
           captureApplicationOutput();
           mockCompositionSuccess();
 
@@ -607,7 +597,7 @@ describe("service:check", () => {
     it("is correct with breaking changes", () => {
       expect(
         formatMarkdown({
-          serviceName: "engine",
+          graphName: "engine",
           tag: "staging",
           checkSchemaResult
         })
@@ -615,7 +605,7 @@ describe("service:check", () => {
       // Check when all the values are singluar
       expect(
         formatMarkdown({
-          serviceName: "engine",
+          graphName: "engine",
           tag: "staging",
           checkSchemaResult: {
             ...checkSchemaResult,
@@ -642,7 +632,7 @@ describe("service:check", () => {
     it("is correct with no breaking changes", () => {
       expect(
         formatMarkdown({
-          serviceName: "engine",
+          graphName: "engine",
           tag: "staging",
           checkSchemaResult: {
             ...checkSchemaResult,


### PR DESCRIPTION
Support `--markdown` and `--json` flags for `apollo schema:check` command. Reintroduce tests and update snapshots.

Also refactor `check.ts` slightly, including renaming `serviceName` to `graphName` in markdown output now that there is a more pronounced difference between the terms with federation.

TODO:

- [x] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass

\*Make sure changelog entries note which project(s) has been affected. See older entries for examples on what this looks like.
