### PR TITLE
Add helpful message for invalid API key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,12 +19,12 @@
 - `apollo-graphql`
   - <First `apollo-graphql` related entry goes here>
 - `apollo-language-server`
-  - <First `apollo-language-server` related entry goes here>
+  - Add error message for service lookup failure [#1413](https://github.com/apollographql/apollo-tooling/pull/1413)
 - `apollo-tools`
   - <First `apollo-tools` related entry goes here>
 - `vscode-apollo`
   - Only activate extension on apollo.config.js/ts [#1411](https://github.com/apollographql/apollo-tooling/pull/1411)
-  - Changed the status bar title to be "Apollo" to save space.
+  - Changed the status bar title to be "Apollo" to save space. [#1415](https://github.com/apollographql/apollo-tooling/pull/1415)
 
 ## `apollo@2.16.0`, `apollo-codegen-swift@0.34.0`, `apollo-language-server@1.13.0`, `apollo-tools@0.4.0`, `vscode-apollo@1.8.0`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Upcoming
 
 - `apollo`
-  - <First `apollo` related entry goes here>
+  - Add `ApolloConfig` type to exports from `apollo` [#1413](https://github.com/apollographql/apollo-tooling/pull/1413)
 - `apollo-codegen-core`
   - <First `apollo-codegen-core` related entry goes here>
 - `apollo-codegen-flow`

--- a/packages/apollo-language-server/src/engine/index.ts
+++ b/packages/apollo-language-server/src/engine/index.ts
@@ -274,8 +274,12 @@ export class ApolloEngineClient extends GraphQLDataSource {
       }
     });
 
-    if (!(data && data.service)) {
-      throw new Error();
+    if (!(data && data.service) || errors) {
+      throw new Error(
+        errors
+          ? errors.map(error => error.message).join("\n")
+          : "No service returned. Make sure your service name and API key match"
+      );
     }
 
     const schemaTags: string[] = data.service.schemaTags.map(

--- a/packages/apollo-language-server/src/project/client.ts
+++ b/packages/apollo-language-server/src/project/client.ts
@@ -169,7 +169,8 @@ export class GraphQLClientProject extends GraphQLProject {
         total: totalTypes
       },
       tag: this.config.tag,
-      loaded: this.serviceID ? true : false,
+      loaded:
+        this.serviceID && (this.schema || this.serviceSchema) ? true : false,
       lastFetch: this.lastLoadDate
     };
   }
@@ -271,15 +272,19 @@ export class GraphQLClientProject extends GraphQLProject {
     await this.loadingHandler.handle(
       `Loading Engine data for ${this.displayName}`,
       (async () => {
-        const {
-          schemaTags,
-          fieldStats
-        } = await engineClient.loadSchemaTagsAndFieldStats(serviceID);
-        this._onSchemaTags && this._onSchemaTags([serviceID, schemaTags]);
-        this.fieldStats = fieldStats;
-        this.lastLoadDate = +new Date();
+        try {
+          const {
+            schemaTags,
+            fieldStats
+          } = await engineClient.loadSchemaTagsAndFieldStats(serviceID);
+          this._onSchemaTags && this._onSchemaTags([serviceID, schemaTags]);
+          this.fieldStats = fieldStats;
+          this.lastLoadDate = +new Date();
 
-        this.generateDecorations();
+          this.generateDecorations();
+        } catch (e) {
+          console.error(e);
+        }
       })()
     );
   }

--- a/packages/apollo-language-server/src/project/client.ts
+++ b/packages/apollo-language-server/src/project/client.ts
@@ -169,8 +169,7 @@ export class GraphQLClientProject extends GraphQLProject {
         total: totalTypes
       },
       tag: this.config.tag,
-      loaded:
-        this.serviceID && (this.schema || this.serviceSchema) ? true : false,
+      loaded: Boolean(this.serviceID && (this.schema || this.serviceSchema)),
       lastFetch: this.lastLoadDate
     };
   }

--- a/packages/apollo-language-server/src/providers/schema/engine.ts
+++ b/packages/apollo-language-server/src/providers/schema/engine.ts
@@ -4,6 +4,7 @@ import gql from "graphql-tag";
 import { GraphQLSchema, buildClientSchema } from "graphql";
 import { ApolloEngineClient, ClientIdentity } from "../../engine";
 import { ClientConfig, parseServiceSpecifier } from "../../config";
+import { getServiceFromKey } from "../../config/utils";
 import {
   GraphQLSchemaProvider,
   SchemaChangeUnsubscribeHandler,
@@ -44,6 +45,15 @@ export class EngineSchemaProvider implements GraphQLSchemaProvider {
     }
 
     const [id, tag = "current"] = parseServiceSpecifier(client.service);
+
+    // make sure the API key is valid for the service we're requesting a schema of.
+    const keyServiceName = getServiceFromKey(engine.apiKey);
+    if (id !== keyServiceName) {
+      throw new Error(
+        `API key service name (${keyServiceName}) does not match the service name in your config (${id}). Try changing the service name in your config to ${keyServiceName} or get a new key.`
+      );
+    }
+
     const { data, errors } = await this.client.execute<GetSchemaByTag>({
       query: SCHEMA_QUERY,
       variables: {

--- a/packages/apollo/src/index.ts
+++ b/packages/apollo/src/index.ts
@@ -6,3 +6,5 @@ export * from "./Command";
 
 // export git utils
 export * from "./git";
+
+export { ApolloConfigFormat as ApolloConfig } from "apollo-language-server";


### PR DESCRIPTION
Right now, there's no error being printed when schema lookup fails. 

This PR aims to fix that, and add at least a safeguard for people using incorrect API keys. This can be partially checked on the client by checking the `config.service.name` against the identifier in the API key.

See the comments in the file changes for more explanation.

For the future, we really should standardize our error strategy to make sure they're being printed prettily in the editor. Right now, we're getting some pretty ugly stack traces.

<!--
  Thanks for filing a pull request on Apollo Tooling!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [ ] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [ ] Make sure all of the significant new logic is covered by tests
- [ ] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests and linter rules pass

\*Make sure changelog entries note which project(s) has been affected. See older entries for examples on what this looks like.
