### PR TITLE
[BE-362] Add overrideComposedSchema option to service:push

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - `apollo`
   - Shorten `client:check` and `service:check` output in CI [#1404](https://github.com/apollographql/apollo-tooling/pull/1404)
   - service:check add null check for validation config [#1471](https://github.com/apollographql/apollo-tooling/pull/1471)
+  - `service:push` add `overrideComposedSchema` option, which allows schemas to be force-pushed directly to federated graphs
 - `apollo-codegen-core`
   - <First `apollo-codegen-core` related entry goes here>
 - `apollo-codegen-flow`

--- a/packages/apollo-codegen-core/src/loading.ts
+++ b/packages/apollo-codegen-core/src/loading.ts
@@ -231,7 +231,9 @@ export function extractOperationsAndFragments(
 
         if (fragments[node.name.value]) {
           (errorLogger || console.warn)(
-            `Duplicate definition of fragment ${node.name.value}. Please rename one of them or use the same fragment`
+            `Duplicate definition of fragment ${
+              node.name.value
+            }. Please rename one of them or use the same fragment`
           );
         }
         fragments[node.name.value] = node;
@@ -285,7 +287,9 @@ function getNestedFragments(
       }
       if (!fragments[node.name.value]) {
         (errorLogger || console.warn)(
-          `Fragment ${node.name.value} is not defined. Please add the file containing the fragment to the set of included paths`
+          `Fragment ${
+            node.name.value
+          } is not defined. Please add the file containing the fragment to the set of included paths`
         );
       }
       Object.assign(

--- a/packages/apollo-language-server/src/engine/operations/uploadSchema.ts
+++ b/packages/apollo-language-server/src/engine/operations/uploadSchema.ts
@@ -6,9 +6,15 @@ export const UPLOAD_SCHEMA = gql`
     $schema: IntrospectionSchemaInput!
     $tag: String!
     $gitContext: GitContextInput
+    $overrideComposedSchema: Boolean
   ) {
     service(id: $id) {
-      uploadSchema(schema: $schema, tag: $tag, gitContext: $gitContext) {
+      uploadSchema(
+        schema: $schema
+        tag: $tag
+        gitContext: $gitContext
+        overrideComposedSchema: $overrideComposedSchema
+      ) {
         code
         message
         success

--- a/packages/apollo-language-server/src/graphqlTypes.ts
+++ b/packages/apollo-language-server/src/graphqlTypes.ts
@@ -43,11 +43,11 @@ export interface CheckPartialSchema_service {
   __typename: "ServiceMutation";
   /**
    * This mutation will not result in any changes to the implementing service
-   * 
+   *
    * Run composition with the Implementing Service's partial schema replaced with the one provided
    * in the mutation's input. Store the composed schema, return the hash of the composed schema,
    * and any warnings and errors pertaining to composition.
-   * 
+   *
    * This mutation will not run validation against operations.
    */
   validatePartialSchemaOfImplementingServiceAgainstGraph: CheckPartialSchema_service_validatePartialSchemaOfImplementingServiceAgainstGraph;
@@ -170,11 +170,11 @@ export interface CheckSchema_service {
   /**
    * Validate, diff, and store a schema so the diff can be viewed by users in the UI.
    * This mutation will not mark the schema as "published".
-   * 
+   *
    * One of "proposedSchema" or "proposedSchemaHash" must be provided.
    * If both are provided, the computed schema hash will be compared with the input hash,
    * an error will be returned if the hashes don't match.
-   * 
+   *
    * If the "proposedSchemaHash" is specified, the already stored schema will be loaded.
    */
   checkSchema: CheckSchema_service_checkSchema;
@@ -521,10 +521,10 @@ export interface UploadAndComposePartialSchema_service {
   /**
    * Creates or updates an implementing service of a given "name" on the graph variant, then
    * updates the graph variant's composition configs/artifacts to reflect these changes.
-   * 
+   *
    * An enriched SDL of the implementing service can be uploaded
    * via "implementingServiceConfiguration.partialSchema.partialSchemaSDL".
-   * 
+   *
    * Alternatively, previously uploaded partial schema could be re-associated with the
    * implementing service via "implementingServiceConfiguration.partialSchema.partialSchemaHash".
    */
@@ -588,6 +588,7 @@ export interface UploadSchemaVariables {
   schema: IntrospectionSchemaInput;
   tag: string;
   gitContext?: GitContextInput | null;
+  overrideComposedSchema?: boolean | null;
 }
 
 /* tslint:disable */
@@ -1728,10 +1729,10 @@ export interface OperationDocumentInput {
 /**
  * Input for registering a partial schema to an implementing service.
  * One of the fields must be specified (validated server-side).
- * 
+ *
  * If a new partialSchemaSDL is passed in, this operation will store it before
  * creating the association.
- * 
+ *
  * If both the sdl and hash are specified, an error will be thrown if the provided
  * hash doesn't match our hash of the sdl contents
  */

--- a/packages/apollo-language-server/src/languageProvider.ts
+++ b/packages/apollo-language-server/src/languageProvider.ts
@@ -296,7 +296,9 @@ export class GraphQLLanguageProvider {
             return {
               contents: {
                 language: "graphql",
-                value: `fragment ${fragmentName} on ${fragment.typeCondition.name.value}`
+                value: `fragment ${fragmentName} on ${
+                  fragment.typeCondition.name.value
+                }`
               }
             };
           }

--- a/packages/apollo-language-server/src/project/base.ts
+++ b/packages/apollo-language-server/src/project/base.ts
@@ -117,7 +117,9 @@ export abstract class GraphQLProject implements GraphQLSchemaProvider {
       .catch(error => {
         console.error(error);
         this.loadingHandler.showError(
-          `Error initializing Apollo GraphQL project "${this.displayName}": ${error}`
+          `Error initializing Apollo GraphQL project "${
+            this.displayName
+          }": ${error}`
         );
       });
   }

--- a/packages/apollo/src/commands/client/extract.ts
+++ b/packages/apollo/src/commands/client/extract.ts
@@ -49,7 +49,9 @@ export default class ClientExtract extends ClientCommand {
     ]);
 
     this.log(
-      `Successfully wrote ${operations.length} operations from the ${clientIdentity.name} client to ${filename}`
+      `Successfully wrote ${operations.length} operations from the ${
+        clientIdentity.name
+      } client to ${filename}`
     );
   }
 }

--- a/packages/apollo/src/commands/service/delete.ts
+++ b/packages/apollo/src/commands/service/delete.ts
@@ -73,7 +73,11 @@ export default class ServiceDelete extends ProjectCommand {
 
     if (result.updatedGateway) {
       this.log(
-        `The ${result.serviceName} service with ${result.graphVariant} tag was removed from ${result.graphName}. Remaining services were composed.`
+        `The ${result.serviceName} service with ${
+          result.graphVariant
+        } tag was removed from ${
+          result.graphName
+        }. Remaining services were composed.`
       );
       this.log("\n");
     }


### PR DESCRIPTION
By default, it is forbidden to push a schema directly to a federated
graph. If users try to push a schema directly, the API will return
errors unless 'overrideComposedSchema' is specified in the arguments.
This change adds the boolean flag that corresponds to this "force push"
to the CLI.

It also runs lint-fix, unfortunately in the same commit.

See https://github.com/mdg-private/monorepo/pull/2533 for corresponding PR

<!--
  Thanks for filing a pull request on Apollo Tooling!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [x] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests and linter rules pass

\*Make sure changelog entries note which project(s) has been affected. See older entries for examples on what this looks like.
