### PR TITLE
Standardize language server errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,11 +19,11 @@
 - `apollo-graphql`
   - <First `apollo-graphql` related entry goes here>
 - `apollo-language-server`
-  - <First `apollo-language-server` related entry goes here>
+  - Add debugging util classes for better error/warning handling [#1429](https://github.com/apollographql/apollo-tooling/pull/1429)
 - `apollo-tools`
   - <First `apollo-tools` related entry goes here>
 - `vscode-apollo`
-  - <First `vscode-apollo` related entry goes here>
+  - Add debugging util class for better logging in vs code [#1429](https://github.com/apollographql/apollo-tooling/pull/1429)
 
 ## `apollo-language-server@1.14.3`
 

--- a/packages/apollo-language-server/src/config/__tests__/loadConfig.ts
+++ b/packages/apollo-language-server/src/config/__tests__/loadConfig.ts
@@ -153,8 +153,14 @@ describe("loadConfig", () => {
       writeFilesToDir(dir, {
         "package.json": `{"apollo":{"client": {"service": "hello"}} }`
       });
+
+      // silence the warning
+      const spy = jest.spyOn(console, "warn");
+      spy.mockImplementationOnce(() => {});
+
       const config = await loadConfig({ configPath: dirPath });
 
+      spy.mockRestore();
       expect(config.client.service).toEqual("hello");
     });
 
@@ -168,7 +174,7 @@ describe("loadConfig", () => {
     });
   });
 
-  fdescribe("errors", () => {
+  describe("errors", () => {
     it("throws when config file is empty", async () => {
       writeFilesToDir(dir, { "my.config.js": `` });
 
@@ -335,20 +341,6 @@ describe("loadConfig", () => {
       });
 
       expect(config.isService).toEqual(true);
-    });
-
-    it("throws if project type cant be inferred", done => {
-      writeFilesToDir(dir, {
-        "my.config.js": `module.exports = { engine: { endpoint: 'http://a.a' } }`
-      });
-
-      return loadConfig({
-        configPath: dirPath,
-        configFileName: "my.config.js"
-      }).catch(err => {
-        expect(err.message).toMatch(/.*Unable to resolve project type.*/);
-        done();
-      });
     });
   });
 

--- a/packages/apollo-language-server/src/config/__tests__/loadConfig.ts
+++ b/packages/apollo-language-server/src/config/__tests__/loadConfig.ts
@@ -181,9 +181,11 @@ describe("loadConfig", () => {
         configFileName: "my.config.js"
       });
 
-      expect(
-        spy.mock.calls[0][0].includes("config file failed to load")
-      ).toBeTruthy();
+      expect(spy).toHaveBeenCalledWith(
+        expect.stringMatching(/config file failed to load/i)
+      );
+
+      spy.mockRestore();
     });
 
     it("throws when explorer.search fails", async () => {
@@ -197,9 +199,12 @@ describe("loadConfig", () => {
         configPath: dirPath,
         configFileName: "my.config.js"
       });
-      expect(
-        spy.mock.calls[0][0].includes("config file failed to load")
-      ).toBeTruthy();
+
+      expect(spy).toHaveBeenCalledWith(
+        expect.stringMatching(/config file failed to load/i)
+      );
+
+      spy.mockRestore();
     });
 
     it("issues a deprecation warning when loading config from package.json", async () => {
@@ -215,9 +220,9 @@ describe("loadConfig", () => {
         configFileName: "package.json"
       });
 
-      expect(
-        spy.mock.calls[0][0].includes('The "apollo" package.json configuration')
-      ).toBeTruthy();
+      expect(spy).toHaveBeenCalledWith(
+        expect.stringMatching(/The "apollo" package.json configuration/i)
+      );
 
       spy.mockRestore();
     });
@@ -233,7 +238,9 @@ describe("loadConfig", () => {
         requireConfig: true // this is what we're testing
       });
 
-      expect(spy.mock.calls[0][0].includes("No Apollo config")).toBeTruthy();
+      expect(spy).toHaveBeenCalledWith(
+        expect.stringMatching(/no apollo config/i)
+      );
       spy.mockRestore();
     });
 
@@ -250,9 +257,9 @@ describe("loadConfig", () => {
         configFileName: "my.config.js"
       });
 
