### PR TITLE
Fix config path parsing with ts files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 - `apollo-graphql`
   - <First `apollo-graphql` related entry goes here>
 - `apollo-language-server`
-  - <First `apollo-language-server` related entry goes here>
+  - Fix dirname parsing for ts config files [#1463](https://github.com/apollographql/apollo-tooling/pull/1463)
 - `apollo-tools`
   - <First `apollo-tools` related entry goes here>
 - `vscode-apollo`

--- a/packages/apollo-language-server/src/config/config.ts
+++ b/packages/apollo-language-server/src/config/config.ts
@@ -147,7 +147,8 @@ export class ApolloConfig {
   }
 
   get configDirURI() {
-    return this.configURI && this.configURI.fsPath.includes(".js")
+    // if the filepath has a _file_ in it, then we get its dir
+    return this.configURI && this.configURI.fsPath.match(/\.(ts|js|json)$/i)
       ? URI.parse(dirname(this.configURI.fsPath))
       : this.configURI;
   }


### PR DESCRIPTION
resolves #881

Previously, when initializing an `ApolloConfig` class, we were pulling the `dirname` properly off the file path of a `.js` config file, but we weren't handling the case of the config filepath being a `.ts` file at all (oops).

This change should fix the dirname parsing for all files that we support.


<!--
  Thanks for filing a pull request on Apollo Tooling!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [ ] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [ ] Make sure all of the significant new logic is covered by tests
- [ ] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests and linter rules pass

\*Make sure changelog entries note which project(s) has been affected. See older entries for examples on what this looks like.
