### PR TITLE
[airbnb] Update Swift codegen to add operation name to generated query classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 - `apollo-codegen-scala`
   - <First `apollo-codegen-scala` related entry goes here>
 - `apollo-codegen-swift`
-  - <First `apollo-codegen-swift` related entry goes here>
+  - Add operation name to generated classes
 - `apollo-codegen-typescript`
   - <First `apollo-codegen-typescript` related entry goes here>
 - `apollo-env`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 - `apollo-codegen-scala`
   - <First `apollo-codegen-scala` related entry goes here>
 - `apollo-codegen-swift`
-  - Add operation name to generated classes
+  - Update Swift codegen to add operation name to generated query classes [#1386](https://github.com/apollographql/apollo-tooling/pull/1386)
   - Append terminating newline character to generated files [#531](https://github.com/apollographql/apollo-ios/issues/531)
 - `apollo-codegen-typescript`
   - <First `apollo-codegen-typescript` related entry goes here>

--- a/packages/apollo-codegen-swift/src/__tests__/__snapshots__/codeGeneration.ts.snap
+++ b/packages/apollo-codegen-swift/src/__tests__/__snapshots__/codeGeneration.ts.snap
@@ -5,6 +5,8 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
   public let operationDefinition =
     \\"mutation CreateReview($episode: Episode) {\\\\n  createReview(episode: $episode, review: {stars: 5, commentary: \\\\\\"Wow!\\\\\\"}) {\\\\n    stars\\\\n    commentary\\\\n  }\\\\n}\\"
 
+  public let operationName = \\"CreateReview\\"
+
   public var episode: Episode?
 
   public init(episode: Episode? = nil) {
@@ -87,6 +89,8 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
 "public final class HeroQuery: GraphQLQuery {
   public let operationDefinition =
     \\"query Hero {\\\\n  hero {\\\\n    ... on Droid {\\\\n      ...HeroDetails\\\\n    }\\\\n  }\\\\n}\\"
+
+  public let operationName = \\"Hero\\"
 
   public var queryDocument: String { return operationDefinition.appending(HeroDetails.fragmentDefinition) }
 
@@ -217,6 +221,8 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
 "public final class HeroQuery: GraphQLQuery {
   public let operationDefinition =
     \\"query Hero {\\\\n  hero {\\\\n    ...DroidDetails\\\\n  }\\\\n}\\"
+
+  public let operationName = \\"Hero\\"
 
   public var queryDocument: String { return operationDefinition.appending(DroidDetails.fragmentDefinition) }
 
@@ -376,6 +382,8 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
   public let operationDefinition =
     \\"query Hero {\\\\n  hero {\\\\n    ...HeroDetails\\\\n  }\\\\n}\\"
 
+  public let operationName = \\"Hero\\"
+
   public var queryDocument: String { return operationDefinition.appending(HeroDetails.fragmentDefinition) }
 
   public init() {
@@ -473,6 +481,8 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
   public let operationDefinition =
     \\"query HeroName($episode: Episode) {\\\\n  hero(episode: $episode) {\\\\n    name\\\\n  }\\\\n}\\"
 
+  public let operationName = \\"HeroName\\"
+
   public var episode: Episode?
 
   public init(episode: Episode? = nil) {
@@ -548,6 +558,8 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
 "public final class HeroQuery: GraphQLQuery {
   public let operationDefinition =
     \\"query Hero {\\\\n  hero {\\\\n    ...HeroDetails\\\\n  }\\\\n}\\"
+
+  public let operationName = \\"Hero\\"
 
   public let operationIdentifier: String? = \\"90d0d674eb6a7b33776f63200d6cec3d09f881247c360a2ac9a29037a02210c4\\"
 

--- a/packages/apollo-codegen-swift/src/codeGeneration.ts
+++ b/packages/apollo-codegen-swift/src/codeGeneration.ts
@@ -182,6 +182,9 @@ export class SwiftAPIGenerator extends SwiftGenerator<CompilerContext> {
           });
         }
 
+        this.printNewlineIfNeeded();
+        this.printOnNewline(`public let operationName = "${operationName}"`);
+
         const fragmentsReferenced = collectFragmentsReferenced(
           operation.selectionSet,
           this.context.fragments

--- a/packages/apollo/src/commands/client/__tests__/__snapshots__/generate.test.ts.snap
+++ b/packages/apollo/src/commands/client/__tests__/__snapshots__/generate.test.ts.snap
@@ -179,6 +179,8 @@ public final class SimpleQueryQuery: GraphQLQuery {
   public let operationDefinition =
     \\"query SimpleQuery {\\\\n  hello\\\\n}\\"
 
+  public let operationName = \\"SimpleQuery\\"
+
   public init() {
   }
 
@@ -219,6 +221,8 @@ import Apollo
 public final class SimpleQueryQuery: GraphQLQuery {
   public let operationDefinition =
     \\"query SimpleQuery {\\\\n  hello\\\\n}\\"
+
+  public let operationName = \\"SimpleQuery\\"
 
   public init() {
   }


### PR DESCRIPTION
Updates Swift codegen to add the operation name to generated query classes. 

TODO:

- [x] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass

\*Make sure changelog entries note which project(s) has been affected. See older entries for examples on what this looks like.
