### PR TITLE
Swift Codegen Upgrades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@
   - Fix issue where type names were not being properly escaped [iOS 193](https://github.com/apollographql/apollo-ios/issues/193)
   - Fix overcorrection on removing redundant modifiers [#1449](https://github.com/apollographql/apollo-tooling/issues/1449)
   - Added `CaseIterable` conformance so all known cases can be easily iterated.
-  - Switched to using mutli-line string literals when there's a multi-line string (mostly affects operation/fragment definitions)
+  - Added comment to `operationDefinition` to show the original query
+  - Stripped excess whitespace out of `operationDefinition`
   - Removed force-unwrap when the thing being unwrapped is a double optional
 - `apollo-codegen-typescript`
   - <First `apollo-codegen-typescript` related entry goes here>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@
 - `apollo-codegen-swift`
   - Fix issue where type names were not being properly escaped [iOS 193](https://github.com/apollographql/apollo-ios/issues/193)
   - Fix overcorrection on removing redundant modifiers [#1449](https://github.com/apollographql/apollo-tooling/issues/1449)
+  - Added `CaseIterable` conformance so all known cases can be easily iterated.
+  - Switched to using mutli-line string literals when there's a multi-line string (mostly affects operation/fragment definitions)
+  - Removed force-unwrap when the thing being unwrapped is a double optional
 - `apollo-codegen-typescript`
   - <First `apollo-codegen-typescript` related entry goes here>
 - `apollo-env`

--- a/packages/apollo-codegen-swift/src/__tests__/__snapshots__/codeGeneration.ts.snap
+++ b/packages/apollo-codegen-swift/src/__tests__/__snapshots__/codeGeneration.ts.snap
@@ -879,6 +879,10 @@ exports[`Swift code generation #initializerDeclarationForProperties() should gen
 
 exports[`Swift code generation #structDeclarationForFragment() should generate a struct declaration for a fragment that includes a fragment spread 1`] = `
 "public struct HeroDetails: GraphQLFragment {
+  /// fragment HeroDetails on Character {
+  ///   name
+  ///   ...MoreHeroDetails
+  /// }
   public static let fragmentDefinition =
     \\"fragment HeroDetails on Character {\\\\n  name\\\\n  ...MoreHeroDetails\\\\n}\\"
 
@@ -953,6 +957,10 @@ exports[`Swift code generation #structDeclarationForFragment() should generate a
 
 exports[`Swift code generation #structDeclarationForFragment() should generate a struct declaration for a fragment with a concrete type condition 1`] = `
 "public struct DroidDetails: GraphQLFragment {
+  /// fragment DroidDetails on Droid {
+  ///   name
+  ///   primaryFunction
+  /// }
   public static let fragmentDefinition =
     \\"fragment DroidDetails on Droid {\\\\n  name\\\\n  primaryFunction\\\\n}\\"
 
@@ -997,6 +1005,12 @@ exports[`Swift code generation #structDeclarationForFragment() should generate a
 
 exports[`Swift code generation #structDeclarationForFragment() should generate a struct declaration for a fragment with a subselection 1`] = `
 "public struct HeroDetails: GraphQLFragment {
+  /// fragment HeroDetails on Character {
+  ///   name
+  ///   friends {
+  ///     name
+  ///   }
+  /// }
   public static let fragmentDefinition =
     \\"fragment HeroDetails on Character {\\\\n  name\\\\n  friends {\\\\n    name\\\\n  }\\\\n}\\"
 
@@ -1077,6 +1091,10 @@ exports[`Swift code generation #structDeclarationForFragment() should generate a
 
 exports[`Swift code generation #structDeclarationForFragment() should generate a struct declaration for a fragment with an abstract type condition 1`] = `
 "public struct HeroDetails: GraphQLFragment {
+  /// fragment HeroDetails on Character {
+  ///   name
+  ///   appearsIn
+  /// }
   public static let fragmentDefinition =
     \\"fragment HeroDetails on Character {\\\\n  name\\\\n  appearsIn\\\\n}\\"
 

--- a/packages/apollo-codegen-swift/src/__tests__/__snapshots__/codeGeneration.ts.snap
+++ b/packages/apollo-codegen-swift/src/__tests__/__snapshots__/codeGeneration.ts.snap
@@ -1712,7 +1712,7 @@ public struct ReviewInput: GraphQLMapConvertible {
   /// Comment about the movie, optional
   public var commentary: Swift.Optional<String?> {
     get {
-      return graphQLMap[\\"commentary\\"] as! Swift.Optional<String?>
+      return graphQLMap[\\"commentary\\"] as? Swift.Optional<String?>
     }
     set {
       graphQLMap.updateValue(newValue, forKey: \\"commentary\\")
@@ -1722,7 +1722,7 @@ public struct ReviewInput: GraphQLMapConvertible {
   /// Favorite color, optional
   public var favoriteColor: Swift.Optional<ColorInput?> {
     get {
-      return graphQLMap[\\"favorite_color\\"] as! Swift.Optional<ColorInput?>
+      return graphQLMap[\\"favorite_color\\"] as? Swift.Optional<ColorInput?>
     }
     set {
       graphQLMap.updateValue(newValue, forKey: \\"favorite_color\\")

--- a/packages/apollo-codegen-swift/src/__tests__/__snapshots__/codeGeneration.ts.snap
+++ b/packages/apollo-codegen-swift/src/__tests__/__snapshots__/codeGeneration.ts.snap
@@ -173,14 +173,7 @@ exports[`Swift code generation #classDeclarationForOperation() should correctly 
 exports[`Swift code generation #classDeclarationForOperation() should generate a class declaration for a mutation with variables 1`] = `
 "public final class CreateReviewMutation: GraphQLMutation {
   public let operationDefinition =
-\\"\\"\\"
-mutation CreateReview($episode: Episode) {
-  createReview(episode: $episode, review: {stars: 5, commentary: \\"Wow!\\"}) {
-    stars
-    commentary
-  }
-}
-\\"\\"\\"
+    \\"mutation CreateReview($episode: Episode) {\\\\n  createReview(episode: $episode, review: {stars: 5, commentary: \\\\\\"Wow!\\\\\\"}) {\\\\n    stars\\\\n    commentary\\\\n  }\\\\n}\\"
 
   public let operationName = \\"CreateReview\\"
 
@@ -265,15 +258,7 @@ mutation CreateReview($episode: Episode) {
 exports[`Swift code generation #classDeclarationForOperation() should generate a class declaration for a query with a fragment spread nested in an inline fragment 1`] = `
 "public final class HeroQuery: GraphQLQuery {
   public let operationDefinition =
-\\"\\"\\"
-query Hero {
-  hero {
-    ... on Droid {
-      ...HeroDetails
-    }
-  }
-}
-\\"\\"\\"
+    \\"query Hero {\\\\n  hero {\\\\n    ... on Droid {\\\\n      ...HeroDetails\\\\n    }\\\\n  }\\\\n}\\"
 
   public let operationName = \\"Hero\\"
 
@@ -405,13 +390,7 @@ query Hero {
 exports[`Swift code generation #classDeclarationForOperation() should generate a class declaration for a query with conditional fragment spreads 1`] = `
 "public final class HeroQuery: GraphQLQuery {
   public let operationDefinition =
-\\"\\"\\"
-query Hero {
-  hero {
-    ...DroidDetails
-  }
-}
-\\"\\"\\"
+    \\"query Hero {\\\\n  hero {\\\\n    ...DroidDetails\\\\n  }\\\\n}\\"
 
   public let operationName = \\"Hero\\"
 
@@ -571,13 +550,7 @@ query Hero {
 exports[`Swift code generation #classDeclarationForOperation() should generate a class declaration for a query with fragment spreads 1`] = `
 "public final class HeroQuery: GraphQLQuery {
   public let operationDefinition =
-\\"\\"\\"
-query Hero {
-  hero {
-    ...HeroDetails
-  }
-}
-\\"\\"\\"
+    \\"query Hero {\\\\n  hero {\\\\n    ...HeroDetails\\\\n  }\\\\n}\\"
 
   public let operationName = \\"Hero\\"
 
@@ -676,13 +649,7 @@ query Hero {
 exports[`Swift code generation #classDeclarationForOperation() should generate a class declaration for a query with variables 1`] = `
 "public final class HeroNameQuery: GraphQLQuery {
   public let operationDefinition =
-\\"\\"\\"
-query HeroName($episode: Episode) {
-  hero(episode: $episode) {
-    name
-  }
-}
-\\"\\"\\"
+    \\"query HeroName($episode: Episode) {\\\\n  hero(episode: $episode) {\\\\n    name\\\\n  }\\\\n}\\"
 
   public let operationName = \\"HeroName\\"
 
@@ -760,13 +727,7 @@ query HeroName($episode: Episode) {
 exports[`Swift code generation #classDeclarationForOperation() should generate a class declaration with an operationIdentifier property when generateOperationIds is specified 1`] = `
 "public final class HeroQuery: GraphQLQuery {
   public let operationDefinition =
-\\"\\"\\"
-query Hero {
-  hero {
-    ...HeroDetails
-  }
-}
-\\"\\"\\"
+    \\"query Hero {\\\\n  hero {\\\\n    ...HeroDetails\\\\n  }\\\\n}\\"
 
   public let operationName = \\"Hero\\"
 
@@ -886,12 +847,7 @@ exports[`Swift code generation #initializerDeclarationForProperties() should gen
 exports[`Swift code generation #structDeclarationForFragment() should generate a struct declaration for a fragment that includes a fragment spread 1`] = `
 "public struct HeroDetails: GraphQLFragment {
   public static let fragmentDefinition =
-\\"\\"\\"
-fragment HeroDetails on Character {
-  name
-  ...MoreHeroDetails
-}
-\\"\\"\\"
+    \\"fragment HeroDetails on Character {\\\\n  name\\\\n  ...MoreHeroDetails\\\\n}\\"
 
   public static let possibleTypes = [\\"Human\\", \\"Droid\\"]
 
@@ -965,12 +921,7 @@ fragment HeroDetails on Character {
 exports[`Swift code generation #structDeclarationForFragment() should generate a struct declaration for a fragment with a concrete type condition 1`] = `
 "public struct DroidDetails: GraphQLFragment {
   public static let fragmentDefinition =
-\\"\\"\\"
-fragment DroidDetails on Droid {
-  name
-  primaryFunction
-}
-\\"\\"\\"
+    \\"fragment DroidDetails on Droid {\\\\n  name\\\\n  primaryFunction\\\\n}\\"
 
   public static let possibleTypes = [\\"Droid\\"]
 
@@ -1014,14 +965,7 @@ fragment DroidDetails on Droid {
 exports[`Swift code generation #structDeclarationForFragment() should generate a struct declaration for a fragment with a subselection 1`] = `
 "public struct HeroDetails: GraphQLFragment {
   public static let fragmentDefinition =
-\\"\\"\\"
-fragment HeroDetails on Character {
-  name
-  friends {
-    name
-  }
-}
-\\"\\"\\"
+    \\"fragment HeroDetails on Character {\\\\n  name\\\\n  friends {\\\\n    name\\\\n  }\\\\n}\\"
 
   public static let possibleTypes = [\\"Human\\", \\"Droid\\"]
 
@@ -1101,12 +1045,7 @@ fragment HeroDetails on Character {
 exports[`Swift code generation #structDeclarationForFragment() should generate a struct declaration for a fragment with an abstract type condition 1`] = `
 "public struct HeroDetails: GraphQLFragment {
   public static let fragmentDefinition =
-\\"\\"\\"
-fragment HeroDetails on Character {
-  name
-  appearsIn
-}
-\\"\\"\\"
+    \\"fragment HeroDetails on Character {\\\\n  name\\\\n  appearsIn\\\\n}\\"
 
   public static let possibleTypes = [\\"Human\\", \\"Droid\\"]
 

--- a/packages/apollo-codegen-swift/src/__tests__/__snapshots__/codeGeneration.ts.snap
+++ b/packages/apollo-codegen-swift/src/__tests__/__snapshots__/codeGeneration.ts.snap
@@ -2,6 +2,16 @@
 
 exports[`Swift code generation #classDeclarationForOperation() should correctly escape a mutli-line string literal 1`] = `
 "public final class CreateReviewMutation: GraphQLMutation {
+  /// mutation CreateReview($episode: Episode) {
+  ///   createReview(episode: $episode, review: {stars: 5, commentary: """
+  ///     Wow!
+  ///     
+  ///       This movie ROCKED!
+  ///   """}) {
+  ///     stars
+  ///     commentary
+  ///   }
+  /// }
   public let operationDefinition =
     \\"mutation CreateReview($episode: Episode) {\\\\n  createReview(episode: $episode, review: {stars: 5, commentary: \\\\\\"\\\\\\"\\\\\\"\\\\n    Wow!\\\\n    \\\\n      This movie ROCKED!\\\\n  \\\\\\"\\\\\\"\\\\\\"}) {\\\\n    stars\\\\n    commentary\\\\n  }\\\\n}\\"
 
@@ -87,6 +97,16 @@ exports[`Swift code generation #classDeclarationForOperation() should correctly 
 
 exports[`Swift code generation #classDeclarationForOperation() should correctly escape a mutli-line string literal with backslashes 1`] = `
 "public final class CreateReviewMutation: GraphQLMutation {
+  /// mutation CreateReview($episode: Episode) {
+  ///   createReview(episode: $episode, review: {stars: 5, commentary: """
+  ///     Wow!
+  ///     
+  ///       This movie \\\\ ROCKED!
+  ///   """}) {
+  ///     stars
+  ///     commentary
+  ///   }
+  /// }
   public let operationDefinition =
     \\"mutation CreateReview($episode: Episode) {\\\\n  createReview(episode: $episode, review: {stars: 5, commentary: \\\\\\"\\\\\\"\\\\\\"\\\\n    Wow!\\\\n    \\\\n      This movie \\\\ ROCKED!\\\\n  \\\\\\"\\\\\\"\\\\\\"}) {\\\\n    stars\\\\n    commentary\\\\n  }\\\\n}\\"
 

--- a/packages/apollo-codegen-swift/src/__tests__/__snapshots__/codeGeneration.ts.snap
+++ b/packages/apollo-codegen-swift/src/__tests__/__snapshots__/codeGeneration.ts.snap
@@ -1649,7 +1649,7 @@ exports[`Swift code generation #structDeclarationForSelectionSet() should genera
 `;
 
 exports[`Swift code generation #typeDeclarationForGraphQLType() should escape identifiers in cases of enum declaration for a GraphQLEnumType 1`] = `
-"public enum AlbumPrivacies: RawRepresentable, Equatable, Hashable, Apollo.JSONDecodable, Apollo.JSONEncodable {
+"public enum AlbumPrivacies: RawRepresentable, Equatable, Hashable, CaseIterable, Apollo.JSONDecodable, Apollo.JSONEncodable {
   public typealias RawValue = String
   case \`public\`
   case \`private\`
@@ -1679,6 +1679,13 @@ exports[`Swift code generation #typeDeclarationForGraphQLType() should escape id
       case (.__unknown(let lhsValue), .__unknown(let rhsValue)): return lhsValue == rhsValue
       default: return false
     }
+  }
+
+  public static var allCases: [AlbumPrivacies] {
+    return [
+      .public,
+      .private,
+    ]
   }
 }"
 `;
@@ -1726,7 +1733,7 @@ public struct ReviewInput: GraphQLMapConvertible {
 
 exports[`Swift code generation #typeDeclarationForGraphQLType() should generate an enum declaration for a GraphQLEnumType 1`] = `
 "/// The episodes in the Star Wars trilogy
-public enum Episode: RawRepresentable, Equatable, Hashable, Apollo.JSONDecodable, Apollo.JSONEncodable {
+public enum Episode: RawRepresentable, Equatable, Hashable, CaseIterable, Apollo.JSONDecodable, Apollo.JSONEncodable {
   public typealias RawValue = String
   /// Star Wars Episode IV: A New Hope, released in 1977.
   case newhope
@@ -1763,6 +1770,14 @@ public enum Episode: RawRepresentable, Equatable, Hashable, Apollo.JSONDecodable
       case (.__unknown(let lhsValue), .__unknown(let rhsValue)): return lhsValue == rhsValue
       default: return false
     }
+  }
+
+  public static var allCases: [Episode] {
+    return [
+      .newhope,
+      .empire,
+      .jedi,
+    ]
   }
 }"
 `;

--- a/packages/apollo-codegen-swift/src/__tests__/__snapshots__/codeGeneration.ts.snap
+++ b/packages/apollo-codegen-swift/src/__tests__/__snapshots__/codeGeneration.ts.snap
@@ -173,7 +173,14 @@ exports[`Swift code generation #classDeclarationForOperation() should correctly 
 exports[`Swift code generation #classDeclarationForOperation() should generate a class declaration for a mutation with variables 1`] = `
 "public final class CreateReviewMutation: GraphQLMutation {
   public let operationDefinition =
-    \\"mutation CreateReview($episode: Episode) {\\\\n  createReview(episode: $episode, review: {stars: 5, commentary: \\\\\\"Wow!\\\\\\"}) {\\\\n    stars\\\\n    commentary\\\\n  }\\\\n}\\"
+\\"\\"\\"
+mutation CreateReview($episode: Episode) {
+  createReview(episode: $episode, review: {stars: 5, commentary: \\"Wow!\\"}) {
+    stars
+    commentary
+  }
+}
+\\"\\"\\"
 
   public let operationName = \\"CreateReview\\"
 
@@ -258,7 +265,15 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
 exports[`Swift code generation #classDeclarationForOperation() should generate a class declaration for a query with a fragment spread nested in an inline fragment 1`] = `
 "public final class HeroQuery: GraphQLQuery {
   public let operationDefinition =
-    \\"query Hero {\\\\n  hero {\\\\n    ... on Droid {\\\\n      ...HeroDetails\\\\n    }\\\\n  }\\\\n}\\"
+\\"\\"\\"
+query Hero {
+  hero {
+    ... on Droid {
+      ...HeroDetails
+    }
+  }
+}
+\\"\\"\\"
 
   public let operationName = \\"Hero\\"
 
@@ -390,7 +405,13 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
 exports[`Swift code generation #classDeclarationForOperation() should generate a class declaration for a query with conditional fragment spreads 1`] = `
 "public final class HeroQuery: GraphQLQuery {
   public let operationDefinition =
-    \\"query Hero {\\\\n  hero {\\\\n    ...DroidDetails\\\\n  }\\\\n}\\"
+\\"\\"\\"
+query Hero {
+  hero {
+    ...DroidDetails
+  }
+}
+\\"\\"\\"
 
   public let operationName = \\"Hero\\"
 
@@ -550,7 +571,13 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
 exports[`Swift code generation #classDeclarationForOperation() should generate a class declaration for a query with fragment spreads 1`] = `
 "public final class HeroQuery: GraphQLQuery {
   public let operationDefinition =
-    \\"query Hero {\\\\n  hero {\\\\n    ...HeroDetails\\\\n  }\\\\n}\\"
+\\"\\"\\"
+query Hero {
+  hero {
+    ...HeroDetails
+  }
+}
+\\"\\"\\"
 
   public let operationName = \\"Hero\\"
 
@@ -649,7 +676,13 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
 exports[`Swift code generation #classDeclarationForOperation() should generate a class declaration for a query with variables 1`] = `
 "public final class HeroNameQuery: GraphQLQuery {
   public let operationDefinition =
-    \\"query HeroName($episode: Episode) {\\\\n  hero(episode: $episode) {\\\\n    name\\\\n  }\\\\n}\\"
+\\"\\"\\"
+query HeroName($episode: Episode) {
+  hero(episode: $episode) {
+    name
+  }
+}
+\\"\\"\\"
 
   public let operationName = \\"HeroName\\"
 
@@ -727,7 +760,13 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
 exports[`Swift code generation #classDeclarationForOperation() should generate a class declaration with an operationIdentifier property when generateOperationIds is specified 1`] = `
 "public final class HeroQuery: GraphQLQuery {
   public let operationDefinition =
-    \\"query Hero {\\\\n  hero {\\\\n    ...HeroDetails\\\\n  }\\\\n}\\"
+\\"\\"\\"
+query Hero {
+  hero {
+    ...HeroDetails
+  }
+}
+\\"\\"\\"
 
   public let operationName = \\"Hero\\"
 
@@ -847,7 +886,12 @@ exports[`Swift code generation #initializerDeclarationForProperties() should gen
 exports[`Swift code generation #structDeclarationForFragment() should generate a struct declaration for a fragment that includes a fragment spread 1`] = `
 "public struct HeroDetails: GraphQLFragment {
   public static let fragmentDefinition =
-    \\"fragment HeroDetails on Character {\\\\n  name\\\\n  ...MoreHeroDetails\\\\n}\\"
+\\"\\"\\"
+fragment HeroDetails on Character {
+  name
+  ...MoreHeroDetails
+}
+\\"\\"\\"
 
   public static let possibleTypes = [\\"Human\\", \\"Droid\\"]
 
@@ -921,7 +965,12 @@ exports[`Swift code generation #structDeclarationForFragment() should generate a
 exports[`Swift code generation #structDeclarationForFragment() should generate a struct declaration for a fragment with a concrete type condition 1`] = `
 "public struct DroidDetails: GraphQLFragment {
   public static let fragmentDefinition =
-    \\"fragment DroidDetails on Droid {\\\\n  name\\\\n  primaryFunction\\\\n}\\"
+\\"\\"\\"
+fragment DroidDetails on Droid {
+  name
+  primaryFunction
+}
+\\"\\"\\"
 
   public static let possibleTypes = [\\"Droid\\"]
 
@@ -965,7 +1014,14 @@ exports[`Swift code generation #structDeclarationForFragment() should generate a
 exports[`Swift code generation #structDeclarationForFragment() should generate a struct declaration for a fragment with a subselection 1`] = `
 "public struct HeroDetails: GraphQLFragment {
   public static let fragmentDefinition =
-    \\"fragment HeroDetails on Character {\\\\n  name\\\\n  friends {\\\\n    name\\\\n  }\\\\n}\\"
+\\"\\"\\"
+fragment HeroDetails on Character {
+  name
+  friends {
+    name
+  }
+}
+\\"\\"\\"
 
   public static let possibleTypes = [\\"Human\\", \\"Droid\\"]
 
@@ -1045,7 +1101,12 @@ exports[`Swift code generation #structDeclarationForFragment() should generate a
 exports[`Swift code generation #structDeclarationForFragment() should generate a struct declaration for a fragment with an abstract type condition 1`] = `
 "public struct HeroDetails: GraphQLFragment {
   public static let fragmentDefinition =
-    \\"fragment HeroDetails on Character {\\\\n  name\\\\n  appearsIn\\\\n}\\"
+\\"\\"\\"
+fragment HeroDetails on Character {
+  name
+  appearsIn
+}
+\\"\\"\\"
 
   public static let possibleTypes = [\\"Human\\", \\"Droid\\"]
 

--- a/packages/apollo-codegen-swift/src/__tests__/__snapshots__/codeGeneration.ts.snap
+++ b/packages/apollo-codegen-swift/src/__tests__/__snapshots__/codeGeneration.ts.snap
@@ -179,7 +179,7 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
   ///   }
   /// }
   public let operationDefinition =
-    \\"mutation CreateReview($episode: Episode) {\\\\n createReview(episode: $episode, review: {stars: 5, commentary: \\\\\\"Wow!\\\\\\"}) {\\\\n stars\\\\n commentary\\\\n }\\\\n }\\"
+    \\"mutation CreateReview($episode: Episode) { createReview(episode: $episode, review: {stars: 5, commentary: \\\\\\"Wow!\\\\\\"}) { stars commentary } }\\"
 
   public let operationName = \\"CreateReview\\"
 
@@ -271,7 +271,7 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
   ///   }
   /// }
   public let operationDefinition =
-    \\"query Hero {\\\\n hero {\\\\n ... on Droid {\\\\n ...HeroDetails\\\\n }\\\\n }\\\\n }\\"
+    \\"query Hero { hero { ... on Droid { ...HeroDetails } } }\\"
 
   public let operationName = \\"Hero\\"
 
@@ -408,7 +408,7 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
   ///   }
   /// }
   public let operationDefinition =
-    \\"query Hero {\\\\n hero {\\\\n ...DroidDetails\\\\n }\\\\n }\\"
+    \\"query Hero { hero { ...DroidDetails } }\\"
 
   public let operationName = \\"Hero\\"
 
@@ -573,7 +573,7 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
   ///   }
   /// }
   public let operationDefinition =
-    \\"query Hero {\\\\n hero {\\\\n ...HeroDetails\\\\n }\\\\n }\\"
+    \\"query Hero { hero { ...HeroDetails } }\\"
 
   public let operationName = \\"Hero\\"
 
@@ -677,7 +677,7 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
   ///   }
   /// }
   public let operationDefinition =
-    \\"query HeroName($episode: Episode) {\\\\n hero(episode: $episode) {\\\\n name\\\\n }\\\\n }\\"
+    \\"query HeroName($episode: Episode) { hero(episode: $episode) { name } }\\"
 
   public let operationName = \\"HeroName\\"
 
@@ -760,7 +760,7 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
   ///   }
   /// }
   public let operationDefinition =
-    \\"query Hero {\\\\n hero {\\\\n ...HeroDetails\\\\n }\\\\n }\\"
+    \\"query Hero { hero { ...HeroDetails } }\\"
 
   public let operationName = \\"Hero\\"
 
@@ -884,7 +884,7 @@ exports[`Swift code generation #structDeclarationForFragment() should generate a
   ///   ...MoreHeroDetails
   /// }
   public static let fragmentDefinition =
-    \\"fragment HeroDetails on Character {\\\\n name\\\\n ...MoreHeroDetails\\\\n }\\"
+    \\"fragment HeroDetails on Character { name ...MoreHeroDetails }\\"
 
   public static let possibleTypes = [\\"Human\\", \\"Droid\\"]
 
@@ -962,7 +962,7 @@ exports[`Swift code generation #structDeclarationForFragment() should generate a
   ///   primaryFunction
   /// }
   public static let fragmentDefinition =
-    \\"fragment DroidDetails on Droid {\\\\n name\\\\n primaryFunction\\\\n }\\"
+    \\"fragment DroidDetails on Droid { name primaryFunction }\\"
 
   public static let possibleTypes = [\\"Droid\\"]
 
@@ -1012,7 +1012,7 @@ exports[`Swift code generation #structDeclarationForFragment() should generate a
   ///   }
   /// }
   public static let fragmentDefinition =
-    \\"fragment HeroDetails on Character {\\\\n name\\\\n friends {\\\\n name\\\\n }\\\\n }\\"
+    \\"fragment HeroDetails on Character { name friends { name } }\\"
 
   public static let possibleTypes = [\\"Human\\", \\"Droid\\"]
 
@@ -1096,7 +1096,7 @@ exports[`Swift code generation #structDeclarationForFragment() should generate a
   ///   appearsIn
   /// }
   public static let fragmentDefinition =
-    \\"fragment HeroDetails on Character {\\\\n name\\\\n appearsIn\\\\n }\\"
+    \\"fragment HeroDetails on Character { name appearsIn }\\"
 
   public static let possibleTypes = [\\"Human\\", \\"Droid\\"]
 

--- a/packages/apollo-codegen-swift/src/__tests__/__snapshots__/codeGeneration.ts.snap
+++ b/packages/apollo-codegen-swift/src/__tests__/__snapshots__/codeGeneration.ts.snap
@@ -3,17 +3,17 @@
 exports[`Swift code generation #classDeclarationForOperation() should correctly escape a mutli-line string literal 1`] = `
 "public final class CreateReviewMutation: GraphQLMutation {
   /// mutation CreateReview($episode: Episode) {
-  ///   createReview(episode: $episode, review: {stars: 5, commentary: """
+  ///   createReview(episode: $episode, review: {stars: 5, commentary: \\"\\"\\"
   ///     Wow!
-  ///     
+  ///      I thought
   ///       This movie ROCKED!
-  ///   """}) {
+  ///   \\"\\"\\"}) {
   ///     stars
   ///     commentary
   ///   }
   /// }
   public let operationDefinition =
-    \\"mutation CreateReview($episode: Episode) {\\\\n  createReview(episode: $episode, review: {stars: 5, commentary: \\\\\\"\\\\\\"\\\\\\"\\\\n    Wow!\\\\n    \\\\n      This movie ROCKED!\\\\n  \\\\\\"\\\\\\"\\\\\\"}) {\\\\n    stars\\\\n    commentary\\\\n  }\\\\n}\\"
+    \\"mutation CreateReview($episode: Episode) {\\\\n  createReview(episode: $episode, review: {stars: 5, commentary: \\\\\\"\\\\\\"\\\\\\"\\\\n    Wow!\\\\n     I thought\\\\n      This movie ROCKED!\\\\n  \\\\\\"\\\\\\"\\\\\\"}) {\\\\n    stars\\\\n    commentary\\\\n  }\\\\n}\\"
 
   public let operationName = \\"CreateReview\\"
 
@@ -31,7 +31,7 @@ exports[`Swift code generation #classDeclarationForOperation() should correctly 
     public static let possibleTypes = [\\"Mutation\\"]
 
     public static let selections: [GraphQLSelection] = [
-      GraphQLField(\\"createReview\\", arguments: [\\"episode\\": GraphQLVariable(\\"episode\\"), \\"review\\": [\\"stars\\": 5, \\"commentary\\": \\"Wow!\\\\n\\\\n  This movie ROCKED!\\"]], type: .object(CreateReview.selections)),
+      GraphQLField(\\"createReview\\", arguments: [\\"episode\\": GraphQLVariable(\\"episode\\"), \\"review\\": [\\"stars\\": 5, \\"commentary\\": \\"Wow!\\\\n I thought\\\\n  This movie ROCKED!\\"]], type: .object(CreateReview.selections)),
     ]
 
     public private(set) var resultMap: ResultMap
@@ -98,17 +98,17 @@ exports[`Swift code generation #classDeclarationForOperation() should correctly 
 exports[`Swift code generation #classDeclarationForOperation() should correctly escape a mutli-line string literal with backslashes 1`] = `
 "public final class CreateReviewMutation: GraphQLMutation {
   /// mutation CreateReview($episode: Episode) {
-  ///   createReview(episode: $episode, review: {stars: 5, commentary: """
+  ///   createReview(episode: $episode, review: {stars: 5, commentary: \\"\\"\\"
   ///     Wow!
-  ///     
+  ///      I thought
   ///       This movie \\\\ ROCKED!
-  ///   """}) {
+  ///   \\"\\"\\"}) {
   ///     stars
   ///     commentary
   ///   }
   /// }
   public let operationDefinition =
-    \\"mutation CreateReview($episode: Episode) {\\\\n  createReview(episode: $episode, review: {stars: 5, commentary: \\\\\\"\\\\\\"\\\\\\"\\\\n    Wow!\\\\n    \\\\n      This movie \\\\ ROCKED!\\\\n  \\\\\\"\\\\\\"\\\\\\"}) {\\\\n    stars\\\\n    commentary\\\\n  }\\\\n}\\"
+    \\"mutation CreateReview($episode: Episode) {\\\\n  createReview(episode: $episode, review: {stars: 5, commentary: \\\\\\"\\\\\\"\\\\\\"\\\\n    Wow!\\\\n     I thought\\\\n      This movie \\\\ ROCKED!\\\\n  \\\\\\"\\\\\\"\\\\\\"}) {\\\\n    stars\\\\n    commentary\\\\n  }\\\\n}\\"
 
   public let operationName = \\"CreateReview\\"
 
@@ -126,7 +126,7 @@ exports[`Swift code generation #classDeclarationForOperation() should correctly 
     public static let possibleTypes = [\\"Mutation\\"]
 
     public static let selections: [GraphQLSelection] = [
-      GraphQLField(\\"createReview\\", arguments: [\\"episode\\": GraphQLVariable(\\"episode\\"), \\"review\\": [\\"stars\\": 5, \\"commentary\\": \\"Wow!\\\\n\\\\n  This movie \\\\\\\\ ROCKED!\\"]], type: .object(CreateReview.selections)),
+      GraphQLField(\\"createReview\\", arguments: [\\"episode\\": GraphQLVariable(\\"episode\\"), \\"review\\": [\\"stars\\": 5, \\"commentary\\": \\"Wow!\\\\n I thought\\\\n  This movie \\\\\\\\ ROCKED!\\"]], type: .object(CreateReview.selections)),
     ]
 
     public private(set) var resultMap: ResultMap

--- a/packages/apollo-codegen-swift/src/__tests__/__snapshots__/codeGeneration.ts.snap
+++ b/packages/apollo-codegen-swift/src/__tests__/__snapshots__/codeGeneration.ts.snap
@@ -179,7 +179,7 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
   ///   }
   /// }
   public let operationDefinition =
-    \\"mutation CreateReview($episode: Episode) {\\\\n  createReview(episode: $episode, review: {stars: 5, commentary: \\\\\\"Wow!\\\\\\"}) {\\\\n    stars\\\\n    commentary\\\\n  }\\\\n}\\"
+    \\"mutation CreateReview($episode: Episode) {\\\\n createReview(episode: $episode, review: {stars: 5, commentary: \\\\\\"Wow!\\\\\\"}) {\\\\n stars\\\\n commentary\\\\n }\\\\n }\\"
 
   public let operationName = \\"CreateReview\\"
 
@@ -271,7 +271,7 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
   ///   }
   /// }
   public let operationDefinition =
-    \\"query Hero {\\\\n  hero {\\\\n    ... on Droid {\\\\n      ...HeroDetails\\\\n    }\\\\n  }\\\\n}\\"
+    \\"query Hero {\\\\n hero {\\\\n ... on Droid {\\\\n ...HeroDetails\\\\n }\\\\n }\\\\n }\\"
 
   public let operationName = \\"Hero\\"
 
@@ -408,7 +408,7 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
   ///   }
   /// }
   public let operationDefinition =
-    \\"query Hero {\\\\n  hero {\\\\n    ...DroidDetails\\\\n  }\\\\n}\\"
+    \\"query Hero {\\\\n hero {\\\\n ...DroidDetails\\\\n }\\\\n }\\"
 
   public let operationName = \\"Hero\\"
 
@@ -573,7 +573,7 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
   ///   }
   /// }
   public let operationDefinition =
-    \\"query Hero {\\\\n  hero {\\\\n    ...HeroDetails\\\\n  }\\\\n}\\"
+    \\"query Hero {\\\\n hero {\\\\n ...HeroDetails\\\\n }\\\\n }\\"
 
   public let operationName = \\"Hero\\"
 
@@ -677,7 +677,7 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
   ///   }
   /// }
   public let operationDefinition =
-    \\"query HeroName($episode: Episode) {\\\\n  hero(episode: $episode) {\\\\n    name\\\\n  }\\\\n}\\"
+    \\"query HeroName($episode: Episode) {\\\\n hero(episode: $episode) {\\\\n name\\\\n }\\\\n }\\"
 
   public let operationName = \\"HeroName\\"
 
@@ -760,7 +760,7 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
   ///   }
   /// }
   public let operationDefinition =
-    \\"query Hero {\\\\n  hero {\\\\n    ...HeroDetails\\\\n  }\\\\n}\\"
+    \\"query Hero {\\\\n hero {\\\\n ...HeroDetails\\\\n }\\\\n }\\"
 
   public let operationName = \\"Hero\\"
 
@@ -884,7 +884,7 @@ exports[`Swift code generation #structDeclarationForFragment() should generate a
   ///   ...MoreHeroDetails
   /// }
   public static let fragmentDefinition =
-    \\"fragment HeroDetails on Character {\\\\n  name\\\\n  ...MoreHeroDetails\\\\n}\\"
+    \\"fragment HeroDetails on Character {\\\\n name\\\\n ...MoreHeroDetails\\\\n }\\"
 
   public static let possibleTypes = [\\"Human\\", \\"Droid\\"]
 
@@ -962,7 +962,7 @@ exports[`Swift code generation #structDeclarationForFragment() should generate a
   ///   primaryFunction
   /// }
   public static let fragmentDefinition =
-    \\"fragment DroidDetails on Droid {\\\\n  name\\\\n  primaryFunction\\\\n}\\"
+    \\"fragment DroidDetails on Droid {\\\\n name\\\\n primaryFunction\\\\n }\\"
 
   public static let possibleTypes = [\\"Droid\\"]
 
@@ -1012,7 +1012,7 @@ exports[`Swift code generation #structDeclarationForFragment() should generate a
   ///   }
   /// }
   public static let fragmentDefinition =
-    \\"fragment HeroDetails on Character {\\\\n  name\\\\n  friends {\\\\n    name\\\\n  }\\\\n}\\"
+    \\"fragment HeroDetails on Character {\\\\n name\\\\n friends {\\\\n name\\\\n }\\\\n }\\"
 
   public static let possibleTypes = [\\"Human\\", \\"Droid\\"]
 
@@ -1096,7 +1096,7 @@ exports[`Swift code generation #structDeclarationForFragment() should generate a
   ///   appearsIn
   /// }
   public static let fragmentDefinition =
-    \\"fragment HeroDetails on Character {\\\\n  name\\\\n  appearsIn\\\\n}\\"
+    \\"fragment HeroDetails on Character {\\\\n name\\\\n appearsIn\\\\n }\\"
 
   public static let possibleTypes = [\\"Human\\", \\"Droid\\"]
 

--- a/packages/apollo-codegen-swift/src/__tests__/__snapshots__/codeGeneration.ts.snap
+++ b/packages/apollo-codegen-swift/src/__tests__/__snapshots__/codeGeneration.ts.snap
@@ -1783,7 +1783,7 @@ public struct ReviewInput: GraphQLMapConvertible {
   /// Comment about the movie, optional
   public var commentary: Swift.Optional<String?> {
     get {
-      return graphQLMap[\\"commentary\\"] as? Swift.Optional<String?>
+      return graphQLMap[\\"commentary\\"] as? Swift.Optional<String?> ?? .none
     }
     set {
       graphQLMap.updateValue(newValue, forKey: \\"commentary\\")
@@ -1793,7 +1793,7 @@ public struct ReviewInput: GraphQLMapConvertible {
   /// Favorite color, optional
   public var favoriteColor: Swift.Optional<ColorInput?> {
     get {
-      return graphQLMap[\\"favorite_color\\"] as? Swift.Optional<ColorInput?>
+      return graphQLMap[\\"favorite_color\\"] as? Swift.Optional<ColorInput?> ?? .none
     }
     set {
       graphQLMap.updateValue(newValue, forKey: \\"favorite_color\\")

--- a/packages/apollo-codegen-swift/src/__tests__/__snapshots__/codeGeneration.ts.snap
+++ b/packages/apollo-codegen-swift/src/__tests__/__snapshots__/codeGeneration.ts.snap
@@ -172,6 +172,12 @@ exports[`Swift code generation #classDeclarationForOperation() should correctly 
 
 exports[`Swift code generation #classDeclarationForOperation() should generate a class declaration for a mutation with variables 1`] = `
 "public final class CreateReviewMutation: GraphQLMutation {
+  /// mutation CreateReview($episode: Episode) {
+  ///   createReview(episode: $episode, review: {stars: 5, commentary: \\"Wow!\\"}) {
+  ///     stars
+  ///     commentary
+  ///   }
+  /// }
   public let operationDefinition =
     \\"mutation CreateReview($episode: Episode) {\\\\n  createReview(episode: $episode, review: {stars: 5, commentary: \\\\\\"Wow!\\\\\\"}) {\\\\n    stars\\\\n    commentary\\\\n  }\\\\n}\\"
 
@@ -257,6 +263,13 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
 
 exports[`Swift code generation #classDeclarationForOperation() should generate a class declaration for a query with a fragment spread nested in an inline fragment 1`] = `
 "public final class HeroQuery: GraphQLQuery {
+  /// query Hero {
+  ///   hero {
+  ///     ... on Droid {
+  ///       ...HeroDetails
+  ///     }
+  ///   }
+  /// }
   public let operationDefinition =
     \\"query Hero {\\\\n  hero {\\\\n    ... on Droid {\\\\n      ...HeroDetails\\\\n    }\\\\n  }\\\\n}\\"
 
@@ -389,6 +402,11 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
 
 exports[`Swift code generation #classDeclarationForOperation() should generate a class declaration for a query with conditional fragment spreads 1`] = `
 "public final class HeroQuery: GraphQLQuery {
+  /// query Hero {
+  ///   hero {
+  ///     ...DroidDetails
+  ///   }
+  /// }
   public let operationDefinition =
     \\"query Hero {\\\\n  hero {\\\\n    ...DroidDetails\\\\n  }\\\\n}\\"
 
@@ -549,6 +567,11 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
 
 exports[`Swift code generation #classDeclarationForOperation() should generate a class declaration for a query with fragment spreads 1`] = `
 "public final class HeroQuery: GraphQLQuery {
+  /// query Hero {
+  ///   hero {
+  ///     ...HeroDetails
+  ///   }
+  /// }
   public let operationDefinition =
     \\"query Hero {\\\\n  hero {\\\\n    ...HeroDetails\\\\n  }\\\\n}\\"
 
@@ -648,6 +671,11 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
 
 exports[`Swift code generation #classDeclarationForOperation() should generate a class declaration for a query with variables 1`] = `
 "public final class HeroNameQuery: GraphQLQuery {
+  /// query HeroName($episode: Episode) {
+  ///   hero(episode: $episode) {
+  ///     name
+  ///   }
+  /// }
   public let operationDefinition =
     \\"query HeroName($episode: Episode) {\\\\n  hero(episode: $episode) {\\\\n    name\\\\n  }\\\\n}\\"
 
@@ -726,6 +754,11 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
 
 exports[`Swift code generation #classDeclarationForOperation() should generate a class declaration with an operationIdentifier property when generateOperationIds is specified 1`] = `
 "public final class HeroQuery: GraphQLQuery {
+  /// query Hero {
+  ///   hero {
+  ///     ...HeroDetails
+  ///   }
+  /// }
   public let operationDefinition =
     \\"query Hero {\\\\n  hero {\\\\n    ...HeroDetails\\\\n  }\\\\n}\\"
 

--- a/packages/apollo-codegen-swift/src/__tests__/codeGeneration.ts
+++ b/packages/apollo-codegen-swift/src/__tests__/codeGeneration.ts
@@ -96,7 +96,7 @@ describe("Swift code generation", () => {
           createReview(episode: $episode, review: {stars: 5, commentary:
             """
             Wow!
-
+             I thought
               This movie ROCKED!
             """
           }) {
@@ -117,7 +117,7 @@ describe("Swift code generation", () => {
           createReview(episode: $episode, review: {stars: 5, commentary:
             """
             Wow!
-
+             I thought
               This movie \\ ROCKED!
             """
           }) {

--- a/packages/apollo-codegen-swift/src/codeGeneration.ts
+++ b/packages/apollo-codegen-swift/src/codeGeneration.ts
@@ -1150,7 +1150,7 @@ export class SwiftAPIGenerator extends SwiftGenerator<CompilerContext> {
             this.withinBlock(() => {
               if (isOptional) {
                 this.printOnNewline(
-                  `return graphQLMap["${name}"] as? ${typeName}`
+                  `return graphQLMap["${name}"] as? ${typeName} ?? .none`
                 );
               } else {
                 this.printOnNewline(

--- a/packages/apollo-codegen-swift/src/codeGeneration.ts
+++ b/packages/apollo-codegen-swift/src/codeGeneration.ts
@@ -977,7 +977,7 @@ export class SwiftAPIGenerator extends SwiftGenerator<CompilerContext> {
     this.printNewlineIfNeeded();
     this.comment(description || undefined);
     this.printOnNewline(
-      `public enum ${name}: RawRepresentable, Equatable, Hashable, Apollo.JSONDecodable, Apollo.JSONEncodable`
+      `public enum ${name}: RawRepresentable, Equatable, Hashable, CaseIterable, Apollo.JSONDecodable, Apollo.JSONEncodable`
     );
     this.withinBlock(() => {
       this.printOnNewline("public typealias RawValue = String");
@@ -1048,6 +1048,21 @@ export class SwiftAPIGenerator extends SwiftGenerator<CompilerContext> {
           );
           this.printOnNewline(`default: return false`);
         });
+      });
+
+      this.printNewlineIfNeeded();
+      this.printOnNewline(`public static var allCases: [${name}]`);
+      this.withinBlock(() => {
+        this.printOnNewline(`return [`);
+        values.forEach(value => {
+          const enumDotCaseName = escapeIdentifierIfNeeded(
+            this.helpers.enumDotCaseName(value.name)
+          );
+          this.withIndent(() => {
+            this.printOnNewline(`${enumDotCaseName},`);
+          });
+        });
+        this.printOnNewline(`]`);
       });
     });
   }

--- a/packages/apollo-codegen-swift/src/codeGeneration.ts
+++ b/packages/apollo-codegen-swift/src/codeGeneration.ts
@@ -316,6 +316,7 @@ export class SwiftAPIGenerator extends SwiftGenerator<CompilerContext> {
       outputIndividualFiles,
       () => {
         if (source) {
+          this.commentWithoutTrimming(source);
           this.printOnNewline("public static let fragmentDefinition =");
           this.withIndent(() => {
             this.multilineString(source);

--- a/packages/apollo-codegen-swift/src/codeGeneration.ts
+++ b/packages/apollo-codegen-swift/src/codeGeneration.ts
@@ -1135,7 +1135,8 @@ export class SwiftAPIGenerator extends SwiftGenerator<CompilerContext> {
           name,
           propertyName,
           typeName,
-          description
+          description,
+          isOptional
         } of properties) {
           this.printNewlineIfNeeded();
           this.comment(description || undefined);
@@ -1145,9 +1146,15 @@ export class SwiftAPIGenerator extends SwiftGenerator<CompilerContext> {
           this.withinBlock(() => {
             this.printOnNewline("get");
             this.withinBlock(() => {
-              this.printOnNewline(
-                `return graphQLMap["${name}"] as! ${typeName}`
-              );
+              if (isOptional) {
+                this.printOnNewline(
+                  `return graphQLMap["${name}"] as? ${typeName}`
+                );
+              } else {
+                this.printOnNewline(
+                  `return graphQLMap["${name}"] as! ${typeName}`
+                );
+              }
             });
             this.printOnNewline("set");
             this.withinBlock(() => {

--- a/packages/apollo-codegen-swift/src/codeGeneration.ts
+++ b/packages/apollo-codegen-swift/src/codeGeneration.ts
@@ -202,6 +202,7 @@ export class SwiftAPIGenerator extends SwiftGenerator<CompilerContext> {
       },
       () => {
         if (source) {
+          this.commentWithoutTrimming(source);
           this.printOnNewline("public let operationDefinition =");
           this.withIndent(() => {
             this.multilineString(source);

--- a/packages/apollo-codegen-swift/src/language.ts
+++ b/packages/apollo-codegen-swift/src/language.ts
@@ -62,15 +62,7 @@ export class SwiftGenerator<Context> extends CodeGenerator<
   }
 
   multilineString(string: string) {
-    this.printNewline();
-    this.print(`"""`);
-
-    string.split("\n").forEach(line => {
-      this.printNewline();
-      this.print(line);
-    });
-    this.printNewline();
-    this.print(`"""`);
+    this.printOnNewline(`"${escapedString(string)}"`);
   }
 
   comment(comment?: string) {

--- a/packages/apollo-codegen-swift/src/language.ts
+++ b/packages/apollo-codegen-swift/src/language.ts
@@ -38,7 +38,7 @@ export function escapedString(string: string) {
       return line.replace(/"/g, '\\"');
     });
 
-  return lines.join("\\n ");
+  return lines.join(" ");
 }
 
 // prettier-ignore

--- a/packages/apollo-codegen-swift/src/language.ts
+++ b/packages/apollo-codegen-swift/src/language.ts
@@ -41,7 +41,7 @@ export function escapedString(string: string) {
         return line.trim();
       })
       .map(line => {
-        line.replace(/"/g, '\\"');
+        return line.replace(/"/g, '\\"');
       })
       .join(" ");
   }

--- a/packages/apollo-codegen-swift/src/language.ts
+++ b/packages/apollo-codegen-swift/src/language.ts
@@ -29,7 +29,16 @@ export interface Property {
 }
 
 export function escapedString(string: string) {
-  return string.replace(/"/g, '\\"').replace(/\n/g, "\\n");
+  var lines = string
+    .split(/\n/g)
+    .map(line => {
+      return line.trim();
+    })
+    .map(line => {
+      return line.replace(/"/g, '\\"');
+    });
+
+  return lines.join("\\n ");
 }
 
 // prettier-ignore

--- a/packages/apollo-codegen-swift/src/language.ts
+++ b/packages/apollo-codegen-swift/src/language.ts
@@ -62,7 +62,15 @@ export class SwiftGenerator<Context> extends CodeGenerator<
   }
 
   multilineString(string: string) {
-    this.printOnNewline(`"${escapedString(string)}"`);
+    this.printNewline();
+    this.print(`"""`);
+
+    string.split("\n").forEach(line => {
+      this.printNewline();
+      this.print(line);
+    });
+    this.printNewline();
+    this.print(`"""`);
   }
 
   comment(comment?: string) {

--- a/packages/apollo-codegen-swift/src/language.ts
+++ b/packages/apollo-codegen-swift/src/language.ts
@@ -37,12 +37,8 @@ export function escapedString(string: string) {
     // Strip unnecessary whitespace.
     return string
       .split(/\n/g)
-      .map(line => {
-        return line.trim();
-      })
-      .map(line => {
-        return line.replace(/"/g, '\\"');
-      })
+      .map(line => line.trim())
+      .map(line => line.replace(/"/g, '\\"'))
       .join(" ");
   }
 }

--- a/packages/apollo-codegen-swift/src/language.ts
+++ b/packages/apollo-codegen-swift/src/language.ts
@@ -35,16 +35,15 @@ export function escapedString(string: string) {
     return string.replace(/"/g, '\\"').replace(/\n/g, "\\n");
   } else {
     // Strip unnecessary whitespace.
-    var lines = string
+    return string
       .split(/\n/g)
       .map(line => {
         return line.trim();
       })
       .map(line => {
-        return line.replace(/"/g, '\\"');
-      });
-
-    return lines.join(" ");
+        line.replace(/"/g, '\\"');
+      })
+      .join(" ");
   }
 }
 

--- a/packages/apollo-codegen-swift/src/language.ts
+++ b/packages/apollo-codegen-swift/src/language.ts
@@ -29,16 +29,23 @@ export interface Property {
 }
 
 export function escapedString(string: string) {
-  var lines = string
-    .split(/\n/g)
-    .map(line => {
-      return line.trim();
-    })
-    .map(line => {
-      return line.replace(/"/g, '\\"');
-    });
+  if (string.includes('"""')) {
+    // This includes a multi-line string literal, and we may strip out meaningful
+    // whitespace if we try to strip whitespace. Don't try.
+    return string.replace(/"/g, '\\"').replace(/\n/g, "\\n");
+  } else {
+    // Strip unnecessary whitespace.
+    var lines = string
+      .split(/\n/g)
+      .map(line => {
+        return line.trim();
+      })
+      .map(line => {
+        return line.replace(/"/g, '\\"');
+      });
 
-  return lines.join(" ");
+    return lines.join(" ");
+  }
 }
 
 // prettier-ignore

--- a/packages/apollo-codegen-swift/src/language.ts
+++ b/packages/apollo-codegen-swift/src/language.ts
@@ -72,6 +72,13 @@ export class SwiftGenerator<Context> extends CodeGenerator<
       });
   }
 
+  commentWithoutTrimming(comment?: string) {
+    comment &&
+      comment.split("\n").forEach(line => {
+        this.printOnNewline(`/// ${line}`);
+      });
+  }
+
   deprecationAttributes(
     isDeprecated: boolean | undefined,
     deprecationReason: string | undefined

--- a/packages/apollo/src/commands/client/__tests__/__snapshots__/generate.test.ts.snap
+++ b/packages/apollo/src/commands/client/__tests__/__snapshots__/generate.test.ts.snap
@@ -177,7 +177,11 @@ import Apollo
 
 public final class SimpleQueryQuery: GraphQLQuery {
   public let operationDefinition =
-    \\"query SimpleQuery {\\\\n  hello\\\\n}\\"
+\\"\\"\\"
+query SimpleQuery {
+  hello
+}
+\\"\\"\\"
 
   public let operationName = \\"SimpleQuery\\"
 
@@ -221,7 +225,11 @@ import Apollo
 
 public final class SimpleQueryQuery: GraphQLQuery {
   public let operationDefinition =
-    \\"query SimpleQuery {\\\\n  hello\\\\n}\\"
+\\"\\"\\"
+query SimpleQuery {
+  hello
+}
+\\"\\"\\"
 
   public let operationName = \\"SimpleQuery\\"
 

--- a/packages/apollo/src/commands/client/__tests__/__snapshots__/generate.test.ts.snap
+++ b/packages/apollo/src/commands/client/__tests__/__snapshots__/generate.test.ts.snap
@@ -180,7 +180,7 @@ public final class SimpleQueryQuery: GraphQLQuery {
   ///   hello
   /// }
   public let operationDefinition =
-    \\"query SimpleQuery {\\\\n hello\\\\n }\\"
+    \\"query SimpleQuery { hello }\\"
 
   public let operationName = \\"SimpleQuery\\"
 
@@ -227,7 +227,7 @@ public final class SimpleQueryQuery: GraphQLQuery {
   ///   hello
   /// }
   public let operationDefinition =
-    \\"query SimpleQuery {\\\\n hello\\\\n }\\"
+    \\"query SimpleQuery { hello }\\"
 
   public let operationName = \\"SimpleQuery\\"
 

--- a/packages/apollo/src/commands/client/__tests__/__snapshots__/generate.test.ts.snap
+++ b/packages/apollo/src/commands/client/__tests__/__snapshots__/generate.test.ts.snap
@@ -180,7 +180,7 @@ public final class SimpleQueryQuery: GraphQLQuery {
   ///   hello
   /// }
   public let operationDefinition =
-    \\"query SimpleQuery {\\\\n  hello\\\\n}\\"
+    \\"query SimpleQuery {\\\\n hello\\\\n }\\"
 
   public let operationName = \\"SimpleQuery\\"
 
@@ -227,7 +227,7 @@ public final class SimpleQueryQuery: GraphQLQuery {
   ///   hello
   /// }
   public let operationDefinition =
-    \\"query SimpleQuery {\\\\n  hello\\\\n}\\"
+    \\"query SimpleQuery {\\\\n hello\\\\n }\\"
 
   public let operationName = \\"SimpleQuery\\"
 

--- a/packages/apollo/src/commands/client/__tests__/__snapshots__/generate.test.ts.snap
+++ b/packages/apollo/src/commands/client/__tests__/__snapshots__/generate.test.ts.snap
@@ -177,11 +177,7 @@ import Apollo
 
 public final class SimpleQueryQuery: GraphQLQuery {
   public let operationDefinition =
-\\"\\"\\"
-query SimpleQuery {
-  hello
-}
-\\"\\"\\"
+    \\"query SimpleQuery {\\\\n  hello\\\\n}\\"
 
   public let operationName = \\"SimpleQuery\\"
 
@@ -225,11 +221,7 @@ import Apollo
 
 public final class SimpleQueryQuery: GraphQLQuery {
   public let operationDefinition =
-\\"\\"\\"
-query SimpleQuery {
-  hello
-}
-\\"\\"\\"
+    \\"query SimpleQuery {\\\\n  hello\\\\n}\\"
 
   public let operationName = \\"SimpleQuery\\"
 

--- a/packages/apollo/src/commands/client/__tests__/__snapshots__/generate.test.ts.snap
+++ b/packages/apollo/src/commands/client/__tests__/__snapshots__/generate.test.ts.snap
@@ -176,6 +176,9 @@ exports[`client:codegen writes swift types from local schema 1`] = `
 import Apollo
 
 public final class SimpleQueryQuery: GraphQLQuery {
+  /// query SimpleQuery {
+  ///   hello
+  /// }
   public let operationDefinition =
     \\"query SimpleQuery {\\\\n  hello\\\\n}\\"
 
@@ -220,6 +223,9 @@ exports[`client:codegen writes swift types from local schema in a graphql file 1
 import Apollo
 
 public final class SimpleQueryQuery: GraphQLQuery {
+  /// query SimpleQuery {
+  ///   hello
+  /// }
   public let operationDefinition =
     \\"query SimpleQuery {\\\\n  hello\\\\n}\\"
 


### PR DESCRIPTION
In this PR: 
- Added `CaseIterable` conformance to `enum` types so all known cases can be easily iterated.
- Added comments with the original fragment or query definition to `operationDefinition` and `fragmentDefinition`
- Trimmed out excess whitespace from the final strings sent to the server for `operationDefinition` and `fragmentDefinition`
- Removed force-unwrap when the thing being unwrapped is a double optional

Note to tooling team: When this gets merged it should be released as minor-version alpha so I can make sure everything works well against our API and I haven't missed anything. 

Also I am teh suck at typescript so would love any suggestions on how to do stuff better.

- [X] Update CHANGELOG.md with your change (include reference to issue & this PR)
- [X] Make sure all of the significant new logic is covered by tests
- [X] Rebase your changes on master so that they can be merged easily
- [X] Make sure all tests and linter rules pass

