### PR TITLE
Dart support for vscode-apollo and language-server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,11 +19,11 @@
 - `apollo-graphql`
   - <First `apollo-graphql` related entry goes here>
 - `apollo-language-server`
-  - <First `apollo-language-server` related entry goes here>
+  - Add Dart operation extraction [#1385](https://github.com/apollographql/apollo-tooling/pull/1385)
 - `apollo-tools`
   - <First `apollo-tools` related entry goes here>
 - `vscode-apollo`
-  - <First `vscode-apollo` related entry goes here>
+  - Add Dart support for vscode [#1385](https://github.com/apollographql/apollo-tooling/pull/1385)
 
 ## `apollo@2.16.1`, `apollo-language-server@1.13.1`, `vscode-apollo@1.8.1`
 

--- a/packages/apollo-language-server/src/document.ts
+++ b/packages/apollo-language-server/src/document.ts
@@ -70,6 +70,8 @@ export function extractGraphQLDocuments(
       return extractGraphQLDocumentsFromPythonStrings(document, tagName);
     case "ruby":
       return extractGraphQLDocumentsFromRubyStrings(document, tagName);
+    case "dart":
+      return extractGraphQLDocumentsFromDartStrings(document, tagName);
     default:
       return null;
   }
@@ -145,6 +147,36 @@ function extractGraphQLDocumentsFromRubyStrings(
   let result;
   while ((result = regExp.exec(text)) !== null) {
     const contents = replacePlaceholdersWithWhiteSpace(result[2]);
+    const position = document.positionAt(result.index + result[1].length);
+    const locationOffset: SourceLocation = {
+      line: position.line + 1,
+      column: position.character + 1
+    };
+    const source = new Source(contents, document.uri, locationOffset);
+    documents.push(new GraphQLDocument(source));
+  }
+
+  if (documents.length < 1) return null;
+
+  return documents;
+}
+
+function extractGraphQLDocumentsFromDartStrings(
+  document: TextDocument,
+  tagName: string
+): GraphQLDocument[] | null {
+  const text = document.getText();
+
+  const documents: GraphQLDocument[] = [];
+
+  const regExp = new RegExp(
+    `\\b(${tagName}\\(\\s*r?("""|'''))([\\s\\S]+?)\\2\\s*\\)`,
+    "gm"
+  );
+
+  let result;
+  while ((result = regExp.exec(text)) !== null) {
+    const contents = replacePlaceholdersWithWhiteSpace(result[3]);
     const position = document.positionAt(result.index + result[1].length);
     const locationOffset: SourceLocation = {
       line: position.line + 1,

--- a/packages/apollo-language-server/src/project/base.ts
+++ b/packages/apollo-language-server/src/project/base.ts
@@ -41,7 +41,8 @@ const fileAssociations: { [extension: string]: string } = {
   ".tsx": "typescriptreact",
   ".vue": "vue",
   ".py": "python",
-  ".rb": "ruby"
+  ".rb": "ruby",
+  ".dart": "dart"
 };
 
 export interface GraphQLProjectConfig {

--- a/packages/vscode-apollo/package.json
+++ b/packages/vscode-apollo/package.json
@@ -110,6 +110,16 @@
         "embeddedLanguages": {
           "meta.embedded.block.graphql": "graphql"
         }
+      },
+      {
+        "injectTo": [
+          "source.dart"
+        ],
+        "scopeName": "inline.graphql.dart",
+        "path": "./syntaxes/graphql.dart.json",
+        "embeddedLanguages": {
+          "meta.embedded.block.graphql": "graphql"
+        }
       }
     ],
     "commands": [

--- a/packages/vscode-apollo/src/languageServerClient.ts
+++ b/packages/vscode-apollo/src/languageServerClient.ts
@@ -48,13 +48,14 @@ export function getLanguageServerClient(
       "typescriptreact",
       "vue",
       "python",
-      "ruby"
+      "ruby",
+      "dart"
     ],
     synchronize: {
       fileEvents: [
         workspace.createFileSystemWatcher("**/.env"),
         workspace.createFileSystemWatcher(
-          "**/*.{graphql,js,ts,jsx,tsx,vue,py,rb}"
+          "**/*.{graphql,js,ts,jsx,tsx,vue,py,rb,dart}"
         )
       ]
     },

--- a/packages/vscode-apollo/syntaxes/graphql.dart.json
+++ b/packages/vscode-apollo/syntaxes/graphql.dart.json
@@ -1,0 +1,40 @@
+{
+  "fileTypes": [
+    "dart"
+  ],
+  "injectionSelector": "L:source -string -comment",
+  "patterns": [
+    {
+      "name": "meta.function-call.dart",
+      "begin": "\\b(gql)(\\()",
+      "beginCaptures": {
+        "1": {
+          "name": "entity.name.function.dart"
+        },
+        "2": {
+          "name": "punctuation.definition.arguments.begin.dart"
+        }
+      },
+      "end": "(\\))",
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.definition.arguments.end.dart"
+        }
+      },
+      "patterns": [
+        {
+          "name": "taggedTemplates",
+          "contentName": "meta.embedded.block.graphql",
+          "begin": "r?(\"\"\"|''')",
+          "end": "((\\1))",
+          "patterns": [
+            {
+              "include": "source.graphql"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "scopeName": "inline.graphql.dart"
+}


### PR DESCRIPTION
This resolves #1365.

Similar to how python handles this, adding support for graphql syntax highlighting and code completion using a basic function.

```dart
String gql(String x) => x;

var query = gql(r"""
query getPeople {
  allPeople {
    people {
      id
      birthYear
      created
    }
  }
}
""");
```

Screenshot of it in action:

![image](https://user-images.githubusercontent.com/220686/60969833-dcc9bb80-a320-11e9-8bda-14b0793a1991.png)

I need a bit of guidance on building and testing the extension locally (including the language server). What's the process developers are typically using on `vscode-apollo`?

In order to test the functionality out, I patched the extension and language server directly in `/Users/venkat/.vscode/extensions/apollographql.vscode-apollo-1.7.4`. Then I applied those same changes to this repo. However I'd like to double check it all works.