### PR TITLE
Update cli output/flag messaging

### DIFF
--- a/packages/apollo-language-server/src/config/config.ts
+++ b/packages/apollo-language-server/src/config/config.ts
@@ -135,7 +135,7 @@ export class ApolloConfig {
   public name?: string;
   public service?: ServiceConfigFormat;
   public client?: ClientConfigFormat;
-  private _tag?: string;
+  private _variant?: string;
 
   constructor(public rawConfig: ApolloConfigFormat, public configURI?: URI) {
     this.isService = !!rawConfig.service;
@@ -161,19 +161,28 @@ export class ApolloConfig {
     return configs;
   }
 
+  set variant(variant: string) {
+    this._variant = variant;
+  }
+
+  get variant(): string {
+    if (this._variant) return this._variant;
+    let variant: string = "current";
+    if (this.client && typeof this.client.service === "string") {
+      const specifierVariant = parseServiceSpecifier(this.client
+        .service as ServiceSpecifier)[1];
+      if (specifierVariant) variant = specifierVariant;
+    }
+    return variant;
+  }
+
+  // TODO tag has been renamed to variant, use that instead
   set tag(tag: string) {
-    this._tag = tag;
+    this.variant = tag;
   }
 
   get tag(): string {
-    if (this._tag) return this._tag;
-    let tag: string = "current";
-    if (this.client && typeof this.client.service === "string") {
-      const specifierTag = parseServiceSpecifier(this.client
-        .service as ServiceSpecifier)[1];
-      if (specifierTag) tag = specifierTag;
-    }
-    return tag;
+    return this.variant;
   }
 
   // this type needs to be an "EveryKeyIsOptionalApolloConfig"

--- a/packages/apollo/src/Command.ts
+++ b/packages/apollo/src/Command.ts
@@ -79,18 +79,18 @@ export abstract class ProjectCommand extends Command {
         "Additional header to send to server for introspectionQuery. May be used multiple times to add multiple headers. NOTE: The `--endpoint` flag is REQUIRED if using the `--header` flag."
     }),
     endpoint: flags.string({
-      description: "The url of your service"
+      description: "The url of your GraphQL server"
     }),
     key: flags.string({
-      description: "The API key for the Apollo Engine service",
+      description: "The API key for the Apollo Platform Graph",
       default: () => process.env.ENGINE_API_KEY
     }),
     engine: flags.string({
-      description: "Reporting URL for a custom Apollo Engine deployment",
+      description: "Reporting URL for a custom Apollo Platform deployment",
       hidden: true
     }),
     frontend: flags.string({
-      description: "URL for a custom Apollo Engine frontend",
+      description: "URL for a custom Apollo Platform frontend",
       hidden: true
     })
   };
@@ -99,7 +99,8 @@ export abstract class ProjectCommand extends Command {
     // The --tag has been deprecated in favor of --variant
     tag: flags.string({
       char: "t",
-      description: "[Deprecated] Use --variant or -v instead",
+      description:
+        "[Deprecated: use --variant] The published graph variant for this client",
       hidden: true,
       exclusive: ["variant"]
     }),

--- a/packages/apollo/src/Command.ts
+++ b/packages/apollo/src/Command.ts
@@ -145,7 +145,7 @@ export abstract class ProjectCommand extends Command {
       type: this.type
     });
 
-    config.variant = flags.variant || flags.tag || config.tag;
+    config.variant = flags.variant || flags.tag || config.variant;
 
     //  flag overides
     config.setDefaults({

--- a/packages/apollo/src/Command.ts
+++ b/packages/apollo/src/Command.ts
@@ -262,7 +262,7 @@ export abstract class ClientCommand extends ProjectCommand {
     }),
     tag: flags.string({
       char: "t",
-      description: "The published graph variant for this client",
+      description: "[Deprecated] Use --variant or -v instead",
       hidden: true,
       exclusive: ["variant"]
     }),

--- a/packages/apollo/src/Command.ts
+++ b/packages/apollo/src/Command.ts
@@ -263,7 +263,6 @@ export abstract class ClientCommand extends ProjectCommand {
     tag: flags.string({
       char: "t",
       description: "The published graph variant for this client",
-      default: "current",
       hidden: true,
       exclusive: ["variant"]
     }),

--- a/packages/apollo/src/Command.ts
+++ b/packages/apollo/src/Command.ts
@@ -91,6 +91,21 @@ export abstract class ProjectCommand extends Command {
     })
   };
 
+  static variantFlags = {
+    // The --tag has been deprecated in favor of --variant
+    tag: flags.string({
+      char: "t",
+      description: "[Deprecated] Use --variant or -v instead",
+      hidden: true,
+      exclusive: ["variant"]
+    }),
+    variant: flags.string({
+      char: "v",
+      description: "The published graph variant for this client",
+      exclusive: ["tag"]
+    })
+  };
+
   public project!: GraphQLProject;
   public tasks: ListrTask[] = [];
 
