### PR TITLE
Support multiple schema files with localSchemaFile

### DIFF
--- a/packages/apollo-language-server/src/config/config.ts
+++ b/packages/apollo-language-server/src/config/config.ts
@@ -28,7 +28,7 @@ export interface RemoteServiceConfig {
 
 export interface LocalServiceConfig {
   name: ServiceID;
-  localSchemaFile: string;
+  localSchemaFile: string | string[];
 }
 
 export interface EngineConfig {

--- a/packages/apollo-language-server/src/providers/schema/file.ts
+++ b/packages/apollo-language-server/src/providers/schema/file.ts
@@ -1,12 +1,19 @@
 // FileSchemaProvider (FileProvider (SDL || IntrospectionResult) => schema)
-import { GraphQLSchema, buildClientSchema, Source, buildSchema } from "graphql";
+import {
+  GraphQLSchema,
+  buildClientSchema,
+  Source,
+  buildSchema,
+  printSchema
+} from "graphql";
 import { readFileSync } from "fs";
 import { extname, resolve } from "path";
 import { GraphQLSchemaProvider, SchemaChangeUnsubscribeHandler } from "./base";
 import { NotificationHandler } from "vscode-languageserver";
 
 export interface FileSchemaProviderConfig {
-  path: string;
+  path?: string;
+  paths?: string[];
 }
 // XXX file subscription
 export class FileSchemaProvider implements GraphQLSchemaProvider {
@@ -16,7 +23,30 @@ export class FileSchemaProvider implements GraphQLSchemaProvider {
 
   async resolveSchema() {
     if (this.schema) return this.schema;
-    const { path } = this.config;
+    const { path, paths } = this.config;
+
+    // load each path and get sdl string from each, if a list, concatenate them all
+    const sdlResults = path
+      ? this.loadFileAndGetSDL(path)
+      : paths
+      ? paths.map(this.loadFileAndGetSDL).join("\n")
+      : undefined;
+
+    if (!sdlResults)
+      throw new Error(
+        `Schema could not be loaded for [${
+          path ? path : paths ? paths.join(", ") : "undefined"
+        }]`
+      );
+
+    this.schema = buildSchema(sdlResults);
+
+    if (!this.schema) throw new Error(`Schema could not be loaded for ${path}`);
+    return this.schema;
+  }
+
+  // load a graphql file or introspection result and return the SDL version
+  loadFileAndGetSDL(path: string) {
     let result;
     try {
       result = readFileSync(path, {
@@ -28,7 +58,7 @@ export class FileSchemaProvider implements GraphQLSchemaProvider {
 
     const ext = extname(path);
 
-    // an actual introspectionQuery result
+    // an actual introspectionQuery result, convert to sdl
     if (ext === ".json") {
       const parsed = JSON.parse(result);
       const __schema = parsed.data
@@ -37,13 +67,14 @@ export class FileSchemaProvider implements GraphQLSchemaProvider {
         ? parsed.__schema
         : parsed;
 
-      this.schema = buildClientSchema({ __schema });
+      const schema = buildClientSchema({ __schema });
+      return printSchema(schema);
     } else if (ext === ".graphql" || ext === ".graphqls" || ext === ".gql") {
-      const uri = `file://${resolve(path)}`;
-      this.schema = buildSchema(new Source(result, uri));
+      return result;
     }
-    if (!this.schema) throw new Error(`Schema could not be loaded for ${path}`);
-    return this.schema;
+    throw new Error(
+      "File Type not supported for schema loading. Must be a .json, .graphql, .gql, or .graphqls file"
+    );
   }
 
   onSchemaChange(

--- a/packages/apollo-language-server/src/providers/schema/index.ts
+++ b/packages/apollo-language-server/src/providers/schema/index.ts
@@ -42,9 +42,16 @@ export function schemaProviderFromConfig(
 
     if (config.client.service) {
       if (isLocalServiceConfig(config.client.service)) {
-        return new FileSchemaProvider({
-          path: config.client.service.localSchemaFile
-        });
+        const isListOfSchemaFiles = Array.isArray(
+          config.client.service.localSchemaFile
+        );
+        return new FileSchemaProvider(
+          isListOfSchemaFiles
+            ? { paths: config.client.service.localSchemaFile as string[] }
+            : {
+                path: config.client.service.localSchemaFile as string
+              }
+        );
       }
 
       return new IntrospectionSchemaProvider(config.client.service);

--- a/packages/apollo/src/commands/client/codegen.ts
+++ b/packages/apollo/src/commands/client/codegen.ts
@@ -41,7 +41,8 @@ export default class Generate extends ClientCommand {
     }),
     localSchemaFile: flags.string({
       description:
-        "Path to your local GraphQL schema file (introspection result or SDL)"
+        "Path to your local GraphQL schema file (introspection result or SDL)",
+      multiple: true
     }),
     addTypename: flags.boolean({
       description:

--- a/packages/apollo/src/commands/service/check.ts
+++ b/packages/apollo/src/commands/service/check.ts
@@ -287,7 +287,8 @@ export default class ServiceCheck extends ProjectCommand {
     }),
     localSchemaFile: flags.string({
       description:
-        "Path to your local GraphQL schema file (introspection result or SDL)"
+        "Path to your local GraphQL schema file (introspection result or SDL)",
+      multiple: true
     }),
     markdown: flags.boolean({
       description: "Output result in markdown.",

--- a/packages/apollo/src/commands/service/push.ts
+++ b/packages/apollo/src/commands/service/push.ts
@@ -19,7 +19,8 @@ export default class ServicePush extends ProjectCommand {
     }),
     localSchemaFile: flags.string({
       description:
-        "Path to your local GraphQL schema file (introspection result or SDL)"
+        "Path to your local GraphQL schema file (introspection result or SDL)",
+      multiple: true
     }),
     federated: flags.boolean({
       char: "f",


### PR DESCRIPTION
Resolves #1483 

## What

The purpose of this PR is to officially support multiple schema files through the `localSchemaFile` config option and CLI flag for the client and service commands.

## Why

Until VSCode 1.10.0 (and accompanying CLI release), I've been recommending people use the `client.includes` option to allow for multiple schema files when needed. Since client `includes` now is treated as a client schema for the purpose of autocompleting client fields (#1433) this no longer works.

## How

This PR overloads the existing `localSchemaFile` option, allowing for a list of filepaths (in the config file) or multiple uses of the `--localSchemaFile` flag (in the CLI).

The schema loader will go through the same process it used to in order to load a schema from a file, with a couple modifications.

- load each file's contents
  - if the file is a json file, convert it to SDL
- return the schema SDL
- concatenate all collected SDLs
- build schema from concatenated SDLs

## Questions

- [ ] will this work with type extensions?
  - if not, we could use `extendSchema` instead to progressively build the schema
- [ ] are there other benefits to using `extendSchema` rather than concatenating SDL?
- [ ] should we allow globs here rather than just filepaths?
  - this would add a _little_ complexity since we'd have to handle a single glob, multiple globs, as well as a mix of globs/filepaths in the list


<!--
  Thanks for filing a pull request on Apollo Tooling!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [ ] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [ ] Make sure all of the significant new logic is covered by tests
- [ ] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests and linter rules pass

\*Make sure changelog entries note which project(s) has been affected. See older entries for examples on what this looks like.
