### PR TITLE
Add command to delete schema tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Upcoming
 
 - `apollo`
-  - <First `apollo` related entry goes here>
+  - Add `service:delete-tag` and tests [#1417](https://github.com/apollographql/apollo-tooling/pull/1417)
 - `apollo-codegen-core`
   - <First `apollo-codegen-core` related entry goes here>
 - `apollo-codegen-flow`
@@ -19,7 +19,7 @@
 - `apollo-graphql`
   - <First `apollo-graphql` related entry goes here>
 - `apollo-language-server`
-  - <First `apollo-language-server` related entry goes here>
+  - Add `deleteSchemaTag` to engine wrapper. [#1417](https://github.com/apollographql/apollo-tooling/pull/1417)
 - `apollo-tools`
   - <First `apollo-tools` related entry goes here>
 - `vscode-apollo`

--- a/packages/apollo-language-server/src/engine/index.ts
+++ b/packages/apollo-language-server/src/engine/index.ts
@@ -8,6 +8,7 @@ import { SCHEMA_TAGS_AND_FIELD_STATS } from "./operations/schemaTagsAndFieldStat
 import { UPLOAD_AND_COMPOSE_PARTIAL_SCHEMA } from "./operations/uploadAndComposePartialSchema";
 import { CHECK_PARTIAL_SCHEMA } from "./operations/checkPartialSchema";
 import { REMOVE_SERVICE_AND_COMPOSE } from "./operations/removeServiceAndCompose";
+import { DELETE_SCHEMA_TAG } from "./operations/deleteSchemaTag";
 import { LIST_SERVICES } from "./operations/listServices";
 import {
   ListServices,
@@ -26,7 +27,9 @@ import {
   CheckPartialSchema,
   CheckPartialSchemaVariables,
   RemoveServiceAndCompose,
-  RemoveServiceAndComposeVariables
+  RemoveServiceAndComposeVariables,
+  DeleteSchemaTag,
+  DeleteSchemaTagVariables
 } from "../graphqlTypes";
 
 export interface ClientIdentity {
@@ -263,6 +266,30 @@ export class ApolloEngineClient extends GraphQLDataSource {
         throw new Error("Error in request from Engine");
       }
       return data.service.registerOperationsWithResponse;
+    });
+  }
+
+  public async deleteSchemaTag(variables: DeleteSchemaTagVariables) {
+    return this.execute<DeleteSchemaTag>({
+      query: DELETE_SCHEMA_TAG,
+      variables
+    }).then(({ data, errors }) => {
+      // use error logger
+      if (errors) {
+        throw new Error(errors.map(error => error.message).join("\n"));
+      }
+
+      if (data && !data.service) {
+        throw new Error(
+          noServiceError(getServiceFromKey(this.engineKey), this.baseURL)
+        );
+      }
+
+      if (!(data && data.service && data.service.deleteSchemaTag)) {
+        throw new Error("Error in request from Engine");
+      }
+
+      return data.service.deleteSchemaTag;
     });
   }
 

--- a/packages/apollo-language-server/src/engine/operations/deleteSchemaTag.ts
+++ b/packages/apollo-language-server/src/engine/operations/deleteSchemaTag.ts
@@ -1,0 +1,11 @@
+import gql from "graphql-tag";
+
+export const DELETE_SCHEMA_TAG = gql`
+  mutation DeleteSchemaTag($id: ID!, $tag: String!) {
+    service(id: $id) {
+      deleteSchemaTag(tag: $tag) {
+        deleted
+      }
+    }
+  }
+`;

--- a/packages/apollo-language-server/src/graphqlTypes.ts
+++ b/packages/apollo-language-server/src/graphqlTypes.ts
@@ -199,6 +199,33 @@ export interface CheckSchemaVariables {
 // This file was automatically generated and should not be edited.
 
 // ====================================================
+// GraphQL mutation operation: DeleteSchemaTag
+// ====================================================
+
+export interface DeleteSchemaTag_service_deleteSchemaTag {
+  __typename: "DeleteSchemaTagResult";
+  deleted: boolean;
+}
+
+export interface DeleteSchemaTag_service {
+  __typename: "ServiceMutation";
+  deleteSchemaTag: DeleteSchemaTag_service_deleteSchemaTag;
+}
+
+export interface DeleteSchemaTag {
+  service: DeleteSchemaTag_service | null;
+}
+
+export interface DeleteSchemaTagVariables {
+  id: string;
+  tag: string;
+}
+
+/* tslint:disable */
+/* eslint-disable */
+// This file was automatically generated and should not be edited.
+
+// ====================================================
 // GraphQL query operation: ListServices
 // ====================================================
 

--- a/packages/apollo/src/commands/service/__tests__/__snapshots__/delete-tag.test.ts.snap
+++ b/packages/apollo/src/commands/service/__tests__/__snapshots__/delete-tag.test.ts.snap
@@ -1,0 +1,19 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`service:remove-tag integration should fail if tag does not exist 1`] = `
+"Loading Apollo Project [started]
+Loading Apollo Project [completed]
+Deleting schema tag bar [started]
+Deleting schema tag bar [failed]
+→ Could not delete schema tag bar
+"
+`;
+
+exports[`service:remove-tag integration should successfully delete tag if exists 1`] = `
+"Loading Apollo Project [started]
+Loading Apollo Project [completed]
+Deleting schema tag foo [started]
+Deleting schema tag foo [completed]
+Successfully deleted schema tag foo
+"
+`;

--- a/packages/apollo/src/commands/service/__tests__/delete-tag.test.ts
+++ b/packages/apollo/src/commands/service/__tests__/delete-tag.test.ts
@@ -1,0 +1,195 @@
+import ServiceDeleteTag from "../delete-tag";
+import chalk from "chalk";
+import { stdout } from "stdout-stderr";
+import nock = require("nock");
+
+const stagingAPI = "https://engine-staging-graphql.apollographql.com:443";
+
+/**
+ * Default API key. This is not an actual API key but a randomly generated string.
+ *
+ * If you need to use the `nock` recorder, then this will not work because we won't be able to access engine
+ * with a fake API key.
+ */
+const fakeApiKey = "service:engine:9YC5AooMa2yO11eFlZat11";
+
+/**
+ * Engine API key we're using.
+ *
+ * This is hard-coded to `fakeApiKey` because this is out day-to-day usage should be. If we're going to be
+ * updating the mocked data; we'll need to use a real API key (see [README#Regenerating Mocked Network
+ * Data](https://github.com/apollographql/apollo-tooling#regenerating-mocked-network-data)); which will be
+ * placed here.
+ */
+const apiKey = fakeApiKey;
+
+/**
+ * An array that we'll spread into all CLI commands to pass the engine api key.
+ */
+const cliKeyParameter = [`--key=${apiKey}`];
+
+/**
+ * The original `console.log` being mocked.
+ *
+ * We save it so we can restore it after a test.
+ */
+let mockedConsoleLogOriginal: Console["log"] | null = null;
+
+/**
+ * Array of intercepted console values.
+ */
+let mockedConsoleLogValues: string[] | null = null;
+
+// TODO: the following two functions are identical to the ones found in check.test.ts
+// and list.test.ts. We are choosing to duplicate them for now, because with a shared
+// helper function, jest overwrites console log output as the tests are run in parallel
+
+/**
+ * Mock and capture `console.log` and `stdout.write`s. Return them in that order as a single string.
+ *
+ * This will emulate what the output of running the CLI would look like.
+ *
+ * Call `uncaptureApplicationOutput` to reverse the effects of this function.
+ */
+function captureApplicationOutput() {
+  mockedConsoleLogOriginal = console["log"];
+  mockedConsoleLogValues = [];
+  console["log"] = jest.fn((...items) => {
+    if (!mockedConsoleLogValues) {
+      throw new Error(
+        "mockedConsoleLogValues is not prepared but we're still capturing console.log. This means there's a bug somewhere."
+      );
+    }
+
+    mockedConsoleLogValues.push(items.join(" "));
+  });
+
+  stdout.start();
+}
+
+/**
+ * Reverse mocking of `console.log` and `stdout.write`. If they weren't mocked to begin with, this will do
+ * nothing and return null.
+ */
+function uncaptureApplicationOutput(): string | null {
+  // These will be `null` if we haven't mocked `console.log`.
+  if (!mockedConsoleLogOriginal || !mockedConsoleLogValues) {
+    return null;
+  }
+
+  const result = mockedConsoleLogValues.concat(stdout.output).join("\n");
+  mockedConsoleLogValues = null;
+
+  // Restore `console.log`
+  console["log"] = mockedConsoleLogOriginal;
+
+  // Stop capturing `stdout`.
+  stdout.stop();
+
+  return result;
+}
+
+/**
+ * Mock network requests for a successful deletion.
+ */
+function mockDeletionSuccess() {
+  nock(stagingAPI, {
+    encodedQueryParams: true
+  })
+    .post(
+      "/api/graphql",
+      ({ operationName }) => operationName === "DeleteSchemaTag"
+    )
+    .reply(200, {
+      data: {
+        service: {
+          deleteSchemaTag: {
+            deleted: true
+          }
+        }
+      }
+    });
+}
+
+/**
+ * Mock network requests for a failed deletion.
+ */
+function mockDeletionFailure() {
+  nock(stagingAPI, {
+    encodedQueryParams: true
+  })
+    .post(
+      "/api/graphql",
+      ({ operationName }) => operationName === "DeleteSchemaTag"
+    )
+    .reply(200, {
+      data: {
+        service: {
+          deleteSchemaTag: {
+            deleted: false
+          }
+        }
+      }
+    });
+}
+
+describe("service:remove-tag", () => {
+  let originalChalkEnabled;
+
+  beforeEach(() => {
+    originalChalkEnabled = chalk.enabled;
+    chalk.enabled = false;
+
+    // Clean console log capturing before tests in the event that `afterEach` was not run successfully.
+    uncaptureApplicationOutput();
+
+    // Clean up all network mocks before tests in the event that `afterEach` was not run successfully.
+    nock.cleanAll();
+
+    nock.disableNetConnect();
+
+    // Set the jest timeout to be longer than the default 5000ms to compensate for slow CI.
+    jest.setTimeout(15000);
+  });
+
+  afterEach(() => {
+    chalk.enabled = originalChalkEnabled;
+
+    // Clean up console log mocking
+    uncaptureApplicationOutput();
+
+    // Clean up all network mocks and restore original functionality
+    nock.cleanAll();
+    nock.enableNetConnect();
+  });
+
+  describe("integration", () => {
+    it("should successfully delete tag if exists", async () => {
+      captureApplicationOutput();
+      mockDeletionSuccess();
+
+      expect.assertions(2);
+
+      await expect(
+        ServiceDeleteTag.run([...cliKeyParameter, "--tag=foo"])
+      ).resolves.not.toThrow();
+
+      // Inline snapshots don't work here due to https://github.com/facebook/jest/issues/6744.
+      expect(uncaptureApplicationOutput()).toMatchSnapshot();
+    });
+
+    it("should fail if tag does not exist", async () => {
+      captureApplicationOutput();
+      mockDeletionFailure();
+
+      expect.assertions(2);
+
+      await expect(
+        ServiceDeleteTag.run([...cliKeyParameter, "--tag=bar"])
+      ).rejects.toThrow();
+
+      // Inline snapshots don't work here due to https://github.com/facebook/jest/issues/6744.
+      expect(uncaptureApplicationOutput()).toMatchSnapshot();
+    });
+  });
+});

--- a/packages/apollo/src/commands/service/delete-tag.ts
+++ b/packages/apollo/src/commands/service/delete-tag.ts
@@ -1,0 +1,40 @@
+import { flags } from "@oclif/command";
+import { ProjectCommand } from "../../Command";
+
+export default class ServiceDeleteTag extends ProjectCommand {
+  static description = "Delete a schema tag.";
+
+  static flags = {
+    ...ProjectCommand.flags,
+    tag: flags.string({
+      char: "t",
+      description: "The published tag to check this service against"
+    })
+  };
+
+  async run() {
+    await this.runTasks(({ config, flags, project }) => [
+      <any>{
+        title: `Deleting schema tag ${flags.tag}`,
+        task: async () => {
+          if (!config.name) {
+            throw new Error("No service found to link to Engine");
+          }
+          if (!flags.tag) {
+            throw new Error("No tag specified to delete");
+          }
+
+          const { deleted } = await project.engine.deleteSchemaTag({
+            id: config.name,
+            tag: flags.tag
+          });
+          if (deleted) {
+            this.log(`Successfully deleted schema tag ${flags.tag}`);
+          } else {
+            throw new Error(`Could not delete schema tag ${flags.tag}`);
+          }
+        }
+      }
+    ]);
+  }
+}


### PR DESCRIPTION
Add `service:delete-tag` command. This could also be rolled into the current `service:delete` command but that seemed confusing since that was only meant to delete federated services. The command ends up calling the `deleteSchemaTag ` mutation on service.

Fixes https://github.com/apollographql/apollo-tooling/issues/948

```
$ apollo service:delete-tag --tag="foo"
  ✔ Loading Apollo Project
  ✔ Loading Apollo Project
  ✔ Deleting schema tag foo
```

```
apollo service:delete-tag --tag="bar"
  ✔ Loading Apollo Project
  ✔ Loading Apollo Project
  ✖ Deleting schema tag bar
    → Tag not found
Error: Tag not found
    at {apollo-tooling}/packages/apollo-language-server/src/engine/index.ts:279:15
    at Task.task ({apollo-tooling}/packages/apollo/src/commands/service/delete-tag.ts:27:31)
```

TODO:

- [x] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass

\*Make sure changelog entries note which project(s) has been affected. See older entries for examples on what this looks like.
