### PR TITLE
Replace instanceof checks with their respective predicates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,21 +5,21 @@
 - `apollo`
   - <First `apollo` related entry goes here>
 - `apollo-codegen-core`
-  - <First `apollo-codegen-core` related entry goes here>
+  - Replace instanceof checks with their respective predicates [#1518](https://github.com/apollographql/apollo-tooling/pull/1518)
 - `apollo-codegen-flow`
-  - <First `apollo-codegen-flow` related entry goes here>
+  - Replace instanceof checks with their respective predicates [#1518](https://github.com/apollographql/apollo-tooling/pull/1518)
 - `apollo-codegen-scala`
-  - <First `apollo-codegen-scala` related entry goes here>
+  - Replace instanceof checks with their respective predicates [#1518](https://github.com/apollographql/apollo-tooling/pull/1518)
 - `apollo-codegen-swift`
-  - <First `apollo-codegen-swift` related entry goes here>
+  - Replace instanceof checks with their respective predicates [#1518](https://github.com/apollographql/apollo-tooling/pull/1518)
 - `apollo-codegen-typescript`
-  - <First `apollo-codegen-typescript` related entry goes here>
+  - Replace instanceof checks with their respective predicates [#1518](https://github.com/apollographql/apollo-tooling/pull/1518)
 - `apollo-env`
   - <First `apollo-env` related entry goes here>
 - `apollo-graphql`
   - <First `apollo-graphql` related entry goes here>
 - `apollo-language-server`
-  - <First `apollo-language-server` related entry goes here>
+  - Replace instanceof checks with their respective predicates [#1518](https://github.com/apollographql/apollo-tooling/pull/1518)
 - `apollo-tools`
   - <First `apollo-tools` related entry goes here>
 - `vscode-apollo`

--- a/packages/apollo-codegen-core/src/compiler/index.ts
+++ b/packages/apollo-codegen-core/src/compiler/index.ts
@@ -7,9 +7,6 @@ import {
   isCompositeType,
   GraphQLOutputType,
   GraphQLInputType,
-  GraphQLScalarType,
-  GraphQLEnumType,
-  GraphQLInputObjectType,
   GraphQLObjectType,
   GraphQLError,
   GraphQLSchema,
@@ -22,7 +19,10 @@ import {
   SelectionNode,
   isSpecifiedScalarType,
   NonNullTypeNode,
-  GraphQLNonNull
+  GraphQLNonNull,
+  isEnumType,
+  isInputObjectType,
+  isScalarType
 } from "graphql";
 
 import {
@@ -202,13 +202,13 @@ class Compiler {
     if (this.typesUsedSet.has(type)) return;
 
     if (
-      type instanceof GraphQLEnumType ||
-      type instanceof GraphQLInputObjectType ||
-      (type instanceof GraphQLScalarType && !isSpecifiedScalarType(type))
+      isEnumType(type) ||
+      isInputObjectType(type) ||
+      (isScalarType(type) && !isSpecifiedScalarType(type))
     ) {
       this.typesUsedSet.add(type);
     }
-    if (type instanceof GraphQLInputObjectType) {
+    if (isInputObjectType(type)) {
       for (const field of Object.values(type.getFields())) {
         this.addTypeUsed(getNamedType(field.type));
       }

--- a/packages/apollo-codegen-core/src/serializeToJSON.ts
+++ b/packages/apollo-codegen-core/src/serializeToJSON.ts
@@ -3,7 +3,10 @@ import {
   GraphQLType,
   GraphQLScalarType,
   GraphQLEnumType,
-  GraphQLInputObjectType
+  GraphQLInputObjectType,
+  isEnumType,
+  isInputObjectType,
+  isScalarType
 } from "graphql";
 
 import { LegacyCompilerContext } from "./compiler/legacyIR";
@@ -34,11 +37,11 @@ export function serializeAST(ast: any, space?: string) {
 }
 
 function serializeType(type: GraphQLType) {
-  if (type instanceof GraphQLEnumType) {
+  if (isEnumType(type)) {
     return serializeEnumType(type);
-  } else if (type instanceof GraphQLInputObjectType) {
+  } else if (isInputObjectType(type)) {
     return serializeInputObjectType(type);
-  } else if (type instanceof GraphQLScalarType) {
+  } else if (isScalarType(type)) {
     return serializeScalarType(type);
   } else {
     throw new Error(`Unexpected GraphQL type: ${type}`);

--- a/packages/apollo-codegen-core/src/utilities/graphql.ts
+++ b/packages/apollo-codegen-core/src/utilities/graphql.ts
@@ -7,9 +7,6 @@ import {
   TypeMetaFieldDef,
   TypeNameMetaFieldDef,
   GraphQLCompositeType,
-  GraphQLObjectType,
-  GraphQLInterfaceType,
-  GraphQLUnionType,
   GraphQLEnumValue,
   GraphQLError,
   GraphQLSchema,
@@ -24,7 +21,10 @@ import {
   DocumentNode,
   DirectiveNode,
   isListType,
-  isNonNullType
+  isNonNullType,
+  isObjectType,
+  isInterfaceType,
+  isUnionType
 } from "graphql";
 
 declare module "graphql/utilities/buildASTSchema" {
@@ -162,7 +162,7 @@ export function isTypeProperSuperTypeOf(
 ) {
   return (
     isEqualType(maybeSuperType, subType) ||
-    (subType instanceof GraphQLObjectType &&
+    (isObjectType(subType) &&
       (isAbstractType(maybeSuperType) &&
         schema.isPossibleType(maybeSuperType, subType)))
   );
@@ -226,16 +226,13 @@ export function getFieldDef(
   }
   if (
     name === TypeNameMetaFieldDef.name &&
-    (parentType instanceof GraphQLObjectType ||
-      parentType instanceof GraphQLInterfaceType ||
-      parentType instanceof GraphQLUnionType)
+    (isObjectType(parentType) ||
+      isInterfaceType(parentType) ||
+      isUnionType(parentType))
   ) {
     return TypeNameMetaFieldDef;
   }
-  if (
-    parentType instanceof GraphQLObjectType ||
-    parentType instanceof GraphQLInterfaceType
-  ) {
+  if (isObjectType(parentType) || isInterfaceType(parentType)) {
     return parentType.getFields()[name];
   }
 

--- a/packages/apollo-codegen-flow/src/codeGeneration.ts
+++ b/packages/apollo-codegen-flow/src/codeGeneration.ts
@@ -1,6 +1,11 @@
 import * as t from "@babel/types";
 import { stripIndent } from "common-tags";
-import { GraphQLEnumType, GraphQLInputObjectType } from "graphql";
+import {
+  GraphQLEnumType,
+  GraphQLInputObjectType,
+  isEnumType,
+  isInputObjectType
+} from "graphql";
 
 import {
   CompilerContext,
@@ -42,19 +47,13 @@ function printEnumsAndInputObjects(
     //==============================================================
   `);
 
-  context.typesUsed
-    .filter(type => type instanceof GraphQLEnumType)
-    .forEach(enumType => {
-      generator.typeAliasForEnumType(enumType as GraphQLEnumType);
-    });
+  context.typesUsed.filter(isEnumType).forEach(enumType => {
+    generator.typeAliasForEnumType(enumType);
+  });
 
-  context.typesUsed
-    .filter(type => type instanceof GraphQLInputObjectType)
-    .forEach(inputObjectType => {
-      generator.typeAliasForInputObjectType(
-        inputObjectType as GraphQLInputObjectType
-      );
-    });
+  context.typesUsed.filter(isInputObjectType).forEach(inputObjectType => {
+    generator.typeAliasForInputObjectType(inputObjectType);
+  });
 
   generator.printer.enqueue(stripIndent`
     //==============================================================

--- a/packages/apollo-codegen-flow/src/helpers.ts
+++ b/packages/apollo-codegen-flow/src/helpers.ts
@@ -3,11 +3,11 @@ import {
   GraphQLFloat,
   GraphQLInt,
   GraphQLID,
-  GraphQLScalarType,
   GraphQLString,
   GraphQLType,
   isListType,
-  isNonNullType
+  isNonNullType,
+  isScalarType
 } from "graphql";
 
 import * as t from "@babel/types";
@@ -40,7 +40,7 @@ export function createTypeAnnotationFromGraphQLTypeFunction(
           typeAnnotationFromGraphQLType(type.ofType, typeName)
         ])
       );
-    } else if (type instanceof GraphQLScalarType) {
+    } else if (isScalarType(type)) {
       const builtIn = builtInScalarMap[typeName || type.name];
       if (builtIn != null) {
         return builtIn;

--- a/packages/apollo-codegen-scala/src/codeGeneration.ts
+++ b/packages/apollo-codegen-scala/src/codeGeneration.ts
@@ -3,8 +3,10 @@ import {
   getNamedType,
   isCompositeType,
   GraphQLEnumType,
-  GraphQLNonNull,
-  GraphQLInputObjectType
+  GraphQLInputObjectType,
+  isNonNullType,
+  isEnumType,
+  isInputObjectType
 } from "graphql";
 
 import { isTypeProperSuperTypeOf } from "apollo-codegen-core/lib/utilities/graphql";
@@ -157,9 +159,7 @@ export function classDeclarationForOperation(
             undefined,
             true
           );
-          const isOptional = !(
-            type instanceof GraphQLNonNull || type instanceof GraphQLNonNull
-          );
+          const isOptional = !isNonNullType(type);
           return { name, propertyName, type, typeName, isOptional };
         });
 
@@ -382,9 +382,9 @@ export function typeDeclarationForGraphQLType(
   generator: CodeGenerator<LegacyCompilerContext, any>,
   type: GraphQLType
 ) {
-  if (type instanceof GraphQLEnumType) {
+  if (isEnumType(type)) {
     enumerationDeclaration(generator, type);
-  } else if (type instanceof GraphQLInputObjectType) {
+  } else if (isInputObjectType(type)) {
     traitDeclarationForInputObjectType(generator, type);
   }
 }

--- a/packages/apollo-codegen-scala/src/naming.ts
+++ b/packages/apollo-codegen-scala/src/naming.ts
@@ -8,10 +8,10 @@ import { escapeIdentifierIfNeeded, Property } from "./language";
 import { typeNameFromGraphQLType } from "./types";
 
 import {
-  GraphQLList,
-  GraphQLNonNull,
   getNamedType,
-  isCompositeType
+  isCompositeType,
+  isNonNullType,
+  isListType
 } from "graphql";
 import {
   LegacyCompilerContext,
@@ -53,8 +53,8 @@ export function propertyFromInputField(
   const propertyName = escapeIdentifierIfNeeded(unescapedPropertyName);
 
   const type = field.type;
-  const isList = type instanceof GraphQLList || type instanceof GraphQLList;
-  const isOptional = !(type instanceof GraphQLNonNull);
+  const isList = isListType(type);
+  const isOptional = !isNonNullType(type);
   const bareType = getNamedType(type);
 
   const bareTypeName = isCompositeType(bareType)
@@ -94,8 +94,8 @@ export function propertyFromLegacyField(
   const propertyName = escapeIdentifierIfNeeded(name);
 
   const type = field.type;
-  const isList = type instanceof GraphQLList || type instanceof GraphQLList;
-  const isOptional = field.isConditional || !(type instanceof GraphQLNonNull);
+  const isList = isListType(type);
+  const isOptional = field.isConditional || !isNonNullType(type);
   const bareType = getNamedType(type);
 
   const bareTypeName = isCompositeType(bareType)

--- a/packages/apollo-codegen-scala/src/types.ts
+++ b/packages/apollo-codegen-scala/src/types.ts
@@ -5,10 +5,11 @@ import {
   GraphQLBoolean,
   GraphQLID,
   GraphQLScalarType,
-  GraphQLEnumType,
   isAbstractType,
   isNonNullType,
-  isListType
+  isListType,
+  isScalarType,
+  isEnumType
 } from "graphql";
 import { LegacyCompilerContext } from "apollo-codegen-core/lib/compiler/legacyIR";
 import { GraphQLType } from "graphql";
@@ -76,9 +77,9 @@ export function typeNameFromGraphQLType(
         ) +
         "]";
     }
-  } else if (type instanceof GraphQLScalarType) {
+  } else if (isScalarType(type)) {
     typeName = typeNameForScalarType(context, type);
-  } else if (type instanceof GraphQLEnumType) {
+  } else if (isEnumType(type)) {
     typeName = "String";
   } else {
     typeName = bareTypeName || type.name;

--- a/packages/apollo-codegen-swift/src/codeGeneration.ts
+++ b/packages/apollo-codegen-swift/src/codeGeneration.ts
@@ -8,7 +8,9 @@ import {
   GraphQLEnumType,
   GraphQLInputObjectType,
   isNonNullType,
-  isListType
+  isListType,
+  isEnumType,
+  isInputObjectType
 } from "graphql";
 
 import {
@@ -965,9 +967,9 @@ export class SwiftAPIGenerator extends SwiftGenerator<CompilerContext> {
     type: GraphQLType,
     outputIndividualFiles: boolean
   ) {
-    if (type instanceof GraphQLEnumType) {
+    if (isEnumType(type)) {
       this.enumerationDeclaration(type);
-    } else if (type instanceof GraphQLInputObjectType) {
+    } else if (isInputObjectType(type)) {
       this.structDeclarationForInputObjectType(type, outputIndividualFiles);
     }
   }

--- a/packages/apollo-codegen-swift/src/helpers.ts
+++ b/packages/apollo-codegen-swift/src/helpers.ts
@@ -5,14 +5,14 @@ import {
   GraphQLFloat,
   GraphQLBoolean,
   GraphQLID,
-  GraphQLNonNull,
   GraphQLScalarType,
-  GraphQLEnumType,
   isCompositeType,
   getNamedType,
   GraphQLInputField,
   isNonNullType,
-  isListType
+  isListType,
+  isScalarType,
+  isEnumType
 } from "graphql";
 
 import { camelCase, pascalCase } from "change-case";
@@ -66,7 +66,7 @@ export class Helpers {
         "[" +
         this.typeNameFromGraphQLType(type.ofType, unmodifiedTypeName) +
         "]";
-    } else if (type instanceof GraphQLScalarType) {
+    } else if (isScalarType(type)) {
       typeName = this.typeNameForScalarType(type);
     } else {
       typeName = unmodifiedTypeName || type.name;
@@ -89,9 +89,9 @@ export class Helpers {
       return `.nonNull(${this.fieldTypeEnum(type.ofType, structName)})`;
     } else if (isListType(type)) {
       return `.list(${this.fieldTypeEnum(type.ofType, structName)})`;
-    } else if (type instanceof GraphQLScalarType) {
+    } else if (isScalarType(type)) {
       return `.scalar(${this.typeNameForScalarType(type)}.self)`;
-    } else if (type instanceof GraphQLEnumType) {
+    } else if (isEnumType(type)) {
       return `.scalar(${type.name}.self)`;
     } else if (isCompositeType(type)) {
       return `.object(${structName}.selections)`;
@@ -151,7 +151,7 @@ export class Helpers {
       type = type.ofType;
     }
 
-    const isOptional = !(type instanceof GraphQLNonNull);
+    const isOptional = !isNonNullType(type);
 
     const unmodifiedType = getNamedType(field.type);
 
@@ -200,7 +200,7 @@ export class Helpers {
     return Object.assign({}, field, {
       propertyName: camelCase(field.name),
       typeName: this.typeNameFromGraphQLType(field.type),
-      isOptional: !(field.type instanceof GraphQLNonNull)
+      isOptional: !isNonNullType(field.type)
     });
   }
 

--- a/packages/apollo-codegen-typescript/src/helpers.ts
+++ b/packages/apollo-codegen-typescript/src/helpers.ts
@@ -3,11 +3,11 @@ import {
   GraphQLFloat,
   GraphQLInt,
   GraphQLID,
-  GraphQLScalarType,
   GraphQLString,
   GraphQLType,
   isListType,
-  isNonNullType
+  isNonNullType,
+  isScalarType
 } from "graphql";
 
 import * as t from "@babel/types";
@@ -46,7 +46,7 @@ export function createTypeFromGraphQLTypeFunction(
           ? t.TSParenthesizedType(elementType)
           : elementType
       );
-    } else if (graphQLType instanceof GraphQLScalarType) {
+    } else if (isScalarType(graphQLType)) {
       const builtIn = builtInScalarMap[typeName || graphQLType.name];
       if (builtIn != null) {
         return builtIn;

--- a/packages/apollo-language-server/src/languageProvider.ts
+++ b/packages/apollo-language-server/src/languageProvider.ts
@@ -178,7 +178,9 @@ export class GraphQLLanguageProvider {
         if (!suggestedField) {
           return suggest;
         } else {
-          const requiredArgs = suggestedField.args.filter(isNonNullType);
+          const requiredArgs = suggestedField.args.filter(a =>
+            isNonNullType(a.type)
+          );
           const paramsSection =
             requiredArgs.length > 0
               ? `(${requiredArgs

--- a/packages/apollo-language-server/src/languageProvider.ts
+++ b/packages/apollo-language-server/src/languageProvider.ts
@@ -178,9 +178,7 @@ export class GraphQLLanguageProvider {
         if (!suggestedField) {
           return suggest;
         } else {
-          const requiredArgs = suggestedField.args.filter(
-            a => a.type instanceof GraphQLNonNull
-          );
+          const requiredArgs = suggestedField.args.filter(isNonNullType);
           const paramsSection =
             requiredArgs.length > 0
               ? `(${requiredArgs

--- a/packages/apollo-language-server/src/utilities/graphql.ts
+++ b/packages/apollo-language-server/src/utilities/graphql.ts
@@ -1,9 +1,6 @@
 import {
   GraphQLSchema,
   GraphQLCompositeType,
-  GraphQLObjectType,
-  GraphQLInterfaceType,
-  GraphQLUnionType,
   GraphQLField,
   FieldNode,
   SchemaMetaFieldDef,
@@ -15,11 +12,11 @@ import {
   visit,
   print,
   DirectiveNode,
-  OperationDefinitionNode,
   SelectionSetNode,
   DirectiveDefinitionNode,
-  FragmentDefinitionNode,
-  FragmentSpreadNode
+  isObjectType,
+  isInterfaceType,
+  isUnionType
 } from "graphql";
 
 export function isNode(maybeNode: any): maybeNode is ASTNode {
@@ -71,16 +68,13 @@ export function getFieldDef(
   }
   if (
     name === TypeNameMetaFieldDef.name &&
-    (parentType instanceof GraphQLObjectType ||
-      parentType instanceof GraphQLInterfaceType ||
-      parentType instanceof GraphQLUnionType)
+    (isObjectType(parentType) ||
+      isInterfaceType(parentType) ||
+      isUnionType(parentType))
   ) {
     return TypeNameMetaFieldDef;
   }
-  if (
-    parentType instanceof GraphQLObjectType ||
-    parentType instanceof GraphQLInterfaceType
-  ) {
+  if (isObjectType(parentType) || isInterfaceType(parentType)) {
     return parentType.getFields()[name];
   }
 


### PR DESCRIPTION
This replaces all `instanceof GraphQLXYZ` checks with their respective predicate functions.
<!--
  Thanks for filing a pull request on Apollo Tooling!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [x] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass

\*Make sure changelog entries note which project(s) has been affected. See older entries for examples on what this looks like.