-      expect(
-        spy.mock.calls[0][0].includes("Unable to resolve project type")
-      ).toBeTruthy();
+      expect(spy).toHaveBeenCalledWith(
+        expect.stringMatching(/unable to resolve/i)
+      );
       spy.mockRestore();
     });
   });

--- a/packages/apollo-language-server/src/config/loadConfig.ts
+++ b/packages/apollo-language-server/src/config/loadConfig.ts
@@ -14,6 +14,7 @@ import {
 } from "./config";
 import { getServiceFromKey } from "./utils";
 import URI from "vscode-uri";
+import { Debug } from "../utilities";
 
 // config settings
 const MODULE_NAME = "apollo";
@@ -80,28 +81,26 @@ export async function loadConfig({
       ApolloConfigFormat
     >;
   } catch (error) {
-    throw new Error(
-      `A config file failed to load with options: ${JSON.stringify(
-        arguments[0]
-      )}.
-      The error was: ${error}`
-    );
+    return Debug.error(`A config file failed to load with options: ${JSON.stringify(
+      arguments[0]
+    )}.
+    The error was: ${error}`);
   }
 
   if (configPath && !loadedConfig) {
-    throw new Error(
+    return Debug.error(
       `A config file failed to load at '${configPath}'. This is likely because this file is empty or malformed. For more information, please refer to: https://bit.ly/2ByILPj`
     );
   }
 
   if (loadedConfig && loadedConfig.filepath.endsWith("package.json")) {
-    console.warn(
+    Debug.warning(
       'The "apollo" package.json configuration key will no longer be supported in Apollo v3. Please use the apollo.config.js file for Apollo project configuration. For more information, see: https://bit.ly/2ByILPj'
     );
   }
 
   if (requireConfig && !loadedConfig) {
-    throw new Error(
+    return Debug.error(
       `No Apollo config found for project. For more information, please refer to:
       https://bit.ly/2ByILPj`
     );
@@ -135,7 +134,7 @@ export async function loadConfig({
   else if (loadedConfig && loadedConfig.config.client) projectType = "client";
   else if (loadedConfig && loadedConfig.config.service) projectType = "service";
   else
-    throw new Error(
+    return Debug.error(
       "Unable to resolve project type. Please add either a client or service config. For more information, please refer to https://bit.ly/2ByILPj"
     );
 

--- a/packages/apollo-language-server/src/index.ts
+++ b/packages/apollo-language-server/src/index.ts
@@ -24,3 +24,6 @@ export * from "./config";
 // Generated types
 import * as graphqlTypes from "./graphqlTypes";
 export { graphqlTypes };
+
+// debug logger
+export { Debug } from "./utilities";

--- a/packages/apollo-language-server/src/server.ts
+++ b/packages/apollo-language-server/src/server.ts
@@ -12,9 +12,10 @@ import { QuickPickItem } from "vscode";
 import { GraphQLWorkspace } from "./workspace";
 import { GraphQLLanguageProvider } from "./languageProvider";
 import { LanguageServerLoadingHandler } from "./loadingHandler";
-import { debounceHandler } from "./utilities";
+import { debounceHandler, Debug } from "./utilities";
 
 const connection = createConnection(ProposedFeatures.all);
+Debug.SetConnection(connection);
 
 let hasWorkspaceFolderCapability = false;
 

--- a/packages/apollo-language-server/src/utilities/debug.ts
+++ b/packages/apollo-language-server/src/utilities/debug.ts
@@ -1,0 +1,37 @@
+import { IConnection } from "vscode-languageserver";
+
+export class Debug {
+  public static connection: IConnection;
+
+  public static SetConnection(conn: IConnection) {
+    Debug.connection = conn;
+  }
+
+  public static info(message: string) {
+    Debug.connection.sendNotification("serverDebugMessage", {
+      type: "info",
+      message: message
+    });
+  }
+
+  public static error(message: string) {
+    Debug.connection.sendNotification("serverDebugMessage", {
+      type: "error",
+      message: message
+    });
+  }
+
+  public static warning(message: string) {
+    Debug.connection.sendNotification("serverDebugMessage", {
+      type: "warning",
+      message: message
+    });
+  }
+
+  public static sendErrorTelemetry(message: string) {
+    Debug.connection.sendNotification("serverDebugMessage", {
+      type: "errorTelemetry",
+      message: message
+    });
+  }
+}

--- a/packages/apollo-language-server/src/utilities/debug.ts
+++ b/packages/apollo-language-server/src/utilities/debug.ts
@@ -1,5 +1,19 @@
 import { IConnection } from "vscode-languageserver";
 
+// for errors (and other logs in debug mode) we want to print a stack trace showing where they were thrown.
+// This uses an Error's stack trace, removes the three frames regarding this file (since they're useless) and
+// returns the rest of the trace.
+const createAndTrimStackTrace = () => {
+  let stack: string | undefined = new Error().stack;
+  // remove the lines in the stack from _this_ function and the caller (in this file) and shorten the trace
+  return stack && stack.split("\n").length > 2
+    ? stack
+        .split("\n")
+        .slice(3, 7)
+        .join("\n")
+    : stack;
+};
+
 export class Debug {
   public static connection?: IConnection;
 
@@ -17,12 +31,14 @@ export class Debug {
   }
 
   public static error(message: string) {
+    const stack = createAndTrimStackTrace();
     Debug.connection
       ? Debug.connection.sendNotification("serverDebugMessage", {
           type: "error",
-          message: message
+          message: message,
+          stack
         })
-      : console.error("[ERROR] " + message);
+      : console.error(`[ERROR] ${message}\n${stack}`);
   }
 
   public static warning(message: string) {

--- a/packages/apollo-language-server/src/utilities/debug.ts
+++ b/packages/apollo-language-server/src/utilities/debug.ts
@@ -1,37 +1,44 @@
 import { IConnection } from "vscode-languageserver";
 
 export class Debug {
-  public static connection: IConnection;
+  public static connection?: IConnection;
 
   public static SetConnection(conn: IConnection) {
     Debug.connection = conn;
   }
 
   public static info(message: string) {
-    Debug.connection.sendNotification("serverDebugMessage", {
-      type: "info",
-      message: message
-    });
+    Debug.connection
+      ? Debug.connection.sendNotification("serverDebugMessage", {
+          type: "info",
+          message: message
+        })
+      : console.log("[INFO] " + message);
   }
 
   public static error(message: string) {
-    Debug.connection.sendNotification("serverDebugMessage", {
-      type: "error",
-      message: message
-    });
+    Debug.connection
+      ? Debug.connection.sendNotification("serverDebugMessage", {
+          type: "error",
+          message: message
+        })
+      : console.error("[ERROR] " + message);
   }
 
   public static warning(message: string) {
-    Debug.connection.sendNotification("serverDebugMessage", {
-      type: "warning",
-      message: message
-    });
+    Debug.connection
+      ? Debug.connection.sendNotification("serverDebugMessage", {
+          type: "warning",
+          message: message
+        })
+      : console.warn("[WARNING] " + message);
   }
 
   public static sendErrorTelemetry(message: string) {
-    Debug.connection.sendNotification("serverDebugMessage", {
-      type: "errorTelemetry",
-      message: message
-    });
+    Debug.connection &&
+      Debug.connection.sendNotification("serverDebugMessage", {
+        type: "errorTelemetry",
+        message: message
+      });
   }
 }

--- a/packages/apollo-language-server/src/utilities/debug.ts
+++ b/packages/apollo-language-server/src/utilities/debug.ts
@@ -1,8 +1,11 @@
 import { IConnection } from "vscode-languageserver";
 
-// for errors (and other logs in debug mode) we want to print a stack trace showing where they were thrown.
-// This uses an Error's stack trace, removes the three frames regarding this file (since they're useless) and
-// returns the rest of the trace.
+/**
+ * for errors (and other logs in debug mode) we want to print
+ * a stack trace showing where they were thrown. This uses an
+ * Error's stack trace, removes the three frames regarding
+ * this file (since they're useless) and returns the rest of the trace.
+ */
 const createAndTrimStackTrace = () => {
   let stack: string | undefined = new Error().stack;
   // remove the lines in the stack from _this_ function and the caller (in this file) and shorten the trace

--- a/packages/apollo-language-server/src/utilities/debug.ts
+++ b/packages/apollo-language-server/src/utilities/debug.ts
@@ -18,7 +18,7 @@ const createAndTrimStackTrace = () => {
 };
 
 export class Debug {
-  public static connection?: IConnection;
+  private static connection?: IConnection;
 
   public static SetConnection(conn: IConnection) {
     Debug.connection = conn;

--- a/packages/apollo-language-server/src/utilities/index.ts
+++ b/packages/apollo-language-server/src/utilities/index.ts
@@ -1,2 +1,3 @@
 export * from "./debouncer";
 export * from "./uri";
+export { Debug } from "./debug";

--- a/packages/apollo/src/Command.ts
+++ b/packages/apollo/src/Command.ts
@@ -103,6 +103,13 @@ export abstract class ProjectCommand extends Command {
     this.ctx = { flags, args } as any;
 
     const config = await this.createConfig(flags);
+
+    if (!config) {
+      this.error("A config failed to load, so the command couldn't be run");
+      this.exit(1);
+      return;
+    }
+
     this.createService(config, flags);
     this.ctx.config = config;
 
@@ -125,6 +132,12 @@ export abstract class ProjectCommand extends Command {
       name: service,
       type: this.type
     });
+
+    if (!config) {
+      this.error("A config failed to load, so the command couldn't be run");
+      this.exit(1);
+      return;
+    }
 
     config.tag = flags.tag || config.tag || "current";
     //  flag overides

--- a/packages/vscode-apollo/src/debug.ts
+++ b/packages/vscode-apollo/src/debug.ts
@@ -1,5 +1,19 @@
 import { window, workspace, OutputChannel } from "vscode";
 
+// for errors (and other logs in debug mode) we want to print a stack trace showing where they were thrown.
+// This uses an Error's stack trace, removes the three frames regarding this file (since they're useless) and
+// returns the rest of the trace.
+const createAndTrimStackTrace = () => {
+  let stack: string | undefined = new Error().stack;
+  // remove the lines in the stack from _this_ function and the caller (in this file) and shorten the trace
+  return stack && stack.split("\n").length > 2
+    ? stack
+        .split("\n")
+        .slice(3, 7)
+        .join("\n")
+    : stack;
+};
+
 export class Debug {
   private static calls: number = 0;
   private static outputConsole?: OutputChannel;
@@ -11,22 +25,27 @@ export class Debug {
   /**
    * Displays an info message prefixed with [INFO]
    */
-  public static info(message: string) {
+  public static info(message: string, _stack?: string) {
     this.outputConsole && this.outputConsole.appendLine(`[INFO] ${message}`);
   }
 
   /**
    * Displays and error message prefixed with [ERROR]
+   * Creates and shows a truncated stack trace
    */
-  public static error(message: string) {
+  public static error(message: string, stack?: string) {
+    const stackTrace = stack || createAndTrimStackTrace();
     Debug.showConsole();
     this.outputConsole && this.outputConsole.appendLine(`[ERROR] ${message}`);
+    stackTrace &&
+      this.outputConsole &&
+      this.outputConsole.appendLine(stackTrace);
   }
 
   /**
    * Displays and warning message prefixed with [WARN]
    */
-  public static warning(message: string) {
+  public static warning(message: string, _stack?: string) {
     this.outputConsole && this.outputConsole.appendLine(`[WARN] ${message}`);
   }
 

--- a/packages/vscode-apollo/src/debug.ts
+++ b/packages/vscode-apollo/src/debug.ts
@@ -1,8 +1,11 @@
 import { window, workspace, OutputChannel } from "vscode";
 
-// for errors (and other logs in debug mode) we want to print a stack trace showing where they were thrown.
-// This uses an Error's stack trace, removes the three frames regarding this file (since they're useless) and
-// returns the rest of the trace.
+/**
+ * for errors (and other logs in debug mode) we want to print
+ * a stack trace showing where they were thrown. This uses an
+ * Error's stack trace, removes the three frames regarding
+ * this file (since they're useless) and returns the rest of the trace.
+ */
 const createAndTrimStackTrace = () => {
   let stack: string | undefined = new Error().stack;
   // remove the lines in the stack from _this_ function and the caller (in this file) and shorten the trace
@@ -15,7 +18,6 @@ const createAndTrimStackTrace = () => {
 };
 
 export class Debug {
-  private static calls: number = 0;
   private static outputConsole?: OutputChannel;
 
   public static SetOutputConsole(outputConsole: OutputChannel) {
@@ -44,6 +46,8 @@ export class Debug {
 
   /**
    * Displays and warning message prefixed with [WARN]
+   * Does not open the output window, since these
+   * are less urgent
    */
   public static warning(message: string, _stack?: string) {
     this.outputConsole && this.outputConsole.appendLine(`[WARN] ${message}`);
@@ -51,7 +55,6 @@ export class Debug {
 
   /**
    * TODO: enable error reporting and telemetry
-   * Displays and warning message prefixed with [WARN]
    */
   // public static sendErrorTelemetry(message: string) {
   //   if (Config.enableErrorTelemetry) {

--- a/packages/vscode-apollo/src/debug.ts
+++ b/packages/vscode-apollo/src/debug.ts
@@ -1,0 +1,52 @@
+import { window, workspace, OutputChannel } from "vscode";
+
+export class Debug {
+  private static calls: number = 0;
+  private static outputConsole?: OutputChannel;
+
+  public static SetOutputConsole(outputConsole: OutputChannel) {
+    this.outputConsole = outputConsole;
+  }
+
+  /**
+   * Displays an info message prefixed with [INFO]
+   */
+  public static info(message: string) {
+    this.outputConsole && this.outputConsole.appendLine(`[INFO] ${message}`);
+  }
+
+  /**
+   * Displays and error message prefixed with [ERROR]
+   */
+  public static error(message: string) {
+    Debug.showConsole();
+    this.outputConsole && this.outputConsole.appendLine(`[ERROR] ${message}`);
+  }
+
+  /**
+   * Displays and warning message prefixed with [WARN]
+   */
+  public static warning(message: string) {
+    this.outputConsole && this.outputConsole.appendLine(`[WARN] ${message}`);
+  }
+
+  /**
+   * TODO: enable error reporting and telemetry
+   * Displays and warning message prefixed with [WARN]
+   */
+  // public static sendErrorTelemetry(message: string) {
+  //   if (Config.enableErrorTelemetry) {
+  //     let encoded = new Buffer(message).toString("base64");
+  //     http.get("" + encoded, function () {});
+  //   }
+  // }
+
+  public static clear() {
+    this.outputConsole && this.outputConsole.clear();
+    this.outputConsole && this.outputConsole.dispose();
+  }
+
+  private static showConsole() {
+    this.outputConsole && this.outputConsole.show();
+  }
+}

--- a/packages/vscode-apollo/src/debug.ts
+++ b/packages/vscode-apollo/src/debug.ts
@@ -28,7 +28,12 @@ export class Debug {
    * Displays an info message prefixed with [INFO]
    */
   public static info(message: string, _stack?: string) {
-    this.outputConsole && this.outputConsole.appendLine(`[INFO] ${message}`);
+    // we check for the output console in every function
+    // since these are static functions and can be
+    // theoretically called before the output console is set
+    // (although that shouldn't technically be possible)
+    if (!this.outputConsole) return;
+    this.outputConsole.appendLine(`[INFO] ${message}`);
   }
 
   /**
@@ -36,12 +41,11 @@ export class Debug {
    * Creates and shows a truncated stack trace
    */
   public static error(message: string, stack?: string) {
+    if (!this.outputConsole) return;
     const stackTrace = stack || createAndTrimStackTrace();
     Debug.showConsole();
-    this.outputConsole && this.outputConsole.appendLine(`[ERROR] ${message}`);
-    stackTrace &&
-      this.outputConsole &&
-      this.outputConsole.appendLine(stackTrace);
+    this.outputConsole.appendLine(`[ERROR] ${message}`);
+    stackTrace && this.outputConsole.appendLine(stackTrace);
   }
 
   /**
@@ -50,7 +54,8 @@ export class Debug {
    * are less urgent
    */
   public static warning(message: string, _stack?: string) {
-    this.outputConsole && this.outputConsole.appendLine(`[WARN] ${message}`);
+    if (!this.outputConsole) return;
+    this.outputConsole.appendLine(`[WARN] ${message}`);
   }
 
   /**
@@ -64,11 +69,13 @@ export class Debug {
   // }
 
   public static clear() {
-    this.outputConsole && this.outputConsole.clear();
-    this.outputConsole && this.outputConsole.dispose();
+    if (!this.outputConsole) return;
+    this.outputConsole.clear();
+    this.outputConsole.dispose();
   }
 
   private static showConsole() {
-    this.outputConsole && this.outputConsole.show();
+    if (!this.outputConsole) return;
+    this.outputConsole.show();
   }
 }

--- a/packages/vscode-apollo/src/extension.ts
+++ b/packages/vscode-apollo/src/extension.ts
@@ -62,7 +62,7 @@ export function activate(context: ExtensionContext) {
   context.subscriptions.push(statusBar, outputChannel, clientDisposable);
 
   var serverDebugMessage: NotificationType<
-    { type: string; message: string },
+    { type: string; message: string; stack?: string },
     any
   > = new NotificationType("serverDebugMessage");
 
@@ -71,16 +71,16 @@ export function activate(context: ExtensionContext) {
     client.onNotification(serverDebugMessage, message => {
       switch (message.type) {
         case "info":
-          Debug.info(message.message);
+          Debug.info(message.message, message.stack);
           break;
         case "error":
-          Debug.error(message.message);
+          Debug.error(message.message, message.stack);
           break;
         case "warning":
-          Debug.warning(message.message);
+          Debug.warning(message.message, message.stack);
           break;
         default:
-          Debug.info(message.message);
+          Debug.info(message.message, message.stack);
           break;
       }
     });


### PR DESCRIPTION
This PR is the result of investigating how other implementations of the language server protocol handle errors. This PR proposes a new method of handling errors across the language server and its clients (CLI and VS Code). The intention is to produce a more friendly, consistent means by which to log and handle errors, as well as set up the basis for what could become usage metrics and error reporting, and verbose/debugging modes.

### The state of things now

- No control over the granularity of errors (full stack traces, all the time)
- No proper debug logging mechanism to help trace errors.
- No standard way to log normal messages/warnings from the language server to all clients
- Most language server implementations don't fail out. If an operation is unsuccessful, they just return an empty response, and the clients are responsible for messaging.


### Proposed Solution

At a high level, this method would eliminate the throwing of errors, and rely on errors being passed as notifications from the server to a client. For clients that don't consume the language server from a JSON-RPC transport (like the CLI which calls it directly) the server's error mechanism would be to fallback to console logs and errors. 

**The key with this proposal is to ONLY have graceful exits** from the language server. If something goes wrong, we should explain the error and do nothing. Failing out completely isn't great. Instead, clients should see empty responses from failed operations.

- `Debug` classes on the client (vscode) and server.
  - The client `Debug` class is responsible for printing errors, warnings, and info messages to the console. In CLI projects (or where `connection` is unavailable), the util will `log`/`warn`/`error` to the console
  - The server `Debug` class is responsible to notifying the client of errors via the `serverDebugMessage` notification.
  - There is a `serverDebugMessage` notification handler on the client which calls the `Debug` class methods to display errors to the user.
- How do we support stack traces for these errors?
  - By default, for Errors only (not warnings/info logs) we print the top 4 frames of the stack trace. We do this by creating a stack inside the `Debug` module and removing the unhelpful frames.
  - The server sends these frames as a string to the client, which can print it.
  - On the client, if a stack trace hasn't been provided (like if the client itself was erroring), we create a stack trace in the `Debug` module of the client.
  - I think we can support a `-v` or `--verbose` mode where errors and warnings have traces. We could also make sure those stacks aren't trimmed.
  - The `[INFO]` messages could be used for debug logs (maybe)

**Notes:**

- Inspiration from the [Crane Server](https://github.com/HvyIndustries/crane/blob/master/server/src/server.ts) implementation.
  - One of the few LSP implementations that explicitly handle errors _along with_ returning empty responses.
- This will also give us consistent hooks for printing debug info when in a `debug` mode (not implemented) and telemetry (not implemented).

**Future work:**

- [ ] the language server's `Debug` class _could_ allow for a separate error logger to be passed to it to support arbitrary clients that can't support console logs or notifications from the LSP, but since we don't have any clients for that, we shouldn't worry about that right now.

<!--
  Thanks for filing a pull request on Apollo Tooling!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [ ] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [ ] Make sure all of the significant new logic is covered by tests
- [ ] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests and linter rules pass

\*Make sure changelog entries note which project(s) has been affected. See older entries for examples on what this looks like.
