### PR TITLE
Error with duplicate operation names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
   - <First `apollo-graphql` related entry goes here>
 - `apollo-language-server`
   - Add debugging util classes for better error/warning handling [#1429](https://github.com/apollographql/apollo-tooling/pull/1429)
-  - Add warning for duplicate client operation names [#1466](https://github.com/apollographql/apollo-tooling/pull/1466)
+  - Add error for duplicate client operation names [#1466](https://github.com/apollographql/apollo-tooling/pull/1466)
 - `apollo-tools`
   - <First `apollo-tools` related entry goes here>
 - `vscode-apollo`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
   - <First `apollo-graphql` related entry goes here>
 - `apollo-language-server`
   - Add debugging util classes for better error/warning handling [#1429](https://github.com/apollographql/apollo-tooling/pull/1429)
+  - Add warning for duplicate client operation names [#1466](https://github.com/apollographql/apollo-tooling/pull/1466)
 - `apollo-tools`
   - <First `apollo-tools` related entry goes here>
 - `vscode-apollo`

--- a/packages/apollo-language-server/src/project/base.ts
+++ b/packages/apollo-language-server/src/project/base.ts
@@ -228,8 +228,8 @@ export abstract class GraphQLProject implements GraphQLSchemaProvider {
       for (const definition of document.ast.definitions) {
         if (definition.kind === Kind.OPERATION_DEFINITION && definition.name) {
           if (operations[definition.name.value]) {
-            console.warn(
-              `⚠️  There are multiple definitions for the ${definition.name.value} operation. All operations in a project must have unique names. If generating types, only the types for the first definition found will be generated.`
+            throw new Error(
+              `️️There are multiple definitions for the ${definition.name.value} operation. All operations in a project must have unique names. If generating types, only the types for the first definition found will be generated.`
             );
           }
           operations[definition.name.value] = definition;

--- a/packages/apollo-language-server/src/project/client.ts
+++ b/packages/apollo-language-server/src/project/client.ts
@@ -352,6 +352,11 @@ export class GraphQLClientProject extends GraphQLProject {
               [definition]
             );
           }
+          if (operations[definition.name.value]) {
+            console.warn(
+              `There are multiple definitions for the ${definition.name.value} operation. All operations in a project must have unique names. If generating types, only the types for the first definition found will be generated.`
+            );
+          }
           operations[definition.name.value] = definition;
         }
       }

--- a/packages/apollo-language-server/src/project/client.ts
+++ b/packages/apollo-language-server/src/project/client.ts
@@ -352,11 +352,6 @@ export class GraphQLClientProject extends GraphQLProject {
               [definition]
             );
           }
-          if (operations[definition.name.value]) {
-            console.warn(
-              `There are multiple definitions for the ${definition.name.value} operation. All operations in a project must have unique names. If generating types, only the types for the first definition found will be generated.`
-            );
-          }
           operations[definition.name.value] = definition;
         }
       }


### PR DESCRIPTION
Currently, the `apollo-language-server` requires operation names in a client project to be unique in order to properly generate types, but this isn't enforced by an error. This PR adds an error so the user is aware of a name collision. 

When generating a type using codegen, if there are duplicate type names, only one of the operations will get types generated. this error will enforce the already designed intention of the CLI.

The following screenshot shows the error as well as showing that **the error doesn't interfere with `--watch` mode**.

<img width="1679" alt="Screen Shot 2019-08-08 at 7 47 37 PM" src="https://user-images.githubusercontent.com/9259509/62744740-f3ddf500-ba15-11e9-9fdc-89982a088280.png">

resolves #1427

<!--
  Thanks for filing a pull request on Apollo Tooling!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [x] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [ ] Make sure all of the significant new logic is covered by tests
- [ ] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests and linter rules pass

\*Make sure changelog entries note which project(s) has been affected. See older entries for examples on what this looks like.
