### PR TITLE
AP-682 Strip `FragmentDefinition`s in `client:check` when only included in `@client` fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 - `apollo-graphql`
   - <First `apollo-graphql` related entry goes here>
 - `apollo-language-server`
-  - <First `apollo-language-server` related entry goes here>
+  - Fix issue where fragment definitions only included in `@client` fields would not be stripped ((AP-682)(https://golinks.io/AP-682), [#1454](https://github.com/apollographql/apollo-tooling/pull/1454))
 - `apollo-tools`
   - <First `apollo-tools` related entry goes here>
 - `vscode-apollo`

--- a/packages/apollo-language-server/src/project/client.ts
+++ b/packages/apollo-language-server/src/project/client.ts
@@ -390,7 +390,7 @@ export class GraphQLClientProject extends GraphQLProject {
     for (const operationName in current) {
       const document = current[operationName];
 
-      let serviceOnly: DocumentNode = removeDirectiveAnnotatedFields(
+      let serviceOnly = removeDirectiveAnnotatedFields(
         removeDirectives(document, clientOnlyDirectives as string[]),
         clientSchemaDirectives as string[]
       );

--- a/packages/apollo-language-server/src/utilities/__tests__/graphql.test.ts
+++ b/packages/apollo-language-server/src/utilities/__tests__/graphql.test.ts
@@ -120,4 +120,73 @@ describe("removeDirectiveAnnotatedFields", () => {
       "
     `);
   });
+
+  it("should remove fragments that become unused when antecendant directives are removed", () => {
+    expect(
+      print(
+        removeDirectiveAnnotatedFields(
+          parse(`
+            fragment ClientObjectFragment on ClientObject {
+              string
+              number
+            }
+
+            fragment LaunchTile on Launch {
+              __typename
+              id
+              isBooked
+              rocket {
+                id
+                name
+              }
+              mission {
+                name
+                missionPatch
+              }
+            }
+
+            query LaunchDetails($launchId: ID!) {
+              launch(id: $launchId) {
+                isInCart @client
+                clientObject @client {
+                  ...ClientObjectFragment
+                }
+                site
+                rocket {
+                  type
+                }
+                ...LaunchTile
+              }
+            }
+          `),
+          ["client"]
+        )
+      )
+    ).toMatchInlineSnapshot(`
+      "fragment LaunchTile on Launch {
+        __typename
+        id
+        isBooked
+        rocket {
+          id
+          name
+        }
+        mission {
+          name
+          missionPatch
+        }
+      }
+
+      query LaunchDetails($launchId: ID!) {
+        launch(id: $launchId) {
+          site
+          rocket {
+            type
+          }
+          ...LaunchTile
+        }
+      }
+      "
+    `);
+  });
 });

--- a/packages/apollo-language-server/src/utilities/graphql.ts
+++ b/packages/apollo-language-server/src/utilities/graphql.ts
@@ -88,10 +88,10 @@ export function removeDirectives(ast: ASTNode, directiveNames: string[]) {
 }
 
 // remove fields where a given directive is found
-export function removeDirectiveAnnotatedFields(
-  ast: ASTNode,
+export function removeDirectiveAnnotatedFields<AST extends ASTNode>(
+  ast: AST,
   directiveNames: string[]
-) {
+): AST {
   if (!directiveNames.length) return ast;
   return visit(ast, {
     Field(node: FieldNode): FieldNode | null {

--- a/packages/apollo-language-server/src/utilities/graphql.ts
+++ b/packages/apollo-language-server/src/utilities/graphql.ts
@@ -129,30 +129,17 @@ function removeOrphanedFragmentDefinitions<AST extends ASTNode>(
   // Strip unused fragment definitions. Flag if we've removed any so we know if we need to continue
   // recursively checking.
   ast = visit(ast, {
-    FragmentDefinition: {
-      enter(node) {
-        if (
-          fragmentNamesEligibleForRemoval.has(node.name.value) &&
-          !fragmentSpreadNodeNames.has(node.name.value)
-        ) {
-          // This definition is not used, remove it.
-          anyFragmentsRemoved = true;
-          return null;
-        }
-
-        return undefined;
+    FragmentDefinition(node) {
+      if (
+        fragmentNamesEligibleForRemoval.has(node.name.value) &&
+        !fragmentSpreadNodeNames.has(node.name.value)
+      ) {
+        // This definition is not used, remove it.
+        anyFragmentsRemoved = true;
+        return null;
       }
-    },
-    FragmentSpread: {
-      leave(node) {
-        if (!fragmentSpreadNodeNames.has(node.name.value)) {
-          // This definition is not used, remove it.
-          anyFragmentsRemoved = true;
-          return null;
-        }
 
-        return undefined;
-      }
+      return undefined;
     }
   });
 

--- a/packages/apollo-language-server/src/utilities/graphql.ts
+++ b/packages/apollo-language-server/src/utilities/graphql.ts
@@ -83,7 +83,7 @@ export function getFieldDef(
 /**
  * Remove specific directives
  *
- * The `ast` param must extend ASTNode. We use a genetic to indicate that this function returns the same type
+ * The `ast` param must extend ASTNode. We use a generic to indicate that this function returns the same type
  * of it's first parameter.
  */
 export function removeDirectives<AST extends ASTNode>(
@@ -106,7 +106,7 @@ export function removeDirectives<AST extends ASTNode>(
  * We expclitily require the fragments to be listed in `fragmentNamesEligibleForRemoval` so we only strip
  * fragments that were orphaned by an operation, not fragments that started as oprhans
  *
- * The `ast` param must extend ASTNode. We use a genetic to indicate that this function returns the same type
+ * The `ast` param must extend ASTNode. We use a generic to indicate that this function returns the same type
  * of it's first parameter.
  */
 function removeOrphanedFragmentDefinitions<AST extends ASTNode>(
@@ -176,7 +176,7 @@ function removeOrphanedFragmentDefinitions<AST extends ASTNode>(
 /**
  * Remove nodes that have zero-length selection sets
  *
- * The `ast` param must extend ASTNode. We use a genetic to indicate that this function returns the same type
+ * The `ast` param must extend ASTNode. We use a generic to indicate that this function returns the same type
  * of it's first parameter.
  */
 function removeNodesWithEmptySelectionSets<AST extends ASTNode>(ast: AST): AST {
@@ -197,7 +197,7 @@ function removeNodesWithEmptySelectionSets<AST extends ASTNode>(ast: AST): AST {
 /**
  * Remove nodes from `ast` when they have a directive in `directiveNames`
  *
- * The `ast` param must extend ASTNode. We use a genetic to indicate that this function returns the same type
+ * The `ast` param must extend ASTNode. We use a generic to indicate that this function returns the same type
  * of it's first parameter.
  */
 export function removeDirectiveAnnotatedFields<AST extends ASTNode>(

--- a/packages/apollo-language-server/src/utilities/graphql.ts
+++ b/packages/apollo-language-server/src/utilities/graphql.ts
@@ -80,6 +80,12 @@ export function getFieldDef(
   return undefined;
 }
 
+/**
+ * Remove specific directives
+ *
+ * The `ast` param must extend ASTNode. We use a genetic to indicate that this function returns the same type
+ * of it's first parameter.
+ */
 export function removeDirectives<AST extends ASTNode>(
   ast: AST,
   directiveNames: string[]
@@ -99,6 +105,9 @@ export function removeDirectives<AST extends ASTNode>(
  *
  * We expclitily require the fragments to be listed in `fragmentNamesEligibleForRemoval` so we only strip
  * fragments that were orphaned by an operation, not fragments that started as oprhans
+ *
+ * The `ast` param must extend ASTNode. We use a genetic to indicate that this function returns the same type
+ * of it's first parameter.
  */
 function removeOrphanedFragmentDefinitions<AST extends ASTNode>(
   ast: AST,
@@ -161,6 +170,9 @@ function removeOrphanedFragmentDefinitions<AST extends ASTNode>(
 
 /**
  * Recursively remove nodes that have zero-length selection sets
+ *
+ * The `ast` param must extend ASTNode. We use a genetic to indicate that this function returns the same type
+ * of it's first parameter.
  */
 function removeNodesWithEmptySelectionSets<AST extends ASTNode>(ast: AST): AST {
   /**
@@ -184,17 +196,20 @@ function removeNodesWithEmptySelectionSets<AST extends ASTNode>(ast: AST): AST {
     }
   });
 
-  if (anyNodesRemoved) {
-    return removeNodesWithEmptySelectionSets(ast);
-  }
+  // if (anyNodesRemoved) {
+  //   console.group('check for children',);
+  //   return removeNodesWithEmptySelectionSets(ast);
+  //   console.groupEnd();
+  // }
 
   return ast;
 }
 
 /**
  * Remove nodes from `ast` when they have a directive in `directiveNames`
- * @param ast
- * @param directiveNames
+ *
+ * The `ast` param must extend ASTNode. We use a genetic to indicate that this function returns the same type
+ * of it's first parameter.
  */
 export function removeDirectiveAnnotatedFields<AST extends ASTNode>(
   ast: AST,

--- a/packages/apollo-language-server/src/utilities/graphql.ts
+++ b/packages/apollo-language-server/src/utilities/graphql.ts
@@ -169,38 +169,22 @@ function removeOrphanedFragmentDefinitions<AST extends ASTNode>(
 }
 
 /**
- * Recursively remove nodes that have zero-length selection sets
+ * Remove nodes that have zero-length selection sets
  *
  * The `ast` param must extend ASTNode. We use a genetic to indicate that this function returns the same type
  * of it's first parameter.
  */
 function removeNodesWithEmptySelectionSets<AST extends ASTNode>(ast: AST): AST {
-  /**
-   * Flag to know if we need to make another recursive pass
-   */
-  let anyNodesRemoved = false;
-
   ast = visit(ast, {
     enter(node) {
       // If this node _has_ a `selectionSet` and it's zero-length, then remove it.
-      if (
-        "selectionSet" in node &&
+      return "selectionSet" in node &&
         node.selectionSet != null &&
         node.selectionSet.selections.length === 0
-      ) {
-        anyNodesRemoved = true;
-        return null;
-      }
-
-      return undefined;
+        ? null
+        : undefined;
     }
   });
-
-  // if (anyNodesRemoved) {
-  //   console.group('check for children',);
-  //   return removeNodesWithEmptySelectionSets(ast);
-  //   console.groupEnd();
-  // }
 
   return ast;
 }

--- a/packages/apollo-language-server/src/utilities/graphql.ts
+++ b/packages/apollo-language-server/src/utilities/graphql.ts
@@ -157,8 +157,26 @@ function removeOrphanedFragmentDefinitions<AST extends ASTNode>(
   });
 
   if (anyFragmentsRemoved) {
-    // We've removed fragments and might have orphaned more fragments, so recursively try to remove more
-    // orphaned fragments.
+    /* Handles the special case where a Fragment was not removed because it was not yet orphaned when being
+       `visit`ed. As an example:
+
+        ```jsx
+        fragment Two on Node {
+          id
+        }
+        fragment One on Query {
+          hero {
+            ...Two @client
+          }
+        }
+
+        { ...One }
+        ```
+
+        On the first visit, `Two` will not be removed. After `One` is removed, `Two` becomes orphaned. If any
+        nodes were removed on this pass; run another pass to see if there are more nodes that are now
+        orphaned.
+      */
     return removeOrphanedFragmentDefinitions(
       ast,
       fragmentNamesEligibleForRemoval


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Tooling!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

We're getting `client:check` failures when using a `Fragment `in a `@client` field because while the fields with `@client` are stripped, `Fragment`s that are nested below them are not. We now check that `Fragment`s can be removed if they are only used in `@client` fields.

I added tests to the existing functionality on one commit, added a failing test for how I expected the method to behave, and then fixed the test. Please look at the last new test to see a reproduction.

---

TODO:

- [x] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass

\*Make sure changelog entries note which project(s) has been affected. See older entries for examples on what this looks like.
