### PR TITLE
Don't break on bad arguments

### DIFF
--- a/packages/apollo-language-server/src/languageProvider.ts
+++ b/packages/apollo-language-server/src/languageProvider.ts
@@ -376,7 +376,8 @@ export class GraphQLLanguageProvider {
         }
 
         case Kind.ARGUMENT: {
-          const argumentNode = typeInfo.getArgument()!;
+          const argumentNode = typeInfo.getArgument();
+          if (!argumentNode) break;
           const content = [
             [
               `\`\`\`graphql`,


### PR DESCRIPTION
When dealing with directives without arguments specified,
such as when using Relay - the argument from typeinfo can be
null/undefined.

This change simply avoids throwing errors when hovering these
arguments - and instead provides no help on hover.

I couldn't find any tests for the language server regarding these
parts, but I tried my best testing it in a local project.

TODO:

- [ ] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [ ] Make sure all of the significant new logic is covered by tests
- [ ] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests and linter rules pass

