### PR TITLE
Revert back to 'tag' for now

### DIFF
--- a/packages/apollo/src/commands/service/push.ts
+++ b/packages/apollo/src/commands/service/push.ts
@@ -217,7 +217,7 @@ export default class ServicePush extends ProjectCommand {
             format: (hash: string) => hash.slice(0, 6)
           },
           { key: "graphId", label: "graph" },
-          { key: "graphVariant", label: "variant" }
+          { key: "graphVariant", label: "tag" }
         ]
       });
       this.log("\n");


### PR DESCRIPTION
While we _do_ want to make the change to using variant internally and externally, we've decided to hold off on this switch for now. Changing this label back to `tag` will keep us consistent until we decide to make the change.

<!--
  Thanks for filing a pull request on Apollo Tooling!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [ ] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [ ] Make sure all of the significant new logic is covered by tests
- [ ] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests and linter rules pass

\*Make sure changelog entries note which project(s) has been affected. See older entries for examples on what this looks like.
