### PR TITLE
Add CLI Build Step to Circle (non-deploy)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,23 +94,23 @@ jobs:
           command: cmp --silent currentTypes.ts ./packages/apollo-language-server/src/graphqlTypes.ts || (echo "Type check failed. Run 'npm run client:codegen'" && exit 1)
 
   Build CLI:
-  docker: [{ image: "circleci/node:10" }]
-  steps:
-    - *run_install_desired_npm
-    - checkout
-    - run: npm install
-    - run:
-        name: Make tmp dir
-        command: cd packages/apollo && mkdir tmp && cd tmp
-    - run:
-        name: Initialize tmp dir with NPM and Git
-        command: npm init -y && git init
-    - run: npm i apollo && cd node_modules/apollo && npm i --package-lock-only
-    - run: cd ../../../
-    - run: rm package.json && cp tmp/node_modules/apollo/package* .
-    - run:
-        name: Build CLI
-        command: npx -p @oclif/dev-cli oclif-dev pack --targets=darwin-x64
+    executor: { name: oss/node }
+    steps:
+      - *run_install_desired_npm
+      - checkout
+      - run: npm install
+      - run:
+          name: Make tmp dir
+          command: cd packages/apollo && mkdir tmp && cd tmp
+      - run:
+          name: Initialize tmp dir with NPM and Git
+          command: npm init -y && git init
+      - run: npm i apollo && cd node_modules/apollo && npm i --package-lock-only
+      - run: cd ../../../
+      - run: rm package.json && cp tmp/node_modules/apollo/package* .
+      - run:
+          name: Build CLI
+          command: npx -p @oclif/dev-cli oclif-dev pack --targets=darwin-x64
 
 common_non_publish_filters: &common_non_publish_filters
   filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,6 +93,25 @@ jobs:
           name: Compare type files
           command: cmp --silent currentTypes.ts ./packages/apollo-language-server/src/graphqlTypes.ts || (echo "Type check failed. Run 'npm run client:codegen'" && exit 1)
 
+  Build CLI:
+  docker: [{ image: "circleci/node:10" }]
+  steps:
+    - *run_install_desired_npm
+    - checkout
+    - run: npm install
+    - run:
+        name: Make tmp dir
+        command: cd packages/apollo && mkdir tmp && cd tmp
+    - run:
+        name: Initialize tmp dir with NPM and Git
+        command: npm init -y && git init
+    - run: npm i apollo && cd node_modules/apollo && npm i --package-lock-only
+    - run: cd ../../../
+    - run: rm package.json && cp tmp/node_modules/apollo/package* .
+    - run:
+        name: Build CLI
+        command: npx -p @oclif/dev-cli oclif-dev pack --targets=darwin-x64
+
 common_non_publish_filters: &common_non_publish_filters
   filters:
     # Ensure every job has `tags` filters since the publish steps have tags.
@@ -124,6 +143,8 @@ workflows:
       - Query Check:
           <<: *common_non_publish_filters
       - Generated Types Check:
+          <<: *common_non_publish_filters
+      - Build CLI:
           <<: *common_non_publish_filters
       - oss/lerna_tarballs:
           name: Package tarballs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,16 +101,25 @@ jobs:
       - oss/npm_clean_install_with_caching
       - run:
           name: Make tmp dir
-          command: cd packages/apollo && mkdir tmp && cd tmp
+          command: cd packages/apollo && mkdir tmp && cd tmp && npm init -y && git init
       - run:
-          name: Initialize tmp dir with NPM and Git
-          command: npm init -y && git init
-      - run: npm i apollo && cd node_modules/apollo && npm i --package-lock-only
-      - run: cd ../../../
-      - run: rm package.json && cp tmp/node_modules/apollo/package* .
+          name: Install apollo in tmp folder and generate lockfile
+          command: npm i apollo && cd node_modules/apollo && npm i --package-lock-only
+          working_directory: packages/apollo/tmp
+      - run:
+          name: Copy package and lockfile to project
+          command: rm package.json && cp tmp/node_modules/apollo/package* .
+          working_directory: packages/apollo
       - run:
           name: Build CLI
           command: npx -p @oclif/dev-cli oclif-dev pack --targets=darwin-x64
+          working_directory: packages/apollo
+      - store_artifacts:
+          path: packages/apollo/dist
+      # - run:
+      #     name: Publish
+      #     command: npx -p @oclif/dev-cli oclif-dev publish --targets=darwin-x64
+      #     working_directory: packages/apollo
 
 common_non_publish_filters: &common_non_publish_filters
   filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,11 +8,11 @@ orbs:
   oss: apollo/oss-ci-cd-tooling@0.0.5
 
 commands:
-# These are the steps used for each version of Node which we're testing
-# against.  Thanks to YAMLs inability to merge arrays (though it is able
-# to merge objects), every version of Node must use the exact same steps,
-# or these steps would need to be repeated in a version of Node that needs
-# something different.  Probably best to avoid that, out of principle, though.
+  # These are the steps used for each version of Node which we're testing
+  # against.  Thanks to YAMLs inability to merge arrays (though it is able
+  # to merge objects), every version of Node must use the exact same steps,
+  # or these steps would need to be repeated in a version of Node that needs
+  # something different.  Probably best to avoid that, out of principle, though.
   common_test_steps:
     description: Commands to run on every Node.js environment
     steps:
@@ -26,12 +26,12 @@ commands:
 jobs:
   # Platform tests, each with the same tests but different platform or version.
   NodeJS 8:
-    executor: { name: oss/node, tag: '8' }
+    executor: { name: oss/node, tag: "8" }
     steps:
       - common_test_steps
 
   NodeJS 10:
-    executor: { name: oss/node, tag: '10' }
+    executor: { name: oss/node, tag: "10" }
     steps:
       - common_test_steps
       # We will save the results of this one particular invocation to use in
@@ -96,9 +96,9 @@ jobs:
   Build CLI:
     executor: { name: oss/node }
     steps:
-      - *run_install_desired_npm
+      - oss/install_specific_npm_version
       - checkout
-      - run: npm install
+      - oss/npm_clean_install_with_caching
       - run:
           name: Make tmp dir
           command: cd packages/apollo && mkdir tmp && cd tmp
@@ -169,4 +169,3 @@ workflows:
           <<: *common_publish_filters
           requires:
             - Confirmation
-

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,6 +116,7 @@ jobs:
           working_directory: packages/apollo
       - store_artifacts:
           path: packages/apollo/dist
+          destination: apollo-cli
       # - run:
       #     name: Publish
       #     command: npx -p @oclif/dev-cli oclif-dev publish --targets=darwin-x64


### PR DESCRIPTION
This adds a tarball build step for packaging up the CLI.

This PR does not yet _publish_ that tarball anywhere, but it does store it as an artifact of the build under the `artifacts` tab in Circle

<!--
  Thanks for filing a pull request on Apollo Tooling!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [ ] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [ ] Make sure all of the significant new logic is covered by tests
- [ ] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests and linter rules pass

\*Make sure changelog entries note which project(s) has been affected. See older entries for examples on what this looks like.
