### PR TITLE
vscode: Fix go to definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
 - `apollo-graphql`
   - <First `apollo-graphql` related entry goes here>
 - `apollo-language-server`
-  - <First `apollo-language-server` related entry goes here>
+  - Fix 'Go to Definition' for local schema files. [#1490](https://github.com/apollographql/apollo-tooling/pull/1490)
 - `apollo-tools`
   - <First `apollo-tools` related entry goes here>
 - `vscode-apollo`

--- a/packages/apollo-language-server/src/providers/schema/file.ts
+++ b/packages/apollo-language-server/src/providers/schema/file.ts
@@ -39,7 +39,7 @@ export class FileSchemaProvider implements GraphQLSchemaProvider {
 
       this.schema = buildClientSchema({ __schema });
     } else if (ext === ".graphql" || ext === ".graphqls" || ext === ".gql") {
-      const uri = `file://${resolve(path)}`;
+      const uri = `file:///${resolve(path)}`;
       this.schema = buildSchema(new Source(result, uri));
     }
     if (!this.schema) throw new Error(`Schema could not be loaded for ${path}`);

--- a/packages/apollo-language-server/src/providers/schema/file.ts
+++ b/packages/apollo-language-server/src/providers/schema/file.ts
@@ -4,6 +4,7 @@ import { readFileSync } from "fs";
 import { extname, resolve } from "path";
 import { GraphQLSchemaProvider, SchemaChangeUnsubscribeHandler } from "./base";
 import { NotificationHandler } from "vscode-languageserver";
+import URI from "vscode-uri";
 
 export interface FileSchemaProviderConfig {
   path: string;
@@ -39,7 +40,7 @@ export class FileSchemaProvider implements GraphQLSchemaProvider {
 
       this.schema = buildClientSchema({ __schema });
     } else if (ext === ".graphql" || ext === ".graphqls" || ext === ".gql") {
-      const uri = `file:///${resolve(path)}`;
+      const uri = URI.file(resolve(path)).toString();
       this.schema = buildSchema(new Source(result, uri));
     }
     if (!this.schema) throw new Error(`Schema could not be loaded for ${path}`);


### PR DESCRIPTION
Go to definition with local schema did fail with `Unable to open 'schema.graphql': File is a directory.`, because of one missing `/`. Not sure what to do about tests here.

- [x] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [ ] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
