### PR TITLE
Revert PR #656

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@
   - <First `apollo-codegen-flow` related entry goes here>
 - `apollo-codegen-scala`
   - <First `apollo-codegen-scala` related entry goes here>
-- `apollo-codegen-swift`
-  - <First `apollo-codegen-swift` related entry goes here>
+- `apollo-codegen-swift` 
+  - Revert changes from [#656](https://github.com/apollographql/apollo-tooling/pull/656) due to build issues not caught by tests.
 - `apollo-codegen-typescript`
   - <First `apollo-codegen-typescript` related entry goes here>
 - `apollo-env`

--- a/packages/apollo-codegen-swift/src/__tests__/__snapshots__/codeGeneration.ts.snap
+++ b/packages/apollo-codegen-swift/src/__tests__/__snapshots__/codeGeneration.ts.snap
@@ -1068,9 +1068,7 @@ exports[`Swift code generation #structDeclarationForFragment() should generate a
   /// The friends of the character, or an empty list if they have none
   public var friends: [Friend?]? {
     get {
-      return (resultMap[\\"friends\\"] as? [ResultMap?]).flatMap { (value: [ResultMap?]) -> [Friend?] in value.map { (value: ResultMap?) -> Friend? in value.flatMap { (value: ResultMap) -> Friend in Friend(unsafeResultMap: value) } } }.filter({
-        Friend.possibleTypes.contains($0.__typename)
-      })
+      return (resultMap[\\"friends\\"] as? [ResultMap?]).flatMap { (value: [ResultMap?]) -> [Friend?] in value.map { (value: ResultMap?) -> Friend? in value.flatMap { (value: ResultMap) -> Friend in Friend(unsafeResultMap: value) } } }
     }
     set {
       resultMap.updateValue(newValue.flatMap { (value: [Friend?]) -> [ResultMap?] in value.map { (value: Friend?) -> ResultMap? in value.flatMap { (value: Friend) -> ResultMap in value.resultMap } } }, forKey: \\"friends\\")
@@ -1222,9 +1220,7 @@ exports[`Swift code generation #structDeclarationForSelectionSet() should genera
   /// The friends of the character, or an empty list if they have none
   public var friends: [Friend?]? {
     get {
-      return (resultMap[\\"friends\\"] as? [ResultMap?]).flatMap { (value: [ResultMap?]) -> [Friend?] in value.map { (value: ResultMap?) -> Friend? in value.flatMap { (value: ResultMap) -> Friend in Friend(unsafeResultMap: value) } } }.filter({
-        Friend.possibleTypes.contains($0.__typename)
-      })
+      return (resultMap[\\"friends\\"] as? [ResultMap?]).flatMap { (value: [ResultMap?]) -> [Friend?] in value.map { (value: ResultMap?) -> Friend? in value.flatMap { (value: ResultMap) -> Friend in Friend(unsafeResultMap: value) } } }
     }
     set {
       resultMap.updateValue(newValue.flatMap { (value: [Friend?]) -> [ResultMap?] in value.map { (value: Friend?) -> ResultMap? in value.flatMap { (value: Friend) -> ResultMap in value.resultMap } } }, forKey: \\"friends\\")

--- a/packages/apollo-codegen-swift/src/codeGeneration.ts
+++ b/packages/apollo-codegen-swift/src/codeGeneration.ts
@@ -727,15 +727,7 @@ export class SwiftAPIGenerator extends SwiftGenerator<CompilerContext> {
                 expression,
                 "ResultMap",
                 structName
-              )}.filter`
-            );
-            this.withinBlock(
-              () =>
-                this.printOnNewline(
-                  `${structName}.possibleTypes.contains($0.__typename)`
-                ),
-              "({",
-              "})"
+              )}`
             );
           });
           this.printOnNewline("set");


### PR DESCRIPTION
This PR reverts changes from #656, they were causing build issues on iOS and the originator is going to come up with a new reproduction before we take another stab at this. 

This will need to go out as a patch release for `swift` and `tooling` since I ~~'m a moron~~ got a little ahead of myself and didn't fully test these locally before getting them released.
