### PR TITLE
[WIP] variant vs. tag vs. config.tag clean-up

### DIFF
--- a/packages/apollo/src/Command.ts
+++ b/packages/apollo/src/Command.ts
@@ -263,7 +263,6 @@ export abstract class ClientCommand extends ProjectCommand {
     tag: flags.string({
       char: "t",
       description: "The published graph variant for this client",
-      default: "current",
       hidden: true,
       exclusive: ["variant"]
     }),

--- a/packages/apollo/src/Command.ts
+++ b/packages/apollo/src/Command.ts
@@ -262,7 +262,16 @@ export abstract class ClientCommand extends ProjectCommand {
     }),
     tag: flags.string({
       char: "t",
-      description: "The published service tag for this client"
+      description: "The published graph variant for this client",
+      default: "current",
+      hidden: true,
+      exclusive: ["variant"]
+    }),
+    variant: flags.string({
+      char: "v",
+      description: "The published graph variant for this client",
+      default: "current",
+      exclusive: ["tag"]
     }),
     queries: flags.string({
       description: "Deprecated in favor of the includes flag"

--- a/packages/apollo/src/Command.ts
+++ b/packages/apollo/src/Command.ts
@@ -270,7 +270,6 @@ export abstract class ClientCommand extends ProjectCommand {
     variant: flags.string({
       char: "v",
       description: "The published graph variant for this client",
-      default: "current",
       exclusive: ["tag"]
     }),
     queries: flags.string({

--- a/packages/apollo/src/commands/client/check.ts
+++ b/packages/apollo/src/commands/client/check.ts
@@ -31,7 +31,7 @@ export default class ClientCheck extends ClientCommand {
     const { validationResults, operations } = await this.runTasks<{
       operations: Operation[];
       validationResults: ValidationResult[];
-    }>(({ project, config }) => [
+    }>(({ project, config, flags }) => [
       {
         title: "Checking client compatibility with service",
         task: async ctx => {
@@ -56,7 +56,7 @@ export default class ClientCheck extends ClientCommand {
 
           ctx.validationResults = await project.engine.validateOperations({
             id: config.name,
-            tag: config.tag,
+            tag: flags.variant || flags.tag || config.tag || "current",
             operations: ctx.operations.map(({ body, name }) => ({
               body,
               name

--- a/packages/apollo/src/commands/client/codegen.ts
+++ b/packages/apollo/src/commands/client/codegen.ts
@@ -158,7 +158,7 @@ export default class Generate extends ClientCommand {
             task: async (ctx, task) => {
               task.title = `Generating query files with '${inferredTarget}' target`;
               const schema = await project.resolveSchema({
-                tag: flags.tag
+                tag: flags.variant || flags.tag || "current"
               });
 
               if (!schema) throw new Error("Error loading schema");

--- a/packages/apollo/src/commands/client/download-schema.ts
+++ b/packages/apollo/src/commands/client/download-schema.ts
@@ -23,11 +23,13 @@ export default class SchemaDownload extends ClientCommand {
   async run() {
     let result;
     let gitContext;
-    await this.runTasks(({ args, project, flags }) => [
+    await this.runTasks(({ args, project, flags, config }) => [
       {
         title: `Saving schema to ${args.output}`,
         task: async () => {
-          const schema = await project.resolveSchema({ tag: flags.tag });
+          const schema = await project.resolveSchema({
+            tag: flags.variant || flags.tag || config.tag || "current"
+          });
           writeFileSync(
             args.output,
             JSON.stringify(introspectionFromSchema(schema), null, 2)

--- a/packages/apollo/src/commands/client/push.ts
+++ b/packages/apollo/src/commands/client/push.ts
@@ -88,7 +88,8 @@ export default class ClientPush extends ClientCommand {
                 id: config.name,
                 operations: operationManifest,
                 manifestVersion: 2,
-                graphVariant: config.tag
+                graphVariant:
+                  flags.variant || flags.tag || config.tag || "current"
               };
               const { operations: _op, ...restVariables } = variables;
               this.debug("Variables sent to Apollo");

--- a/packages/apollo/src/commands/service/check.ts
+++ b/packages/apollo/src/commands/service/check.ts
@@ -621,7 +621,7 @@ export default class ServiceCheck extends ProjectCommand {
         formatMarkdown({
           checkSchemaResult,
           serviceName,
-          tag
+          tag: config.tag
         })
       );
     }

--- a/packages/apollo/src/commands/service/check.ts
+++ b/packages/apollo/src/commands/service/check.ts
@@ -218,7 +218,6 @@ export default class ServiceCheck extends ProjectCommand {
     tag: flags.string({
       char: "t",
       description: "The published tag to check this service against",
-      default: "current",
       exclusive: ["variant"],
       hidden: true
     }),

--- a/packages/apollo/src/commands/service/check.ts
+++ b/packages/apollo/src/commands/service/check.ts
@@ -225,7 +225,6 @@ export default class ServiceCheck extends ProjectCommand {
     variant: flags.string({
       char: "v",
       description: "The published tag to check this service against",
-      default: "current",
       exclusive: ["tag"]
     }),
     validationPeriod: flags.string({

--- a/packages/apollo/src/commands/service/check.ts
+++ b/packages/apollo/src/commands/service/check.ts
@@ -286,7 +286,7 @@ export default class ServiceCheck extends ProjectCommand {
            * A graph can be either a monolithic schema or the result of composition a federated schema.
            */
           const graphName = config.name;
-          const tag = flags.tag || config.tag || "current";
+          const tag = flags.variant || flags.tag || config.tag || "current";
 
           /**
            * Name of the implementing service being checked.
@@ -381,7 +381,7 @@ export default class ServiceCheck extends ProjectCommand {
             {
               title: `Validating ${
                 serviceName ? "composed " : ""
-              }schema against tag ${chalk.blue(tag)} on graph ${chalk.blue(
+              }schema against variant ${chalk.blue(tag)} on graph ${chalk.blue(
                 graphName
               )}`,
               task: async (ctx: TasksOutput, task) => {
@@ -401,7 +401,7 @@ export default class ServiceCheck extends ProjectCommand {
                 } else {
                   // This is _not_ a `federated` schema. Resolve the schema given `config.tag`.
                   task.output = "Resolving schema";
-                  schema = await project.resolveSchema({ tag: config.tag });
+                  schema = await project.resolveSchema({ tag: tag });
                   if (!schema) {
                     throw new Error("Failed to resolve schema");
                   }
@@ -425,7 +425,7 @@ export default class ServiceCheck extends ProjectCommand {
 
                 const variables: CheckSchemaVariables = {
                   id: graphName,
-                  tag: flags.tag,
+                  tag: tag,
                   gitContext: await gitInfo(this.log),
                   frontend: flags.frontend || config.engine.frontend,
                   ...(historicParameters && { historicParameters }),
@@ -621,7 +621,7 @@ export default class ServiceCheck extends ProjectCommand {
         formatMarkdown({
           checkSchemaResult,
           serviceName,
-          tag: config.tag
+          tag
         })
       );
     }

--- a/packages/apollo/src/commands/service/check.ts
+++ b/packages/apollo/src/commands/service/check.ts
@@ -217,7 +217,16 @@ export default class ServiceCheck extends ProjectCommand {
     ...ProjectCommand.flags,
     tag: flags.string({
       char: "t",
-      description: "The published tag to check this service against"
+      description: "The published tag to check this service against",
+      default: "current",
+      exclusive: ["variant"],
+      hidden: true
+    }),
+    variant: flags.string({
+      char: "v",
+      description: "The published tag to check this service against",
+      default: "current",
+      exclusive: ["tag"]
     }),
     validationPeriod: flags.string({
       description:

--- a/packages/apollo/src/commands/service/delete.ts
+++ b/packages/apollo/src/commands/service/delete.ts
@@ -11,7 +11,6 @@ export default class ServiceDelete extends ProjectCommand {
       char: "t",
       hidden: true,
       description: "The variant of the service to delete",
-      default: "current",
       exclusive: ["variant"]
     }),
     variant: flags.string({

--- a/packages/apollo/src/commands/service/delete.ts
+++ b/packages/apollo/src/commands/service/delete.ts
@@ -9,7 +9,16 @@ export default class ServiceDelete extends ProjectCommand {
     ...ProjectCommand.flags,
     tag: flags.string({
       char: "t",
-      description: "The variant of the service to delete"
+      hidden: true,
+      description: "The variant of the service to delete",
+      default: "current",
+      exclusive: ["variant"]
+    }),
+    variant: flags.string({
+      char: "v",
+      description: "The variant of the service to delete",
+      default: "current",
+      exclusive: ["tag"]
     }),
     federated: flags.boolean({
       char: "f",

--- a/packages/apollo/src/commands/service/delete.ts
+++ b/packages/apollo/src/commands/service/delete.ts
@@ -48,7 +48,8 @@ export default class ServiceDelete extends ProjectCommand {
             );
           }
 
-          const graphVariant = config.tag || flags.variant;
+          const graphVariant =
+            flags.variant || flags.tag || config.tag || "current";
 
           const {
             errors,
@@ -80,11 +81,9 @@ export default class ServiceDelete extends ProjectCommand {
 
     if (result.updatedGateway) {
       this.log(
-        `The ${result.serviceName} service with ${
-          result.graphVariant
-        } tag was removed from ${
+        `The ${result.serviceName} service was removed from ${
           result.graphName
-        }. Remaining services were composed.`
+        }@${result.graphVariant}. Remaining services were composed.`
       );
       this.log("\n");
     }

--- a/packages/apollo/src/commands/service/delete.ts
+++ b/packages/apollo/src/commands/service/delete.ts
@@ -17,14 +17,14 @@ export default class ServiceDelete extends ProjectCommand {
     variant: flags.string({
       char: "v",
       description: "The variant of the service to delete",
-      default: "current",
       exclusive: ["tag"]
     }),
     federated: flags.boolean({
       char: "f",
       default: false,
+      hidden: true,
       description:
-        "Indicates that the schema is a partial schema from a federated service"
+        "[Deprecated: use serviceName to indicate that this is deleting a federated service] Indicates that the schema is a partial schema from a federated service"
     }),
     serviceName: flags.string({
       required: true,
@@ -43,13 +43,13 @@ export default class ServiceDelete extends ProjectCommand {
             throw new Error("No service found to link to Engine");
           }
 
-          if (!flags.federated) {
+          if (!flags.federated && !flags.serviceName) {
             this.error(
-              "Deleting a service is only supported for federated services. Use the --federated flag if this is a federated service."
+              "Deleting a service is only supported for federated services. Use the --serviceName flag if this is a federated service."
             );
           }
 
-          const graphVariant = flags.tag || config.tag || "current";
+          const graphVariant = config.tag || flags.variant;
 
           const {
             errors,

--- a/packages/apollo/src/commands/service/download.ts
+++ b/packages/apollo/src/commands/service/download.ts
@@ -39,12 +39,14 @@ export default class ServiceDownload extends ProjectCommand {
   async run() {
     let result;
     let gitContext;
-    await this.runTasks(({ args, project, flags }) => [
+    await this.runTasks(({ args, project, flags, config }) => [
       {
         title: `Saving schema to ${args.output}`,
         task: async () => {
           try {
-            const schema = await project.resolveSchema({ tag: flags.tag });
+            const schema = await project.resolveSchema({
+              tag: flags.variant || flags.tag || config.tag || "current"
+            });
             writeFileSync(
               args.output,
               JSON.stringify(introspectionFromSchema(schema), null, 2)

--- a/packages/apollo/src/commands/service/download.ts
+++ b/packages/apollo/src/commands/service/download.ts
@@ -13,7 +13,6 @@ export default class ServiceDownload extends ProjectCommand {
     tag: flags.string({
       char: "t",
       description: "The published tag to check this service against",
-      default: "current",
       hidden: true,
       exclusive: ["variant"]
     }),

--- a/packages/apollo/src/commands/service/download.ts
+++ b/packages/apollo/src/commands/service/download.ts
@@ -20,7 +20,6 @@ export default class ServiceDownload extends ProjectCommand {
     variant: flags.string({
       char: "v",
       description: "The published tag to check this service against",
-      default: "current",
       exclusive: ["tag"]
     }),
     skipSSLValidation: flags.boolean({

--- a/packages/apollo/src/commands/service/download.ts
+++ b/packages/apollo/src/commands/service/download.ts
@@ -13,7 +13,15 @@ export default class ServiceDownload extends ProjectCommand {
     tag: flags.string({
       char: "t",
       description: "The published tag to check this service against",
-      default: "current"
+      default: "current",
+      hidden: true,
+      exclusive: ["variant"]
+    }),
+    variant: flags.string({
+      char: "v",
+      description: "The published tag to check this service against",
+      default: "current",
+      exclusive: ["tag"]
     }),
     skipSSLValidation: flags.boolean({
       char: "k",

--- a/packages/apollo/src/commands/service/list.ts
+++ b/packages/apollo/src/commands/service/list.ts
@@ -112,8 +112,6 @@ export default class ServiceList extends ProjectCommand {
   async run() {
     // @ts-ignore we're going to populate `taskOutput` later
     const taskOutput: TasksOutput = {};
-
-    let schema: GraphQLSchema | undefined;
     try {
       await this.runTasks<TasksOutput>(({ config, flags, project }) => {
         if (!isServiceProject(project)) {
@@ -128,7 +126,7 @@ export default class ServiceList extends ProjectCommand {
          * A graph can be either a monolithic schema or the result of composition a federated schema.
          */
         const graphName = config.name;
-        const variant = flags.tag || config.tag || "current";
+        const variant = flags.variant || flags.tag || config.tag || "current";
 
         if (!graphName) {
           throw new Error("No service found to link to Engine");

--- a/packages/apollo/src/commands/service/list.ts
+++ b/packages/apollo/src/commands/service/list.ts
@@ -97,7 +97,16 @@ export default class ServiceList extends ProjectCommand {
     ...ProjectCommand.flags,
     tag: flags.string({
       char: "t",
-      description: "The published tag to list the services from"
+      default: "current",
+      description: "The published tag to list the implementing services from",
+      exclusive: ["variant"]
+    }),
+    variant: flags.string({
+      char: "v",
+      default: "current",
+      description:
+        "The published variant to list the implementing services from",
+      exclusive: ["tag"]
     })
   };
 

--- a/packages/apollo/src/commands/service/list.ts
+++ b/packages/apollo/src/commands/service/list.ts
@@ -97,7 +97,6 @@ export default class ServiceList extends ProjectCommand {
     ...ProjectCommand.flags,
     tag: flags.string({
       char: "t",
-      default: "current",
       description: "The published tag to list the implementing services from",
       exclusive: ["variant"],
       hidden: true

--- a/packages/apollo/src/commands/service/list.ts
+++ b/packages/apollo/src/commands/service/list.ts
@@ -99,11 +99,11 @@ export default class ServiceList extends ProjectCommand {
       char: "t",
       default: "current",
       description: "The published tag to list the implementing services from",
-      exclusive: ["variant"]
+      exclusive: ["variant"],
+      hidden: true
     }),
     variant: flags.string({
       char: "v",
-      default: "current",
       description:
         "The published variant to list the implementing services from",
       exclusive: ["tag"]

--- a/packages/apollo/src/commands/service/push.ts
+++ b/packages/apollo/src/commands/service/push.ts
@@ -22,7 +22,6 @@ export default class ServicePush extends ProjectCommand {
     variant: flags.string({
       char: "v",
       description: "The variant to publish this service to",
-      default: "current",
       exclusive: ["tag"]
     }),
     localSchemaFile: flags.string({

--- a/packages/apollo/src/commands/service/push.ts
+++ b/packages/apollo/src/commands/service/push.ts
@@ -15,7 +15,15 @@ export default class ServicePush extends ProjectCommand {
     tag: flags.string({
       char: "t",
       description: "The tag to publish this service to",
-      default: "current"
+      default: "current",
+      hidden: true,
+      exclusive: ["variant"]
+    }),
+    variant: flags.string({
+      char: "v",
+      description: "The variant to publish this service to",
+      default: "current",
+      exclusive: ["tag"]
     }),
     localSchemaFile: flags.string({
       description:
@@ -24,8 +32,9 @@ export default class ServicePush extends ProjectCommand {
     federated: flags.boolean({
       char: "f",
       default: false,
+      hidden: true,
       description:
-        "Indicates that the schema is a partial schema from a federated service"
+        "[Deprecated: use --serviceName to indicate a federated service] Indicates that the schema is a partial schema from a federated service"
     }),
     serviceName: flags.string({
       description:

--- a/packages/apollo/src/commands/service/push.ts
+++ b/packages/apollo/src/commands/service/push.ts
@@ -57,6 +57,7 @@ export default class ServicePush extends ProjectCommand {
       {
         title: "Uploading service to Engine",
         task: async () => {
+          const variant = flags.variant || flags.tag || config.tag || "current";
           if (!config.name) {
             throw new Error("No service found to link to Engine");
           }
@@ -94,7 +95,7 @@ export default class ServicePush extends ProjectCommand {
               serviceWasCreated
             } = await project.engine.uploadAndComposePartialSchema({
               id: config.name,
-              graphVariant: config.tag,
+              graphVariant: variant,
               name: flags.serviceName || info.name,
               url: flags.serviceURL || info.url,
               revision:
@@ -113,20 +114,20 @@ export default class ServicePush extends ProjectCommand {
               serviceWasCreated,
               didUpdateGateway,
               graphId: config.name,
-              graphVariant: config.tag || "current"
+              graphVariant: variant
             };
 
             return;
           }
 
-          const schema = await project.resolveSchema({ tag: flags.tag });
+          const schema = await project.resolveSchema({ tag: variant });
 
           const variables: UploadSchemaVariables = {
             id: config.name,
             // @ts-ignore
             // XXX Looks like TS should be generating ReadonlyArrays instead
             schema: introspectionFromSchema(schema).__schema,
-            tag: flags.tag,
+            tag: variant,
             gitContext
           };
 


### PR DESCRIPTION
This PR started out trying to do something about `service:delete` still requiring `--federated`, but then got super distracted and tried to clean up all of the `flags.variant` vs. `flags.tag` nonsense, but in a probably not super-productive way. I'm not sure how useful those commits are, so we can certainly revert them if we have another solution for this, but consistency is key, and it's something we're sorely lacking here. Leaving this open for now as a point of discussion rather than as an intended solution. I'm hoping someone who understands the nuances better can pick this up :)

<!--
  Thanks for filing a pull request on Apollo Tooling!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [ ] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [ ] Make sure all of the significant new logic is covered by tests
- [ ] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests and linter rules pass

\*Make sure changelog entries note which project(s) has been affected. See older entries for examples on what this looks like.
