### PR TITLE
Change status bar name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
 - `apollo-tools`
   - <First `apollo-tools` related entry goes here>
 - `vscode-apollo`
-  - <First `vscode-apollo` related entry goes here>
+  - Changed the status bar title to be "Apollo" to save space.
 
 ## `apollo@2.16.0`, `apollo-codegen-swift@0.34.0`, `apollo-language-server@1.13.0`, `apollo-tools@0.4.0`, `vscode-apollo@1.8.0`
 

--- a/packages/vscode-apollo/src/statusBar.ts
+++ b/packages/vscode-apollo/src/statusBar.ts
@@ -12,9 +12,9 @@ interface StateChangeInput extends LoadingInput {
 export default class ApolloStatusBar {
   public statusBarItem = window.createStatusBarItem(StatusBarAlignment.Right);
 
-  static loadingStateText = "Apollo GraphQL $(rss)";
-  static loadedStateText = "ApolloGraphQL $(rocket)";
-  static warningText = "Apollo GraphQL $(alert)";
+  static loadingStateText = "Apollo $(rss)";
+  static loadedStateText = "Apollo $(rocket)";
+  static warningText = "Apollo $(alert)";
 
   constructor({ hasActiveTextEditor }: LoadingInput) {
     this.showLoadingState({ hasActiveTextEditor });


### PR DESCRIPTION
"Apollo GraphQL" is a little verbose for the limited space on the status bar. This just renames it to "Apollo"

<!--
  Thanks for filing a pull request on Apollo Tooling!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [x] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests and linter rules pass

\*Make sure changelog entries note which project(s) has been affected. See older entries for examples on what this looks like.
