### PR TITLE
Clear projectForFileCache when schema is reloaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 - `apollo-graphql`
   - <First `apollo-graphql` related entry goes here>
 - `apollo-language-server`
-  - <First `apollo-language-server` related entry goes here>
+  - Fix cache invalidation bug for reload schema which caused outdated results in autocomplete [#1446](https://github.com/apollographql/apollo-tooling/pull/1446)
 - `apollo-tools`
   - <First `apollo-tools` related entry goes here>
 - `vscode-apollo`

--- a/packages/apollo-language-server/src/workspace.ts
+++ b/packages/apollo-language-server/src/workspace.ts
@@ -147,6 +147,7 @@ export class GraphQLWorkspace {
   }
 
   reloadService() {
+    this._projectForFileCache.clear();
     this.projectsByFolderUri.forEach((projects, uri) => {
       this.projectsByFolderUri.set(
         uri,


### PR DESCRIPTION
Resolves #1446 

When I stepped through the debugger I noticed that the cache wasn't getting properly cleared which resulted in outdated autocomplete results. Adding cache clearing to`project.reloadSchema` appears to resolve the issue.