### PR TITLE
[Swift] Fix build failures for optionals

### DIFF
--- a/packages/apollo-codegen-swift/src/__tests__/__snapshots__/codeGeneration.ts.snap
+++ b/packages/apollo-codegen-swift/src/__tests__/__snapshots__/codeGeneration.ts.snap
@@ -1069,7 +1069,7 @@ exports[`Swift code generation #structDeclarationForFragment() should generate a
   public var friends: [Friend?]? {
     get {
       return (resultMap[\\"friends\\"] as? [ResultMap?]).flatMap { (value: [ResultMap?]) -> [Friend?] in value.map { (value: ResultMap?) -> Friend? in value.flatMap { (value: ResultMap) -> Friend in Friend(unsafeResultMap: value) } } }?.filter({
-        guard let type = $0 else { return false }; return Friend.possibleTypes.contains($type.__typename)
+        guard let type = $0 else { return false }; return Friend.possibleTypes.contains(type.__typename)
       })
     }
     set {

--- a/packages/apollo-codegen-swift/src/__tests__/__snapshots__/codeGeneration.ts.snap
+++ b/packages/apollo-codegen-swift/src/__tests__/__snapshots__/codeGeneration.ts.snap
@@ -1069,7 +1069,7 @@ exports[`Swift code generation #structDeclarationForFragment() should generate a
   public var friends: [Friend?]? {
     get {
       return (resultMap[\\"friends\\"] as? [ResultMap?]).flatMap { (value: [ResultMap?]) -> [Friend?] in value.map { (value: ResultMap?) -> Friend? in value.flatMap { (value: ResultMap) -> Friend in Friend(unsafeResultMap: value) } } }?.filter({
-        guard let type = $0 else { return false}; return Friend.possibleTypes.contains($type.__typename)
+        guard let type = $0 else { return false }; return Friend.possibleTypes.contains($type.__typename)
       })
     }
     set {

--- a/packages/apollo-codegen-swift/src/__tests__/__snapshots__/codeGeneration.ts.snap
+++ b/packages/apollo-codegen-swift/src/__tests__/__snapshots__/codeGeneration.ts.snap
@@ -1068,8 +1068,8 @@ exports[`Swift code generation #structDeclarationForFragment() should generate a
   /// The friends of the character, or an empty list if they have none
   public var friends: [Friend?]? {
     get {
-      return (resultMap[\\"friends\\"] as? [ResultMap?]).flatMap { (value: [ResultMap?]) -> [Friend?] in value.map { (value: ResultMap?) -> Friend? in value.flatMap { (value: ResultMap) -> Friend in Friend(unsafeResultMap: value) } } }.filter({
-        Friend.possibleTypes.contains($0.__typename)
+      return (resultMap[\\"friends\\"] as? [ResultMap?]).flatMap { (value: [ResultMap?]) -> [Friend?] in value.map { (value: ResultMap?) -> Friend? in value.flatMap { (value: ResultMap) -> Friend in Friend(unsafeResultMap: value) } } }?.filter({
+        guard let type = $0 else { return false}; return Friend.possibleTypes.contains($type.__typename)
       })
     }
     set {
@@ -1222,8 +1222,8 @@ exports[`Swift code generation #structDeclarationForSelectionSet() should genera
   /// The friends of the character, or an empty list if they have none
   public var friends: [Friend?]? {
     get {
-      return (resultMap[\\"friends\\"] as? [ResultMap?]).flatMap { (value: [ResultMap?]) -> [Friend?] in value.map { (value: ResultMap?) -> Friend? in value.flatMap { (value: ResultMap) -> Friend in Friend(unsafeResultMap: value) } } }.filter({
-        Friend.possibleTypes.contains($0.__typename)
+      return (resultMap[\\"friends\\"] as? [ResultMap?]).flatMap { (value: [ResultMap?]) -> [Friend?] in value.map { (value: ResultMap?) -> Friend? in value.flatMap { (value: ResultMap) -> Friend in Friend(unsafeResultMap: value) } } }?.filter({
+        guard let type = $0 else { return false }; return Friend.possibleTypes.contains(type.__typename)
       })
     }
     set {

--- a/packages/apollo-codegen-swift/src/__tests__/__snapshots__/codeGeneration.ts.snap
+++ b/packages/apollo-codegen-swift/src/__tests__/__snapshots__/codeGeneration.ts.snap
@@ -1069,7 +1069,8 @@ exports[`Swift code generation #structDeclarationForFragment() should generate a
   public var friends: [Friend?]? {
     get {
       return (resultMap[\\"friends\\"] as? [ResultMap?]).flatMap { (value: [ResultMap?]) -> [Friend?] in value.map { (value: ResultMap?) -> Friend? in value.flatMap { (value: ResultMap) -> Friend in Friend(unsafeResultMap: value) } } }?.filter({
-        guard let type = $0 else { return false }; return Friend.possibleTypes.contains(type.__typename)
+        guard let type = $0 else { return false }
+        return Friend.possibleTypes.contains(type.__typename)
       })
     }
     set {
@@ -1223,7 +1224,8 @@ exports[`Swift code generation #structDeclarationForSelectionSet() should genera
   public var friends: [Friend?]? {
     get {
       return (resultMap[\\"friends\\"] as? [ResultMap?]).flatMap { (value: [ResultMap?]) -> [Friend?] in value.map { (value: ResultMap?) -> Friend? in value.flatMap { (value: ResultMap) -> Friend in Friend(unsafeResultMap: value) } } }?.filter({
-        guard let type = $0 else { return false }; return Friend.possibleTypes.contains(type.__typename)
+        guard let type = $0 else { return false }
+        return Friend.possibleTypes.contains(type.__typename)
       })
     }
     set {

--- a/packages/apollo-codegen-swift/src/codeGeneration.ts
+++ b/packages/apollo-codegen-swift/src/codeGeneration.ts
@@ -730,10 +730,14 @@ export class SwiftAPIGenerator extends SwiftGenerator<CompilerContext> {
               )}?.filter`
             );
             this.withinBlock(
-              () =>
+              () => {
                 this.printOnNewline(
-                  `guard let type = $0 else { return false }; return ${structName}.possibleTypes.contains(type.__typename)`
-                ),
+                  `guard let type = $0 else { return false }`
+                );
+                this.printOnNewline(
+                  `return ${structName}.possibleTypes.contains(type.__typename)`
+                );
+              },
               "({",
               "})"
             );

--- a/packages/apollo-codegen-swift/src/codeGeneration.ts
+++ b/packages/apollo-codegen-swift/src/codeGeneration.ts
@@ -727,12 +727,12 @@ export class SwiftAPIGenerator extends SwiftGenerator<CompilerContext> {
                 expression,
                 "ResultMap",
                 structName
-              )}.filter`
+              )}?.filter`
             );
             this.withinBlock(
               () =>
                 this.printOnNewline(
-                  `${structName}.possibleTypes.contains($0.__typename)`
+                  `guard let type = $0 else { return false }; return ${structName}.possibleTypes.contains(type.__typename)`
                 ),
               "({",
               "})"


### PR DESCRIPTION
This PR fixes issues introduced by #656, which I prematurely had released. 🤦‍♀️

The issues are most obvious in [this failed run of the main iOS SDK](https://travis-ci.org/apollographql/apollo-ios/jobs/568034798), but the short version is that we weren't fully checking for optionals with that code, and the compiler was pretty angry about it. 