@@ -249,6 +264,7 @@ export abstract class ProjectCommand extends Command {
 export abstract class ClientCommand extends ProjectCommand {
   static flags = {
     ...ProjectCommand.flags,
+    ...ProjectCommand.variantFlags,
     clientReferenceId: flags.string({
       description:
         "Reference id for the client which will match ids from client traces, will use clientName if not provided"
@@ -259,17 +275,6 @@ export abstract class ClientCommand extends ProjectCommand {
     clientVersion: flags.string({
       description:
         "The version of the client that the queries will be attached to"
-    }),
-    tag: flags.string({
-      char: "t",
-      description: "[Deprecated] Use --variant or -v instead",
-      hidden: true,
-      exclusive: ["variant"]
-    }),
-    variant: flags.string({
-      char: "v",
-      description: "The published graph variant for this client",
-      exclusive: ["tag"]
     }),
     queries: flags.string({
       description: "Deprecated in favor of the includes flag"

--- a/packages/apollo/src/Command.ts
+++ b/packages/apollo/src/Command.ts
@@ -262,7 +262,16 @@ export abstract class ClientCommand extends ProjectCommand {
     }),
     tag: flags.string({
       char: "t",
-      description: "The published service tag for this client"
+      description: "The published graph variant for this client",
+      default: "current",
+      hidden: true,
+      exclusive: ["variant"]
+    }),
+    variant: flags.string({
+      char: "v",
+      description: "The published graph variant for this client",
+      default: "current",
+      exclusive: ["tag"]
     }),
     queries: flags.string({
       description: "Deprecated in favor of the includes flag"

--- a/packages/apollo/src/Command.ts
+++ b/packages/apollo/src/Command.ts
@@ -270,7 +270,6 @@ export abstract class ClientCommand extends ProjectCommand {
     variant: flags.string({
       char: "v",
       description: "The published graph variant for this client",
-      default: "current",
       exclusive: ["tag"]
     }),
     queries: flags.string({

--- a/packages/apollo/src/Command.ts
+++ b/packages/apollo/src/Command.ts
@@ -34,7 +34,11 @@ export interface Flags {
   key?: string;
   engine?: string;
   frontend?: string;
+  // The three flags below are not part of ProjectCommand.flags,
+  // but are used in ProjectCommand.createConfig so will stay
+  // optional on this type.
   tag?: string;
+  variant?: string;
   skipSSLValidation?: boolean;
 }
 
@@ -141,7 +145,8 @@ export abstract class ProjectCommand extends Command {
       type: this.type
     });
 
-    config.tag = flags.tag || config.tag || "current";
+    config.variant = flags.variant || flags.tag || config.tag;
+
     //  flag overides
     config.setDefaults({
       engine: {

--- a/packages/apollo/src/commands/client/check.ts
+++ b/packages/apollo/src/commands/client/check.ts
@@ -39,7 +39,7 @@ export default class ClientCheck extends ClientCommand {
         task: async ctx => {
           if (!config.name) {
             throw new Error(
-              "No graph found in Apollo config. Engine is required for this command."
+              "No graph found in Apollo config. Platform is required for this command."
             );
           }
 

--- a/packages/apollo/src/commands/client/check.ts
+++ b/packages/apollo/src/commands/client/check.ts
@@ -23,7 +23,7 @@ interface LocationOffset {
 
 export default class ClientCheck extends ClientCommand {
   static description =
-    "Check a client project's operations against a variant for a graph";
+    "Check a client project's operations against a published graph";
   static flags = {
     ...ClientCommand.flags
   };

--- a/packages/apollo/src/commands/client/check.ts
+++ b/packages/apollo/src/commands/client/check.ts
@@ -56,7 +56,7 @@ export default class ClientCheck extends ClientCommand {
 
           ctx.validationResults = await project.engine.validateOperations({
             id: config.name,
-            tag: flags.variant || flags.tag || config.tag,
+            tag: config.variant,
             operations: ctx.operations.map(({ body, name }) => ({
               body,
               name

--- a/packages/apollo/src/commands/client/check.ts
+++ b/packages/apollo/src/commands/client/check.ts
@@ -39,7 +39,7 @@ export default class ClientCheck extends ClientCommand {
         task: async ctx => {
           if (!config.name) {
             throw new Error(
-              "No graph found in Apollo config. Platform is required for this command."
+              "No graph name found in Apollo config. Platform must be configured for this command to run."
             );
           }
 

--- a/packages/apollo/src/commands/client/check.ts
+++ b/packages/apollo/src/commands/client/check.ts
@@ -31,7 +31,7 @@ export default class ClientCheck extends ClientCommand {
     const { validationResults, operations } = await this.runTasks<{
       operations: Operation[];
       validationResults: ValidationResult[];
-    }>(({ project, config }) => [
+    }>(({ project, config, flags }) => [
       {
         title: "Checking client compatibility with service",
         task: async ctx => {
@@ -56,7 +56,7 @@ export default class ClientCheck extends ClientCommand {
 
           ctx.validationResults = await project.engine.validateOperations({
             id: config.name,
-            tag: config.tag,
+            tag: flags.variant || flags.tag || config.tag || "current",
             operations: ctx.operations.map(({ body, name }) => ({
               body,
               name

--- a/packages/apollo/src/commands/client/check.ts
+++ b/packages/apollo/src/commands/client/check.ts
@@ -56,7 +56,7 @@ export default class ClientCheck extends ClientCommand {
 
           ctx.validationResults = await project.engine.validateOperations({
             id: config.name,
-            tag: flags.variant || flags.tag || config.tag || "current",
+            tag: flags.variant || flags.tag || config.tag,
             operations: ctx.operations.map(({ body, name }) => ({
               body,
               name

--- a/packages/apollo/src/commands/client/codegen.ts
+++ b/packages/apollo/src/commands/client/codegen.ts
@@ -25,7 +25,7 @@ const waitForKey = async () => {
 export default class Generate extends ClientCommand {
   static aliases = ["codegen:generate"];
   static description =
-    "Generate static types for GraphQL queries. Can use the published schema in Apollo Platform or a downloaded schema.";
+    "Generate static types for GraphQL queries. Can use the published schema in the Apollo Platform or a downloaded schema.";
 
   static flags = {
     ...ClientCommand.flags,

--- a/packages/apollo/src/commands/client/codegen.ts
+++ b/packages/apollo/src/commands/client/codegen.ts
@@ -158,7 +158,7 @@ export default class Generate extends ClientCommand {
             task: async (ctx, task) => {
               task.title = `Generating query files with '${inferredTarget}' target`;
               const schema = await project.resolveSchema({
-                tag: flags.tag
+                tag: flags.variant || flags.tag || "current"
               });
 
               if (!schema) throw new Error("Error loading schema");

--- a/packages/apollo/src/commands/client/codegen.ts
+++ b/packages/apollo/src/commands/client/codegen.ts
@@ -25,7 +25,7 @@ const waitForKey = async () => {
 export default class Generate extends ClientCommand {
   static aliases = ["codegen:generate"];
   static description =
-    "Generate static types for GraphQL queries. Can use the published schema in Apollo Engine or a downloaded schema.";
+    "Generate static types for GraphQL queries. Can use the published schema in Apollo Platform or a downloaded schema.";
 
   static flags = {
     ...ClientCommand.flags,

--- a/packages/apollo/src/commands/client/codegen.ts
+++ b/packages/apollo/src/commands/client/codegen.ts
@@ -118,7 +118,7 @@ export default class Generate extends ClientCommand {
     } = this.parse(Generate);
 
     const run = () =>
-      this.runTasks(({ flags, args, project }) => {
+      this.runTasks(({ flags, args, project, config }) => {
         let inferredTarget: TargetType = "" as TargetType;
         if (
           ["json", "swift", "typescript", "flow", "scala"].includes(
@@ -158,7 +158,7 @@ export default class Generate extends ClientCommand {
             task: async (ctx, task) => {
               task.title = `Generating query files with '${inferredTarget}' target`;
               const schema = await project.resolveSchema({
-                tag: flags.variant || flags.tag || "current"
+                tag: config.variant
               });
 
               if (!schema) throw new Error("Error loading schema");

--- a/packages/apollo/src/commands/client/download-schema.ts
+++ b/packages/apollo/src/commands/client/download-schema.ts
@@ -23,11 +23,13 @@ export default class SchemaDownload extends ClientCommand {
   async run() {
     let result;
     let gitContext;
-    await this.runTasks(({ args, project, flags }) => [
+    await this.runTasks(({ args, project, flags, config }) => [
       {
         title: `Saving schema to ${args.output}`,
         task: async () => {
-          const schema = await project.resolveSchema({ tag: flags.tag });
+          const schema = await project.resolveSchema({
+            tag: flags.variant || flags.tag || config.tag || "current"
+          });
           writeFileSync(
             args.output,
             JSON.stringify(introspectionFromSchema(schema), null, 2)

--- a/packages/apollo/src/commands/client/download-schema.ts
+++ b/packages/apollo/src/commands/client/download-schema.ts
@@ -5,7 +5,8 @@ import { writeFileSync } from "fs";
 import { ClientCommand } from "../../Command";
 
 export default class SchemaDownload extends ClientCommand {
-  static description = "Download a schema from engine or a GraphQL endpoint.";
+  static description =
+    "Download schema from Apollo Platform or a GraphQL endpoint";
 
   static flags = {
     ...ClientCommand.flags

--- a/packages/apollo/src/commands/client/download-schema.ts
+++ b/packages/apollo/src/commands/client/download-schema.ts
@@ -6,7 +6,7 @@ import { ClientCommand } from "../../Command";
 
 export default class SchemaDownload extends ClientCommand {
   static description =
-    "Download schema from Apollo Platform or a GraphQL endpoint";
+    "Download schema from the Apollo Platform or a GraphQL endpoint";
 
   static flags = {
     ...ClientCommand.flags

--- a/packages/apollo/src/commands/client/download-schema.ts
+++ b/packages/apollo/src/commands/client/download-schema.ts
@@ -23,12 +23,12 @@ export default class SchemaDownload extends ClientCommand {
   async run() {
     let result;
     let gitContext;
-    await this.runTasks(({ args, project, flags }) => [
+    await this.runTasks(({ args, project, config }) => [
       {
         title: `Saving schema to ${args.output}`,
         task: async () => {
           const schema = await project.resolveSchema({
-            tag: flags.variant || flags.tag || "current"
+            tag: config.variant
           });
           writeFileSync(
             args.output,

--- a/packages/apollo/src/commands/client/download-schema.ts
+++ b/packages/apollo/src/commands/client/download-schema.ts
@@ -23,12 +23,12 @@ export default class SchemaDownload extends ClientCommand {
   async run() {
     let result;
     let gitContext;
-    await this.runTasks(({ args, project, flags, config }) => [
+    await this.runTasks(({ args, project, flags }) => [
       {
         title: `Saving schema to ${args.output}`,
         task: async () => {
           const schema = await project.resolveSchema({
-            tag: flags.variant || flags.tag || config.tag || "current"
+            tag: flags.variant || flags.tag || "current"
           });
           writeFileSync(
             args.output,

--- a/packages/apollo/src/commands/client/push.ts
+++ b/packages/apollo/src/commands/client/push.ts
@@ -53,7 +53,7 @@ export default class ClientPush extends ClientCommand {
           {
             title: `Checked operations against ${chalk.blue(
               config.name || ""
-            )}@${chalk.blue(config.tag)}`,
+            )}@${chalk.blue(flags.variant || flags.tag || config.tag)}`,
             task: async () => {}
           },
           {
@@ -88,8 +88,7 @@ export default class ClientPush extends ClientCommand {
                 id: config.name,
                 operations: operationManifest,
                 manifestVersion: 2,
-                graphVariant:
-                  flags.variant || flags.tag || config.tag || "current"
+                graphVariant: flags.variant || flags.tag || config.tag
               };
               const { operations: _op, ...restVariables } = variables;
               this.debug("Variables sent to Apollo");

--- a/packages/apollo/src/commands/client/push.ts
+++ b/packages/apollo/src/commands/client/push.ts
@@ -53,7 +53,7 @@ export default class ClientPush extends ClientCommand {
           {
             title: `Checked operations against ${chalk.blue(
               config.name || ""
-            )}@${chalk.blue(flags.variant || flags.tag || config.tag)}`,
+            )}@${chalk.blue(config.variant)}`,
             task: async () => {}
           },
           {
@@ -88,7 +88,7 @@ export default class ClientPush extends ClientCommand {
                 id: config.name,
                 operations: operationManifest,
                 manifestVersion: 2,
-                graphVariant: flags.variant || flags.tag || config.tag
+                graphVariant: config.variant
               };
               const { operations: _op, ...restVariables } = variables;
               this.debug("Variables sent to Apollo");

--- a/packages/apollo/src/commands/client/push.ts
+++ b/packages/apollo/src/commands/client/push.ts
@@ -88,7 +88,8 @@ export default class ClientPush extends ClientCommand {
                 id: config.name,
                 operations: operationManifest,
                 manifestVersion: 2,
-                graphVariant: config.tag
+                graphVariant:
+                  flags.variant || flags.tag || config.tag || "current"
               };
               const { operations: _op, ...restVariables } = variables;
               this.debug("Variables sent to Apollo");

--- a/packages/apollo/src/commands/client/push.ts
+++ b/packages/apollo/src/commands/client/push.ts
@@ -61,7 +61,7 @@ export default class ClientPush extends ClientCommand {
             task: async (_, task) => {
               if (!config.name) {
                 throw new Error(
-                  "No graph found in Apollo config. Platform is required for this command."
+                  "No graph name found in Apollo config. Platform must be configured for this command to run."
                 );
               }
 

--- a/packages/apollo/src/commands/client/push.ts
+++ b/packages/apollo/src/commands/client/push.ts
@@ -61,7 +61,7 @@ export default class ClientPush extends ClientCommand {
             task: async (_, task) => {
               if (!config.name) {
                 throw new Error(
-                  "No service found to link to Engine. Engine is required for this command."
+                  "No graph found in Apollo config. Engine is required for this command."
                 );
               }
 

--- a/packages/apollo/src/commands/client/push.ts
+++ b/packages/apollo/src/commands/client/push.ts
@@ -61,7 +61,7 @@ export default class ClientPush extends ClientCommand {
             task: async (_, task) => {
               if (!config.name) {
                 throw new Error(
-                  "No graph found in Apollo config. Engine is required for this command."
+                  "No graph found in Apollo config. Platform is required for this command."
                 );
               }
 

--- a/packages/apollo/src/commands/service/__tests__/__snapshots__/check.test.ts.snap
+++ b/packages/apollo/src/commands/service/__tests__/__snapshots__/check.test.ts.snap
@@ -71,7 +71,7 @@ exports[`service:check integration federated should report composition errors co
 exports[`service:check integration federated should report composition errors correctly --markdown 1`] = `
 "
 ### Apollo Service Check
-🔄 Validated graph composition on schema tag \`master\` for service \`accounts\` on graph \`engine\`.
+🔄 Validated graph composition on schema variant \`master\` for service \`accounts\` on graph \`engine\`.
 ❌ Found **3 composition errors**
 
 | Service   | Field     | Message   |
@@ -124,7 +124,7 @@ exports[`service:check integration federated should report composition success c
 exports[`service:check integration federated should report composition success correctly --markdown 1`] = `
 "
 ### Apollo Service Check
-🔄 Validated your local schema against schema tag \`master\` for service \`accounts\` on graph \`engine\`.
+🔄 Validated your local schema against schema variant \`master\` for service \`accounts\` on graph \`engine\`.
 🔢 Compared **1 schema change** against **0 operations** seen over the **last 548 days**.
 ✅ Found **no breaking changes**.
 
@@ -141,10 +141,10 @@ Validate graph composition for service accounts on graph engine [started]
 → Attempting to compose graph with accounts service's partial schema
 Found 0 graph composition errors for service accounts on graph engine [title changed]
 Found 0 graph composition errors for service accounts on graph engine [completed]
-Validating composed schema against tag master on graph engine [started]
+Validating composed schema against variant master on graph engine [started]
 → Validating schema
-Validated composed schema against tag master on graph engine [title changed]
-Validated composed schema against tag master on graph engine [completed]
+Validated composed schema against variant master on graph engine [title changed]
+Validated composed schema against variant master on graph engine [completed]
 Comparing schema changes [started]
 Compared 1 schema change against 0 operations over the last 548 days [title changed]
 Compared 1 schema change against 0 operations over the last 548 days [completed]
@@ -181,7 +181,7 @@ exports[`service:check integration non-federated should report traffic errors co
 exports[`service:check integration non-federated should report traffic errors correctly --markdown 1`] = `
 "
 ### Apollo Service Check
-🔄 Validated your local schema against schema tag \`master\` on graph \`engine\`.
+🔄 Validated your local schema against schema variant \`master\` on graph \`engine\`.
 🔢 Compared **1 schema change** against **0 operations** seen over the **last 548 days**.
 ❌ Found **1 breaking change** that would affect **0 operations** across **0 clients**
 
@@ -193,11 +193,11 @@ exports[`service:check integration non-federated should report traffic errors co
 exports[`service:check integration non-federated should report traffic errors correctly vanilla 1`] = `
 "Loading Apollo Project [started]
 Loading Apollo Project [completed]
-Validating schema against tag master on graph engine [started]
+Validating schema against variant master on graph engine [started]
 → Resolving schema
 → Validating schema
-Validated schema against tag master on graph engine [title changed]
-Validated schema against tag master on graph engine [completed]
+Validated schema against variant master on graph engine [title changed]
+Validated schema against variant master on graph engine [completed]
 Comparing schema changes [started]
 Compared 1 schema change against 0 operations over the last 548 days [title changed]
 Compared 1 schema change against 0 operations over the last 548 days [completed]
@@ -235,7 +235,7 @@ exports[`service:check integration non-federated should report traffic non-error
 exports[`service:check integration non-federated should report traffic non-errors correctly --markdown 1`] = `
 "
 ### Apollo Service Check
-🔄 Validated your local schema against schema tag \`master\` on graph \`engine\`.
+🔄 Validated your local schema against schema variant \`master\` on graph \`engine\`.
 🔢 Compared **1 schema change** against **0 operations** seen over the **last 548 days**.
 ✅ Found **no breaking changes**.
 
@@ -247,11 +247,11 @@ exports[`service:check integration non-federated should report traffic non-error
 exports[`service:check integration non-federated should report traffic non-errors correctly vanilla 1`] = `
 "Loading Apollo Project [started]
 Loading Apollo Project [completed]
-Validating schema against tag master on graph engine [started]
+Validating schema against variant master on graph engine [started]
 → Resolving schema
 → Validating schema
-Validated schema against tag master on graph engine [title changed]
-Validated schema against tag master on graph engine [completed]
+Validated schema against variant master on graph engine [title changed]
+Validated schema against variant master on graph engine [completed]
 Comparing schema changes [started]
 Compared 1 schema change against 0 operations over the last 548 days [title changed]
 Compared 1 schema change against 0 operations over the last 548 days [completed]
@@ -268,7 +268,7 @@ View full details at: https://engine-staging.apollographql.com/service/justin-fu
 exports[`service:check markdown formatting is correct with breaking changes 1`] = `
 "
 ### Apollo Service Check
-🔄 Validated your local schema against schema tag \`staging\` on graph \`engine\`.
+🔄 Validated your local schema against schema variant \`staging\` on graph \`engine\`.
 🔢 Compared **18 schema changes** against **100 operations** seen over the **last 24 hours**.
 ❌ Found **7 breaking changes** that would affect **3 operations** across **2 clients**
 
@@ -279,7 +279,7 @@ exports[`service:check markdown formatting is correct with breaking changes 1`] 
 exports[`service:check markdown formatting is correct with breaking changes 2`] = `
 "
 ### Apollo Service Check
-🔄 Validated your local schema against schema tag \`staging\` on graph \`engine\`.
+🔄 Validated your local schema against schema variant \`staging\` on graph \`engine\`.
 🔢 Compared **1 schema change** against **1 operation** seen over the **last 24 hours**.
 ❌ Found **1 breaking change** that would affect **1 operation** across **1 client**
 
@@ -290,7 +290,7 @@ exports[`service:check markdown formatting is correct with breaking changes 2`] 
 exports[`service:check markdown formatting is correct with no breaking changes 1`] = `
 "
 ### Apollo Service Check
-🔄 Validated your local schema against schema tag \`staging\` on graph \`engine\`.
+🔄 Validated your local schema against schema variant \`staging\` on graph \`engine\`.
 🔢 Compared **0 schema changes** against **100 operations** seen over the **last 24 hours**.
 ✅ Found **no breaking changes**.
 

--- a/packages/apollo/src/commands/service/__tests__/__snapshots__/check.test.ts.snap
+++ b/packages/apollo/src/commands/service/__tests__/__snapshots__/check.test.ts.snap
@@ -91,7 +91,7 @@ Validate graph composition for service accounts on graph engine [started]
 → Attempting to compose graph with accounts service's partial schema
 Found 3 graph composition errors for service accounts on graph engine [title changed]
 Found 3 graph composition errors for service accounts on graph engine [failed]
-→ Federated service composition was unsuccessful. Please see the reasons below.
+→ Implementing service composition was unsuccessful. Please see the reasons below.
 
 Service   Field    Message
 ────────  ───────  ────────────────────────────────────────────────────────────────────────────────────────

--- a/packages/apollo/src/commands/service/__tests__/check.test.ts
+++ b/packages/apollo/src/commands/service/__tests__/check.test.ts
@@ -598,7 +598,7 @@ describe("service:check", () => {
       expect(
         formatMarkdown({
           graphName: "engine",
-          tag: "staging",
+          graphVariant: "staging",
           checkSchemaResult,
           graphCompositionID: "fff"
         })
@@ -607,7 +607,7 @@ describe("service:check", () => {
       expect(
         formatMarkdown({
           graphName: "engine",
-          tag: "staging",
+          graphVariant: "staging",
           checkSchemaResult: {
             ...checkSchemaResult,
             diffToPrevious: {
@@ -635,7 +635,7 @@ describe("service:check", () => {
       expect(
         formatMarkdown({
           graphName: "engine",
-          tag: "staging",
+          graphVariant: "staging",
           checkSchemaResult: {
             ...checkSchemaResult,
             diffToPrevious: {

--- a/packages/apollo/src/commands/service/__tests__/check.test.ts
+++ b/packages/apollo/src/commands/service/__tests__/check.test.ts
@@ -24,7 +24,7 @@ const localURL = "http://localhost:4000";
 const fakeApiKey = "service:engine:9YC5AooMa2yO11eFlZat11";
 
 /**
- * Engine API key we're using.
+ * Platform API key we're using.
  *
  * This is hard-coded to `fakeApiKey` because this is out day-to-day usage should be. If we're going to be
  * updating the mocked data; we'll need to use a real API key (see [README#Regenerating Mocked Network

--- a/packages/apollo/src/commands/service/__tests__/list.test.ts
+++ b/packages/apollo/src/commands/service/__tests__/list.test.ts
@@ -14,7 +14,7 @@ const stagingAPI = "https://engine-staging-graphql.apollographql.com:443";
 const fakeApiKey = "service:engine:9YC5AooMa2yO11eFlZat11";
 
 /**
- * Engine API key we're using.
+ * Platform API key we're using.
  *
  * This is hard-coded to `fakeApiKey` because this is out day-to-day usage should be. If we're going to be
  * updating the mocked data; we'll need to use a real API key (see [README#Regenerating Mocked Network

--- a/packages/apollo/src/commands/service/check.ts
+++ b/packages/apollo/src/commands/service/check.ts
@@ -261,7 +261,6 @@ export default class ServiceCheck extends ProjectCommand {
     tag: flags.string({
       char: "t",
       description: "The published tag to check this service against",
-      default: "current",
       exclusive: ["variant"],
       hidden: true
     }),

--- a/packages/apollo/src/commands/service/check.ts
+++ b/packages/apollo/src/commands/service/check.ts
@@ -326,7 +326,7 @@ export default class ServiceCheck extends ProjectCommand {
            * A graph can be either a monolithic schema or the result of composition a federated schema.
            */
           const graphName = config.name;
-          const tag = flags.tag || config.tag || "current";
+          const tag = flags.variant || flags.tag || config.tag || "current";
 
           /**
            * Name of the implementing service being checked.
@@ -434,7 +434,7 @@ export default class ServiceCheck extends ProjectCommand {
             {
               title: `Validating ${
                 serviceName ? "composed " : ""
-              }schema against tag ${chalk.blue(tag)} on graph ${chalk.blue(
+              }schema against variant ${chalk.blue(tag)} on graph ${chalk.blue(
                 graphName
               )}`,
               task: async (ctx: TasksOutput, task) => {
@@ -452,7 +452,7 @@ export default class ServiceCheck extends ProjectCommand {
                 } else {
                   // This is _not_ a `federated` schema. Resolve the schema given `config.tag`.
                   task.output = "Resolving schema";
-                  schema = await project.resolveSchema({ tag: config.tag });
+                  schema = await project.resolveSchema({ tag: tag });
                   if (!schema) {
                     throw new Error("Failed to resolve schema");
                   }
@@ -476,7 +476,7 @@ export default class ServiceCheck extends ProjectCommand {
 
                 const variables: CheckSchemaVariables = {
                   id: graphName,
-                  tag: flags.tag,
+                  tag: tag,
                   gitContext: await gitInfo(this.log),
                   frontend: flags.frontend || config.engine.frontend,
                   ...(historicParameters && { historicParameters }),

--- a/packages/apollo/src/commands/service/check.ts
+++ b/packages/apollo/src/commands/service/check.ts
@@ -268,7 +268,6 @@ export default class ServiceCheck extends ProjectCommand {
     variant: flags.string({
       char: "v",
       description: "The published tag to check this service against",
-      default: "current",
       exclusive: ["tag"]
     }),
     validationPeriod: flags.string({

--- a/packages/apollo/src/commands/service/check.ts
+++ b/packages/apollo/src/commands/service/check.ts
@@ -287,7 +287,7 @@ export default class ServiceCheck extends ProjectCommand {
     }),
     serviceName: flags.string({
       description:
-        "Provides the name of the implementing service for a federated graph. This flag will indicate that the schema is a partial schema from a federated service",
+        "Provides the name of the implementing service for a federated graph. This flag will indicate that the schema is a partial schema from an implementing service",
       dependsOn: ["endpoint"]
     })
   };
@@ -299,7 +299,7 @@ export default class ServiceCheck extends ProjectCommand {
     // Define this constant so we can throw it and compare against the same value.
     const breakingChangesErrorMessage = "breaking changes found";
     const federatedServiceCompositionUnsuccessfulErrorMessage =
-      "Federated service composition was unsuccessful. Please see the reasons below.";
+      "Implementing service composition was unsuccessful. Please see the reasons below.";
 
     let schema: GraphQLSchema | undefined;
     try {
@@ -327,7 +327,7 @@ export default class ServiceCheck extends ProjectCommand {
           const serviceName: string | undefined = flags.serviceName;
 
           if (!graphName) {
-            throw new Error("No service found to link to Engine");
+            throw new Error("No graph found in Apollo config");
           }
 
           // Add some fields to output that are required for producing
@@ -354,7 +354,7 @@ export default class ServiceCheck extends ProjectCommand {
 
                 const info = await project.resolveFederationInfo();
                 if (!info.sdl) {
-                  throw new Error("No SDL found for federated service");
+                  throw new Error("No SDL found for implementing service");
                 }
 
                 task.output = `Attempting to compose graph with ${chalk.blue(
@@ -624,9 +624,7 @@ export default class ServiceCheck extends ProjectCommand {
 
       const { service } = config;
       if (!service) {
-        throw new Error(
-          "Service mising from config. This should have been validated elsewhere"
-        );
+        throw new Error("Graph missing from config");
       }
 
       const graphName = config.service && config.service.name;

--- a/packages/apollo/src/commands/service/check.ts
+++ b/packages/apollo/src/commands/service/check.ts
@@ -260,7 +260,16 @@ export default class ServiceCheck extends ProjectCommand {
     ...ProjectCommand.flags,
     tag: flags.string({
       char: "t",
-      description: "The published tag to check this service against"
+      description: "The published tag to check this service against",
+      default: "current",
+      exclusive: ["variant"],
+      hidden: true
+    }),
+    variant: flags.string({
+      char: "v",
+      description: "The published tag to check this service against",
+      default: "current",
+      exclusive: ["tag"]
     }),
     validationPeriod: flags.string({
       description:

--- a/packages/apollo/src/commands/service/check.ts
+++ b/packages/apollo/src/commands/service/check.ts
@@ -317,7 +317,7 @@ export default class ServiceCheck extends ProjectCommand {
            * A graph can be either a monolithic schema or the result of composition a federated schema.
            */
           const graphName = config.name;
-          const graphVariant = flags.variant || flags.tag || config.tag;
+          const graphVariant = config.variant;
 
           /**
            * Name of the implementing service being checked.
@@ -442,7 +442,7 @@ export default class ServiceCheck extends ProjectCommand {
                     schemaHash: ctx.federationSchemaHash
                   };
                 } else {
-                  // This is _not_ a `federated` schema. Resolve the schema given `config.tag`.
+                  // This is _not_ a `federated` schema. Resolve the schema given `config.variant`.
                   task.output = "Resolving schema";
                   schema = await project.resolveSchema({ tag: graphVariant });
                   if (!schema) {

--- a/packages/apollo/src/commands/service/check.ts
+++ b/packages/apollo/src/commands/service/check.ts
@@ -327,7 +327,7 @@ export default class ServiceCheck extends ProjectCommand {
           const serviceName: string | undefined = flags.serviceName;
 
           if (!graphName) {
-            throw new Error("No graph found in Apollo config");
+            throw new Error("No graph name found in Apollo config");
           }
 
           // Add some fields to output that are required for producing

--- a/packages/apollo/src/commands/service/check.ts
+++ b/packages/apollo/src/commands/service/check.ts
@@ -476,10 +476,10 @@ export default class ServiceCheck extends ProjectCommand {
                 };
 
                 const { schema: _, ...restVariables } = variables;
-                this.debug("Variables sent to Engine:");
+                this.debug("Variables sent to Platform:");
                 this.debug(restVariables);
                 if (schema) {
-                  this.debug("SDL of introspection sent to Engine:");
+                  this.debug("SDL of introspection sent to Platform:");
                   this.debug(printSchema(schema));
                 } else {
                   this.debug("Schema hash generated:");

--- a/packages/apollo/src/commands/service/check.ts
+++ b/packages/apollo/src/commands/service/check.ts
@@ -259,17 +259,7 @@ export default class ServiceCheck extends ProjectCommand {
     "Check a service against known operation workloads to find breaking changes";
   static flags = {
     ...ProjectCommand.flags,
-    tag: flags.string({
-      char: "t",
-      description: "The published tag to check this service against",
-      exclusive: ["variant"],
-      hidden: true
-    }),
-    variant: flags.string({
-      char: "v",
-      description: "The published tag to check this service against",
-      exclusive: ["tag"]
-    }),
+    ...ProjectCommand.variantFlags,
     validationPeriod: flags.string({
       description:
         "The size of the time window with which to validate the schema against. You may provide a number (in seconds), or an ISO8601 format duration for more granularity (see: https://en.wikipedia.org/wiki/ISO_8601#Durations)"

--- a/packages/apollo/src/commands/service/delete.ts
+++ b/packages/apollo/src/commands/service/delete.ts
@@ -7,17 +7,7 @@ export default class ServiceDelete extends ProjectCommand {
     "Delete a federated service from Engine and recompose remaining services";
   static flags = {
     ...ProjectCommand.flags,
-    tag: flags.string({
-      char: "t",
-      hidden: true,
-      description: "The variant of the service to delete",
-      exclusive: ["variant"]
-    }),
-    variant: flags.string({
-      char: "v",
-      description: "The variant of the service to delete",
-      exclusive: ["tag"]
-    }),
+    ...ProjectCommand.variantFlags,
     federated: flags.boolean({
       char: "f",
       default: false,
@@ -81,7 +71,11 @@ export default class ServiceDelete extends ProjectCommand {
 
     if (result.updatedGateway) {
       this.log(
-        `The ${result.serviceName} service with ${result.graphVariant} tag was removed from ${result.graphName}. Remaining services were composed.`
+        `The ${result.serviceName} service with ${
+          result.graphVariant
+        } tag was removed from ${
+          result.graphName
+        }. Remaining services were composed.`
       );
       this.log("\n");
     }

--- a/packages/apollo/src/commands/service/delete.ts
+++ b/packages/apollo/src/commands/service/delete.ts
@@ -48,7 +48,8 @@ export default class ServiceDelete extends ProjectCommand {
             );
           }
 
-          const graphVariant = config.tag || flags.variant;
+          const graphVariant =
+            flags.variant || flags.tag || config.tag || "current";
 
           const {
             errors,

--- a/packages/apollo/src/commands/service/delete.ts
+++ b/packages/apollo/src/commands/service/delete.ts
@@ -11,7 +11,6 @@ export default class ServiceDelete extends ProjectCommand {
       char: "t",
       hidden: true,
       description: "The variant of the service to delete",
-      default: "current",
       exclusive: ["variant"]
     }),
     variant: flags.string({

--- a/packages/apollo/src/commands/service/delete.ts
+++ b/packages/apollo/src/commands/service/delete.ts
@@ -29,7 +29,7 @@ export default class ServiceDelete extends ProjectCommand {
         title: `Removing implementing service ${flags.serviceName} from graph ${config.name}`,
         task: async () => {
           if (!config.name) {
-            throw new Error("No graph found in Apollo config");
+            throw new Error("No graph name found in Apollo config");
           }
 
           if (flags.federated) {

--- a/packages/apollo/src/commands/service/delete.ts
+++ b/packages/apollo/src/commands/service/delete.ts
@@ -4,7 +4,7 @@ import { ProjectCommand } from "../../Command";
 
 export default class ServiceDelete extends ProjectCommand {
   static description =
-    "Delete an implementing service from Platform and recompose remaining implementating services";
+    "Delete an implementing service from a Graph in the Apollo Platform and recompose remaining implementing services";
   static flags = {
     ...ProjectCommand.flags,
     ...ProjectCommand.variantFlags,
@@ -26,7 +26,7 @@ export default class ServiceDelete extends ProjectCommand {
     let result;
     await this.runTasks(({ flags, project, config }) => [
       {
-        title: `Removing implementing service ${config.variant} from graph ${config.name}`,
+        title: `Removing implementing service ${flags.serviceName} from graph ${config.name}`,
         task: async () => {
           if (!config.name) {
             throw new Error("No graph found in Apollo config");

--- a/packages/apollo/src/commands/service/delete.ts
+++ b/packages/apollo/src/commands/service/delete.ts
@@ -38,8 +38,7 @@ export default class ServiceDelete extends ProjectCommand {
             );
           }
 
-          const graphVariant =
-            flags.variant || flags.tag || config.tag || "current";
+          const graphVariant = config.variant;
 
           const {
             errors,
@@ -73,7 +72,7 @@ export default class ServiceDelete extends ProjectCommand {
       this.log(
         `The ${result.serviceName} service with ${
           result.graphVariant
-        } tag was removed from ${
+        } variant was removed from ${
           result.graphName
         }. Remaining services were composed.`
       );

--- a/packages/apollo/src/commands/service/delete.ts
+++ b/packages/apollo/src/commands/service/delete.ts
@@ -17,7 +17,6 @@ export default class ServiceDelete extends ProjectCommand {
     variant: flags.string({
       char: "v",
       description: "The variant of the service to delete",
-      default: "current",
       exclusive: ["tag"]
     }),
     federated: flags.boolean({
@@ -50,7 +49,7 @@ export default class ServiceDelete extends ProjectCommand {
             );
           }
 
-          const graphVariant = flags.tag || config.tag || "current";
+          const graphVariant = config.tag || flags.variant;
 
           const {
             errors,

--- a/packages/apollo/src/commands/service/delete.ts
+++ b/packages/apollo/src/commands/service/delete.ts
@@ -9,7 +9,16 @@ export default class ServiceDelete extends ProjectCommand {
     ...ProjectCommand.flags,
     tag: flags.string({
       char: "t",
-      description: "The variant of the service to delete"
+      hidden: true,
+      description: "The variant of the service to delete",
+      default: "current",
+      exclusive: ["variant"]
+    }),
+    variant: flags.string({
+      char: "v",
+      description: "The variant of the service to delete",
+      default: "current",
+      exclusive: ["tag"]
     }),
     federated: flags.boolean({
       char: "f",

--- a/packages/apollo/src/commands/service/delete.ts
+++ b/packages/apollo/src/commands/service/delete.ts
@@ -4,7 +4,7 @@ import { ProjectCommand } from "../../Command";
 
 export default class ServiceDelete extends ProjectCommand {
   static description =
-    "Delete an implementing service from Engine and recompose remaining implementating services";
+    "Delete an implementing service from Platform and recompose remaining implementating services";
   static flags = {
     ...ProjectCommand.flags,
     ...ProjectCommand.variantFlags,

--- a/packages/apollo/src/commands/service/delete.ts
+++ b/packages/apollo/src/commands/service/delete.ts
@@ -4,7 +4,7 @@ import { ProjectCommand } from "../../Command";
 
 export default class ServiceDelete extends ProjectCommand {
   static description =
-    "Delete a federated service from Engine and recompose remaining services";
+    "Delete an implementing service from Engine and recompose remaining implementating services";
   static flags = {
     ...ProjectCommand.flags,
     ...ProjectCommand.variantFlags,
@@ -13,7 +13,7 @@ export default class ServiceDelete extends ProjectCommand {
       default: false,
       hidden: true,
       description:
-        "[Deprecated: use --serviceName to indicate federation] Indicates that the schema is a partial schema from a federated service"
+        "[Deprecated: use --serviceName to indicate federation] Indicates that the schema is a partial schema from an implementing service"
     }),
     serviceName: flags.string({
       required: true,
@@ -26,10 +26,10 @@ export default class ServiceDelete extends ProjectCommand {
     let result;
     await this.runTasks(({ flags, project, config }) => [
       {
-        title: "Removing service from Engine",
+        title: `Removing implementing service ${config.variant} from graph ${config.name}`,
         task: async () => {
           if (!config.name) {
-            throw new Error("No service found to link to Engine");
+            throw new Error("No graph found in Apollo config");
           }
 
           if (flags.federated) {
@@ -70,11 +70,7 @@ export default class ServiceDelete extends ProjectCommand {
 
     if (result.updatedGateway) {
       this.log(
-        `The ${result.serviceName} service with ${
-          result.graphVariant
-        } variant was removed from ${
-          result.graphName
-        }. Remaining services were composed.`
+        `The ${result.serviceName} implementing service with ${result.graphVariant} variant was removed from graph ${result.graphName}. Remaining implementing services were composed.`
       );
       this.log("\n");
     }

--- a/packages/apollo/src/commands/service/download.ts
+++ b/packages/apollo/src/commands/service/download.ts
@@ -46,7 +46,7 @@ export default class ServiceDownload extends ProjectCommand {
               this.log(chalk.red("ERROR: Connection refused."));
               this.log(
                 chalk.red(
-                  "You may not be running a service locally, or your endpoint url is incorrect."
+                  "You may not be running a GraphQL server locally, or your endpoint url is incorrect."
                 )
               );
               this.log(

--- a/packages/apollo/src/commands/service/download.ts
+++ b/packages/apollo/src/commands/service/download.ts
@@ -51,7 +51,7 @@ export default class ServiceDownload extends ProjectCommand {
               );
               this.log(
                 chalk.red(
-                  "If you're trying to download a schema from Apollo Platform, use the `client:download-schema` command instead."
+                  "If you're trying to download a schema from the Apollo Platform, use the `client:download-schema` command instead."
                 )
               );
             }

--- a/packages/apollo/src/commands/service/download.ts
+++ b/packages/apollo/src/commands/service/download.ts
@@ -39,12 +39,14 @@ export default class ServiceDownload extends ProjectCommand {
   async run() {
     let result;
     let gitContext;
-    await this.runTasks(({ args, project, flags }) => [
+    await this.runTasks(({ args, project, flags, config }) => [
       {
         title: `Saving schema to ${args.output}`,
         task: async () => {
           try {
-            const schema = await project.resolveSchema({ tag: flags.tag });
+            const schema = await project.resolveSchema({
+              tag: flags.variant || flags.tag || config.tag || "current"
+            });
             writeFileSync(
               args.output,
               JSON.stringify(introspectionFromSchema(schema), null, 2)

--- a/packages/apollo/src/commands/service/download.ts
+++ b/packages/apollo/src/commands/service/download.ts
@@ -51,7 +51,7 @@ export default class ServiceDownload extends ProjectCommand {
               );
               this.log(
                 chalk.red(
-                  "If you're trying to download a schema from Apollo Engine, use the `client:download-schema` command instead."
+                  "If you're trying to download a schema from Apollo Platform, use the `client:download-schema` command instead."
                 )
               );
             }

--- a/packages/apollo/src/commands/service/download.ts
+++ b/packages/apollo/src/commands/service/download.ts
@@ -35,7 +35,7 @@ export default class ServiceDownload extends ProjectCommand {
         task: async () => {
           try {
             const schema = await project.resolveSchema({
-              tag: flags.variant || flags.tag || config.tag
+              tag: config.variant
             });
             writeFileSync(
               args.output,

--- a/packages/apollo/src/commands/service/download.ts
+++ b/packages/apollo/src/commands/service/download.ts
@@ -10,17 +10,7 @@ export default class ServiceDownload extends ProjectCommand {
 
   static flags = {
     ...ProjectCommand.flags,
-    tag: flags.string({
-      char: "t",
-      description: "The published tag to check this service against",
-      hidden: true,
-      exclusive: ["variant"]
-    }),
-    variant: flags.string({
-      char: "v",
-      description: "The published tag to check this service against",
-      exclusive: ["tag"]
-    }),
+    ...ProjectCommand.variantFlags,
     skipSSLValidation: flags.boolean({
       char: "k",
       description: "Allow connections to an SSL site without certs"

--- a/packages/apollo/src/commands/service/download.ts
+++ b/packages/apollo/src/commands/service/download.ts
@@ -13,7 +13,6 @@ export default class ServiceDownload extends ProjectCommand {
     tag: flags.string({
       char: "t",
       description: "The published tag to check this service against",
-      default: "current",
       hidden: true,
       exclusive: ["variant"]
     }),

--- a/packages/apollo/src/commands/service/download.ts
+++ b/packages/apollo/src/commands/service/download.ts
@@ -20,7 +20,6 @@ export default class ServiceDownload extends ProjectCommand {
     variant: flags.string({
       char: "v",
       description: "The published tag to check this service against",
-      default: "current",
       exclusive: ["tag"]
     }),
     skipSSLValidation: flags.boolean({

--- a/packages/apollo/src/commands/service/download.ts
+++ b/packages/apollo/src/commands/service/download.ts
@@ -45,7 +45,7 @@ export default class ServiceDownload extends ProjectCommand {
         task: async () => {
           try {
             const schema = await project.resolveSchema({
-              tag: flags.variant || flags.tag || config.tag || "current"
+              tag: flags.variant || flags.tag || config.tag
             });
             writeFileSync(
               args.output,

--- a/packages/apollo/src/commands/service/download.ts
+++ b/packages/apollo/src/commands/service/download.ts
@@ -13,7 +13,15 @@ export default class ServiceDownload extends ProjectCommand {
     tag: flags.string({
       char: "t",
       description: "The published tag to check this service against",
-      default: "current"
+      default: "current",
+      hidden: true,
+      exclusive: ["variant"]
+    }),
+    variant: flags.string({
+      char: "v",
+      description: "The published tag to check this service against",
+      default: "current",
+      exclusive: ["tag"]
     }),
     skipSSLValidation: flags.boolean({
       char: "k",

--- a/packages/apollo/src/commands/service/list.ts
+++ b/packages/apollo/src/commands/service/list.ts
@@ -112,8 +112,6 @@ export default class ServiceList extends ProjectCommand {
   async run() {
     // @ts-ignore we're going to populate `taskOutput` later
     const taskOutput: TasksOutput = {};
-
-    let schema: GraphQLSchema | undefined;
     try {
       await this.runTasks<TasksOutput>(({ config, flags, project }) => {
         if (!isServiceProject(project)) {
@@ -128,7 +126,7 @@ export default class ServiceList extends ProjectCommand {
          * A graph can be either a monolithic schema or the result of composition a federated schema.
          */
         const graphName = config.name;
-        const variant = flags.tag || config.tag || "current";
+        const variant = flags.variant || flags.tag || config.tag || "current";
 
         if (!graphName) {
           throw new Error("No service found to link to Engine");

--- a/packages/apollo/src/commands/service/list.ts
+++ b/packages/apollo/src/commands/service/list.ts
@@ -117,7 +117,7 @@ export default class ServiceList extends ProjectCommand {
          * A graph can be either a monolithic schema or the result of composition a federated schema.
          */
         const graphName = config.name;
-        const variant = flags.variant || flags.tag || config.tag;
+        const graphVariant = config.variant;
 
         if (!graphName) {
           throw new Error("No service found to link to Engine");
@@ -133,7 +133,7 @@ export default class ServiceList extends ProjectCommand {
                 implementingServices
               } = await project.engine.listServices({
                 id: graphName,
-                graphVariant: variant
+                graphVariant
               });
               const newContext: typeof ctx = {
                 implementingServices,

--- a/packages/apollo/src/commands/service/list.ts
+++ b/packages/apollo/src/commands/service/list.ts
@@ -120,7 +120,7 @@ export default class ServiceList extends ProjectCommand {
         const graphVariant = config.variant;
 
         if (!graphName) {
-          throw new Error("No service found to link to Engine");
+          throw new Error("No graph found in Apollo config");
         }
 
         return [

--- a/packages/apollo/src/commands/service/list.ts
+++ b/packages/apollo/src/commands/service/list.ts
@@ -95,18 +95,7 @@ export default class ServiceList extends ProjectCommand {
   static description = "List the services in a graph";
   static flags = {
     ...ProjectCommand.flags,
-    tag: flags.string({
-      char: "t",
-      description: "The published tag to list the implementing services from",
-      exclusive: ["variant"],
-      hidden: true
-    }),
-    variant: flags.string({
-      char: "v",
-      description:
-        "The published variant to list the implementing services from",
-      exclusive: ["tag"]
-    })
+    ...ProjectCommand.variantFlags
   };
 
   async run() {

--- a/packages/apollo/src/commands/service/list.ts
+++ b/packages/apollo/src/commands/service/list.ts
@@ -97,7 +97,16 @@ export default class ServiceList extends ProjectCommand {
     ...ProjectCommand.flags,
     tag: flags.string({
       char: "t",
-      description: "The published tag to list the services from"
+      default: "current",
+      description: "The published tag to list the implementing services from",
+      exclusive: ["variant"]
+    }),
+    variant: flags.string({
+      char: "v",
+      default: "current",
+      description:
+        "The published variant to list the implementing services from",
+      exclusive: ["tag"]
     })
   };
 

--- a/packages/apollo/src/commands/service/list.ts
+++ b/packages/apollo/src/commands/service/list.ts
@@ -97,7 +97,6 @@ export default class ServiceList extends ProjectCommand {
     ...ProjectCommand.flags,
     tag: flags.string({
       char: "t",
-      default: "current",
       description: "The published tag to list the implementing services from",
       exclusive: ["variant"],
       hidden: true

--- a/packages/apollo/src/commands/service/list.ts
+++ b/packages/apollo/src/commands/service/list.ts
@@ -112,6 +112,8 @@ export default class ServiceList extends ProjectCommand {
   async run() {
     // @ts-ignore we're going to populate `taskOutput` later
     const taskOutput: TasksOutput = {};
+
+    let schema: GraphQLSchema | undefined;
     try {
       await this.runTasks<TasksOutput>(({ config, flags, project }) => {
         if (!isServiceProject(project)) {
@@ -126,7 +128,7 @@ export default class ServiceList extends ProjectCommand {
          * A graph can be either a monolithic schema or the result of composition a federated schema.
          */
         const graphName = config.name;
-        const variant = flags.variant || flags.tag || config.tag || "current";
+        const variant = flags.variant || flags.tag || config.tag;
 
         if (!graphName) {
           throw new Error("No service found to link to Engine");

--- a/packages/apollo/src/commands/service/list.ts
+++ b/packages/apollo/src/commands/service/list.ts
@@ -99,11 +99,11 @@ export default class ServiceList extends ProjectCommand {
       char: "t",
       default: "current",
       description: "The published tag to list the implementing services from",
-      exclusive: ["variant"]
+      exclusive: ["variant"],
+      hidden: true
     }),
     variant: flags.string({
       char: "v",
-      default: "current",
       description:
         "The published variant to list the implementing services from",
       exclusive: ["tag"]

--- a/packages/apollo/src/commands/service/list.ts
+++ b/packages/apollo/src/commands/service/list.ts
@@ -120,7 +120,7 @@ export default class ServiceList extends ProjectCommand {
         const graphVariant = config.variant;
 
         if (!graphName) {
-          throw new Error("No graph found in Apollo config");
+          throw new Error("No graph name found in Apollo config");
         }
 
         return [

--- a/packages/apollo/src/commands/service/push.ts
+++ b/packages/apollo/src/commands/service/push.ts
@@ -22,7 +22,6 @@ export default class ServicePush extends ProjectCommand {
     variant: flags.string({
       char: "v",
       description: "The variant to publish this service to",
-      default: "current",
       exclusive: ["tag"]
     }),
     localSchemaFile: flags.string({

--- a/packages/apollo/src/commands/service/push.ts
+++ b/packages/apollo/src/commands/service/push.ts
@@ -48,7 +48,7 @@ export default class ServicePush extends ProjectCommand {
         task: async () => {
           const graphVariant = config.variant;
           if (!config.name) {
-            throw new Error("No graph found in Apollo config");
+            throw new Error("No graph name found in Apollo config");
           }
 
           if (flags.federated) {

--- a/packages/apollo/src/commands/service/push.ts
+++ b/packages/apollo/src/commands/service/push.ts
@@ -57,6 +57,7 @@ export default class ServicePush extends ProjectCommand {
       {
         title: "Uploading service to Engine",
         task: async () => {
+          const variant = flags.variant || flags.tag || config.tag || "current";
           if (!config.name) {
             throw new Error("No service found to link to Engine");
           }
@@ -100,7 +101,7 @@ export default class ServicePush extends ProjectCommand {
               serviceWasCreated
             } = await project.engine.uploadAndComposePartialSchema({
               id: config.name,
-              graphVariant: config.tag,
+              graphVariant: variant,
               name: flags.serviceName || info.name,
               url: flags.serviceURL || info.url,
               revision:
@@ -119,20 +120,20 @@ export default class ServicePush extends ProjectCommand {
               serviceWasCreated,
               didUpdateGateway,
               graphId: config.name,
-              graphVariant: config.tag || "current"
+              graphVariant: variant
             };
 
             return;
           }
 
-          const schema = await project.resolveSchema({ tag: flags.tag });
+          const schema = await project.resolveSchema({ tag: variant });
 
           const variables: UploadSchemaVariables = {
             id: config.name,
             // @ts-ignore
             // XXX Looks like TS should be generating ReadonlyArrays instead
             schema: introspectionFromSchema(schema).__schema,
-            tag: flags.tag,
+            tag: variant,
             gitContext
           };
 

--- a/packages/apollo/src/commands/service/push.ts
+++ b/packages/apollo/src/commands/service/push.ts
@@ -46,8 +46,7 @@ export default class ServicePush extends ProjectCommand {
       {
         title: "Uploading service to Engine",
         task: async () => {
-          const graphVariant =
-            flags.variant || flags.tag || config.tag || "current";
+          const graphVariant = config.variant;
           if (!config.name) {
             throw new Error("No service found to link to Engine");
           }
@@ -79,7 +78,7 @@ export default class ServicePush extends ProjectCommand {
 
             /**
              * id: service id for root mutation (graph id)
-             * variant: like a tag. prod/staging/etc
+             * variant: prod/staging/etc
              * name: implementing service name inside of the graph
              * revision: git commit hash/docker id. placeholder for now
              */

--- a/packages/apollo/src/commands/service/push.ts
+++ b/packages/apollo/src/commands/service/push.ts
@@ -9,7 +9,7 @@ import chalk from "chalk";
 
 export default class ServicePush extends ProjectCommand {
   static aliases = ["schema:publish"];
-  static description = "Push a service to Engine";
+  static description = "Push a service to Platform";
   static flags = {
     ...ProjectCommand.flags,
     ...ProjectCommand.variantFlags,
@@ -44,7 +44,7 @@ export default class ServicePush extends ProjectCommand {
     let gitContext;
     await this.runTasks(({ flags, project, config }) => [
       {
-        title: "Uploading service to Engine",
+        title: "Uploading service to Platform",
         task: async () => {
           const graphVariant = config.variant;
           if (!config.name) {
@@ -127,9 +127,9 @@ export default class ServicePush extends ProjectCommand {
           };
 
           const { schema: _, ...restVariables } = variables;
-          this.debug("Variables sent to Engine:");
+          this.debug("Variables sent to Platform:");
           this.debug(restVariables);
-          this.debug("SDL of introspection sent to Engine:");
+          this.debug("SDL of introspection sent to Platform:");
           this.debug(printSchema(schema));
 
           const response = await project.engine.uploadSchema(variables);
@@ -140,7 +140,7 @@ export default class ServicePush extends ProjectCommand {
               hash: response.tag ? response.tag.schema.hash : null,
               code: response.code
             };
-            this.debug("Result received from Engine:");
+            this.debug("Result received from Platform:");
             this.debug(result);
           }
         }

--- a/packages/apollo/src/commands/service/push.ts
+++ b/packages/apollo/src/commands/service/push.ts
@@ -48,7 +48,7 @@ export default class ServicePush extends ProjectCommand {
         task: async () => {
           const graphVariant = config.variant;
           if (!config.name) {
-            throw new Error("No service found to link to Engine");
+            throw new Error("No graph found in Apollo config");
           }
 
           if (flags.federated) {
@@ -156,15 +156,11 @@ export default class ServicePush extends ProjectCommand {
 
     if (result.serviceWasCreated) {
       this.log(
-        `A new service called '${
-          result.implementingServiceName
-        }' for the '${graphString}' graph was created\n`
+        `A new service called '${result.implementingServiceName}' for the '${graphString}' graph was created\n`
       );
     } else if (result.implementingServiceName && isFederated) {
       this.log(
-        `The '${
-          result.implementingServiceName
-        }' service for the '${graphString}' graph was updated\n`
+        `The '${result.implementingServiceName}' service for the '${graphString}' graph was updated\n`
       );
     }
 
@@ -204,9 +200,7 @@ export default class ServicePush extends ProjectCommand {
 
     if (result.didUpdateGateway) {
       this.log(
-        `The gateway for the '${graphString}' graph was updated with a new schema, composed from the updated '${
-          result.implementingServiceName
-        }' service\n`
+        `The gateway for the '${graphString}' graph was updated with a new schema, composed from the updated '${result.implementingServiceName}' service\n`
       );
     } else if (isFederated) {
       this.log(

--- a/packages/apollo/src/commands/service/push.ts
+++ b/packages/apollo/src/commands/service/push.ts
@@ -57,7 +57,8 @@ export default class ServicePush extends ProjectCommand {
       {
         title: "Uploading service to Engine",
         task: async () => {
-          const variant = flags.variant || flags.tag || config.tag || "current";
+          const graphVariant =
+            flags.variant || flags.tag || config.tag || "current";
           if (!config.name) {
             throw new Error("No service found to link to Engine");
           }
@@ -101,7 +102,7 @@ export default class ServicePush extends ProjectCommand {
               serviceWasCreated
             } = await project.engine.uploadAndComposePartialSchema({
               id: config.name,
-              graphVariant: variant,
+              graphVariant,
               name: flags.serviceName || info.name,
               url: flags.serviceURL || info.url,
               revision:
@@ -120,20 +121,20 @@ export default class ServicePush extends ProjectCommand {
               serviceWasCreated,
               didUpdateGateway,
               graphId: config.name,
-              graphVariant: variant
+              graphVariant
             };
 
             return;
           }
 
-          const schema = await project.resolveSchema({ tag: variant });
+          const schema = await project.resolveSchema({ tag: graphVariant });
 
           const variables: UploadSchemaVariables = {
             id: config.name,
             // @ts-ignore
             // XXX Looks like TS should be generating ReadonlyArrays instead
             schema: introspectionFromSchema(schema).__schema,
-            tag: variant,
+            tag: graphVariant,
             gitContext
           };
 
@@ -167,11 +168,15 @@ export default class ServicePush extends ProjectCommand {
 
     if (result.serviceWasCreated) {
       this.log(
-        `A new service called '${result.implementingServiceName}' for the '${graphString}' graph was created\n`
+        `A new service called '${
+          result.implementingServiceName
+        }' for the '${graphString}' graph was created\n`
       );
     } else if (result.implementingServiceName && isFederated) {
       this.log(
-        `The '${result.implementingServiceName}' service for the '${graphString}' graph was updated\n`
+        `The '${
+          result.implementingServiceName
+        }' service for the '${graphString}' graph was updated\n`
       );
     }
 
@@ -211,7 +216,9 @@ export default class ServicePush extends ProjectCommand {
 
     if (result.didUpdateGateway) {
       this.log(
-        `The gateway for the '${graphString}' graph was updated with a new schema, composed from the updated '${result.implementingServiceName}' service\n`
+        `The gateway for the '${graphString}' graph was updated with a new schema, composed from the updated '${
+          result.implementingServiceName
+        }' service\n`
       );
     } else if (isFederated) {
       this.log(

--- a/packages/apollo/src/commands/service/push.ts
+++ b/packages/apollo/src/commands/service/push.ts
@@ -12,18 +12,7 @@ export default class ServicePush extends ProjectCommand {
   static description = "Push a service to Engine";
   static flags = {
     ...ProjectCommand.flags,
-    tag: flags.string({
-      char: "t",
-      description: "The tag to publish this service to",
-      default: "current",
-      hidden: true,
-      exclusive: ["variant"]
-    }),
-    variant: flags.string({
-      char: "v",
-      description: "The variant to publish this service to",
-      exclusive: ["tag"]
-    }),
+    ...ProjectCommand.variantFlags,
     localSchemaFile: flags.string({
       description:
         "Path to your local GraphQL schema file (introspection result or SDL)"

--- a/packages/apollo/src/commands/service/push.ts
+++ b/packages/apollo/src/commands/service/push.ts
@@ -15,7 +15,15 @@ export default class ServicePush extends ProjectCommand {
     tag: flags.string({
       char: "t",
       description: "The tag to publish this service to",
-      default: "current"
+      default: "current",
+      hidden: true,
+      exclusive: ["variant"]
+    }),
+    variant: flags.string({
+      char: "v",
+      description: "The variant to publish this service to",
+      default: "current",
+      exclusive: ["tag"]
     }),
     localSchemaFile: flags.string({
       description:


### PR DESCRIPTION
Update the output/flags in the cli to reflect the current terminology.
- tag -> variant
- service -> graph (in non federated contexts)
- federated service -> implementing service
- engine -> platform

See https://apollographql.quip.com/smu3Abah39Nq/Service-Tag-Name-apollo-Audit

Pulled a lot of these changes from https://github.com/apollographql/apollo-tooling/pull/1398

Theres more work to do here but I would rather do that in follow up PRs

TODO:

- [ ] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass

\*Make sure changelog entries note which project(s) has been affected. See older entries for examples on what this looks like.
