### PR TITLE
Skip jobs that need API keys on forks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,11 +8,11 @@ orbs:
   oss: apollo/oss-ci-cd-tooling@0.0.5
 
 commands:
-# These are the steps used for each version of Node which we're testing
-# against.  Thanks to YAMLs inability to merge arrays (though it is able
-# to merge objects), every version of Node must use the exact same steps,
-# or these steps would need to be repeated in a version of Node that needs
-# something different.  Probably best to avoid that, out of principle, though.
+  # These are the steps used for each version of Node which we're testing
+  # against.  Thanks to YAMLs inability to merge arrays (though it is able
+  # to merge objects), every version of Node must use the exact same steps,
+  # or these steps would need to be repeated in a version of Node that needs
+  # something different.  Probably best to avoid that, out of principle, though.
   common_test_steps:
     description: Commands to run on every Node.js environment
     steps:
@@ -26,12 +26,12 @@ commands:
 jobs:
   # Platform tests, each with the same tests but different platform or version.
   NodeJS 8:
-    executor: { name: oss/node, tag: '8' }
+    executor: { name: oss/node, tag: "8" }
     steps:
       - common_test_steps
 
   NodeJS 10:
-    executor: { name: oss/node, tag: '10' }
+    executor: { name: oss/node, tag: "10" }
     steps:
       - common_test_steps
       # We will save the results of this one particular invocation to use in
@@ -78,7 +78,14 @@ jobs:
       - oss/install_specific_npm_version
       - checkout
       - oss/npm_clean_install_with_caching
-      - run: ENGINE_API_KEY=$CHECKS_API_KEY ./packages/apollo/bin/run client:check
+      - run:
+          name:
+          command: |
+            if [ -z "$CHECKS_API_KEY" ]; then
+              echo "NO CHECKS_API_KEY! CANNOT RUN! This is normal on PRs from Forks."
+              exit 0 # i.e. pass tests.
+            fi
+            ENGINE_API_KEY=$CHECKS_API_KEY ./packages/apollo/bin/run client:check
 
   Generated Types Check:
     executor: { name: oss/node }
@@ -87,11 +94,14 @@ jobs:
       - checkout
       - oss/npm_clean_install_with_caching
       - run:
-          name: Generate types locally
-          command: npx apollo client:codegen --key=$CHECKS_API_KEY --outputFlat --target=typescript currentTypes.ts
-      - run:
-          name: Compare type files
-          command: cmp --silent currentTypes.ts ./packages/apollo-language-server/src/graphqlTypes.ts || (echo "Type check failed. Run 'npm run client:codegen'" && exit 1)
+          name: Generate types locally and compare type files
+          command: |
+            if [ -z "$CHECKS_API_KEY" ]; then
+              echo "NO CHECKS_API_KEY! CANNOT RUN! This is normal on PRs from Forks."
+              exit 0 # i.e. pass tests.
+            fi
+            npx apollo client:codegen --key=$CHECKS_API_KEY --outputFlat --target=typescript currentTypes.ts
+            cmp --silent currentTypes.ts ./packages/apollo-language-server/src/graphqlTypes.ts || (echo "Type check failed. Run 'npm run client:codegen'" && exit 1)
 
 common_non_publish_filters: &common_non_publish_filters
   filters:
@@ -148,4 +158,3 @@ workflows:
           <<: *common_publish_filters
           requires:
             - Confirmation
-


### PR DESCRIPTION
Two steps in the CI process are reliant on the `CHECKS_API_KEY` env variable. Since this isn't available on runs that are triggered by a fork, those tasks would error out.

This PR skips those commands that requires a env variable which is private.

This is still safe to do, since once merged to master, the checks would be run again, but with those env variables present. And it would be run once again before a release. So the missing check in the PR isn't critical for preventing failures.

TODO:

- [x] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [ ] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass

\*Make sure changelog entries note which project(s) has been affected. See older entries for examples on what this looks like.
