### PR TITLE
Only activate extension on apollo.config.js/ts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
 - `apollo-tools`
   - <First `apollo-tools` related entry goes here>
 - `vscode-apollo`
-  - <First `vscode-apollo` related entry goes here>
+  - Only activate extension on apollo.config.js/ts [#1411](https://github.com/apollographql/apollo-tooling/pull/1411)
 
 ## `apollo@2.16.0`, `apollo-codegen-swift@0.34.0`, `apollo-language-server@1.13.0`, `apollo-tools@0.4.0`, `vscode-apollo@1.8.0`
 

--- a/packages/vscode-apollo/package.json
+++ b/packages/vscode-apollo/package.json
@@ -37,7 +37,7 @@
   ],
   "icon": "images/icon-apollo-blue-400x400.png",
   "activationEvents": [
-    "workspaceContains:**/apollo.config.{js|ts}"
+    "workspaceContains:**/apollo.config.[jt]s"
   ],
   "contributes": {
     "configuration": {

--- a/packages/vscode-apollo/package.json
+++ b/packages/vscode-apollo/package.json
@@ -37,7 +37,7 @@
   ],
   "icon": "images/icon-apollo-blue-400x400.png",
   "activationEvents": [
-    "workspaceContains:**/package.json"
+    "workspaceContains:**/apollo.config.{js|ts}"
   ],
   "contributes": {
     "configuration": {


### PR DESCRIPTION
Activating the extension on `package.json` is potentially obnoxious for non-apollo projects, and breaks for projects that don't use a package file. Activating on `apollo.config.js` works across all project types and keeps the extension quiet for non-apollo projects.

<!--
  Thanks for filing a pull request on Apollo Tooling!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [x] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [ ] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests and linter rules pass

\*Make sure changelog entries note which project(s) has been affected. See older entries for examples on what this looks like.
