### PR TITLE
Use "table" package for tabular output and word wrap support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Upcoming
 
 - `apollo`
-  - <First `apollo` related entry goes here>
+  - Use "table" package for tabular output and word wrap support [#1524](https://github.com/apollographql/apollo-tooling/pull/1524)
 - `apollo-codegen-core`
   - <First `apollo-codegen-core` related entry goes here>
 - `apollo-codegen-flow`

--- a/package-lock.json
+++ b/package-lock.json
@@ -383,6 +383,7 @@
       "version": "1.1.14",
       "resolved": "https://registry.npmjs.org/@heroku-cli/color/-/color-1.1.14.tgz",
       "integrity": "sha512-2JYy//YE2YINTe21hpdVMBNc7aYFkgDeY9JUz/BCjFZmYLn0UjGaCc4BpTcMGXNJwuqoUenw2WGOFGHsJqlIDw==",
+      "dev": true,
       "requires": {
         "ansi-styles": "^3.2.1",
         "chalk": "^2.4.1",
@@ -2903,7 +2904,8 @@
     "@sindresorhus/is": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz",
-      "integrity": "sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow=="
+      "integrity": "sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow==",
+      "dev": true
     },
     "@types/babel-types": {
       "version": "7.0.7",
@@ -3350,7 +3352,6 @@
         "glob": "7.1.4",
         "graphql": "14.0.2 - 14.2.0 || ^14.3.1",
         "graphql-tag": "2.10.1",
-        "heroku-cli-util": "8.0.11",
         "listr": "0.14.3",
         "lodash.identity": "3.0.0",
         "lodash.pickby": "4.6.0",
@@ -4572,6 +4573,7 @@
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-2.1.4.tgz",
       "integrity": "sha1-DYCIAbY0KtM8kd+dC0TcCbkeXD0=",
+      "dev": true,
       "requires": {
         "clone-response": "1.0.2",
         "get-stream": "3.0.0",
@@ -4585,12 +4587,14 @@
         "get-stream": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
+          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+          "dev": true
         },
         "lowercase-keys": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
-          "integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY="
+          "integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY=",
+          "dev": true
         }
       }
     },
@@ -4981,6 +4985,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
       "integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
+      "dev": true,
       "requires": {
         "mimic-response": "^1.0.0"
       }
@@ -4988,7 +4993,8 @@
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+      "dev": true
     },
     "code-point-at": {
       "version": "1.1.0",
@@ -5375,7 +5381,8 @@
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
     },
     "cosmiconfig": {
       "version": "5.2.0",
@@ -5542,12 +5549,14 @@
     "decode-uri-component": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+      "dev": true
     },
     "decompress-response": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
       "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
+      "dev": true,
       "requires": {
         "mimic-response": "^1.0.0"
       }
@@ -5833,7 +5842,8 @@
     "duplexer3": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
-      "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
+      "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
+      "dev": true
     },
     "duplexify": {
       "version": "3.7.1",
@@ -6535,6 +6545,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
       "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
+      "dev": true,
       "requires": {
         "inherits": "^2.0.1",
         "readable-stream": "^2.0.0"
@@ -7640,6 +7651,7 @@
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/got/-/got-8.3.2.tgz",
       "integrity": "sha512-qjUJ5U/hawxosMryILofZCkm3C84PLJS/0grRIpjAwu+Lkxxj5cxeCU25BG0/3mDSpXKTyZr8oh8wIgLaH0QCw==",
+      "dev": true,
       "requires": {
         "@sindresorhus/is": "^0.7.0",
         "cacheable-request": "^2.1.1",
@@ -7663,12 +7675,14 @@
         "get-stream": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
+          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+          "dev": true
         },
         "pify": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
         }
       }
     },
@@ -7769,7 +7783,8 @@
     "has-symbol-support-x": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/has-symbol-support-x/-/has-symbol-support-x-1.4.2.tgz",
-      "integrity": "sha512-3ToOva++HaW+eCpgqZrCfN51IPB+7bJNVT6CUATzueB5Heb8o6Nam0V3HG5dlDvZU1Gn5QLcbahiKw/XVk5JJw=="
+      "integrity": "sha512-3ToOva++HaW+eCpgqZrCfN51IPB+7bJNVT6CUATzueB5Heb8o6Nam0V3HG5dlDvZU1Gn5QLcbahiKw/XVk5JJw==",
+      "dev": true
     },
     "has-symbols": {
       "version": "1.0.0",
@@ -7780,6 +7795,7 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/has-to-string-tag-x/-/has-to-string-tag-x-1.4.1.tgz",
       "integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
+      "dev": true,
       "requires": {
         "has-symbol-support-x": "^1.4.1"
       }
@@ -7841,6 +7857,7 @@
       "version": "8.0.11",
       "resolved": "https://registry.npmjs.org/heroku-cli-util/-/heroku-cli-util-8.0.11.tgz",
       "integrity": "sha512-cApMBbrfAhFTKs/loXm7zkWRC4kOH1VHoqU5WNgzs2TGKJqQI3QYvxITKE+8iC1Gb1xAy0BCqdGgzx8t7EoeWQ==",
+      "dev": true,
       "requires": {
         "@heroku-cli/color": "^1.1.3",
         "ansi-escapes": "^3.1.0",
@@ -7862,12 +7879,14 @@
         "ansi-regex": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
         },
         "strip-ansi": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
           "requires": {
             "ansi-regex": "^3.0.0"
           }
@@ -7878,6 +7897,7 @@
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/heroku-client/-/heroku-client-3.0.7.tgz",
       "integrity": "sha512-wL8d3ufIWGzL8B2U7oPzN+SdcMt6LPqA/x4nb9pDG45IXpr8KO+N4dvX4Vycgn0WrJVDfQnQ1juctJsUwuoeww==",
+      "dev": true,
       "requires": {
         "is-retry-allowed": "^1.0.0",
         "tunnel-agent": "^0.6.0"
@@ -7928,7 +7948,8 @@
     "http-cache-semantics": {
       "version": "3.8.1",
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-3.8.1.tgz",
-      "integrity": "sha512-5ai2iksyV8ZXmnZhHH4rWPoxxistEexSi5936zIQ1bnNTW5VnA85B6P/VpXiRM017IgRvb2kKo1a//y+0wSp3w=="
+      "integrity": "sha512-5ai2iksyV8ZXmnZhHH4rWPoxxistEexSi5936zIQ1bnNTW5VnA85B6P/VpXiRM017IgRvb2kKo1a//y+0wSp3w==",
+      "dev": true
     },
     "http-call": {
       "version": "5.2.4",
@@ -8338,6 +8359,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/into-stream/-/into-stream-3.1.0.tgz",
       "integrity": "sha1-lvsKk2wSur1v8XUqF9BWFqvQlMY=",
+      "dev": true,
       "requires": {
         "from2": "^2.1.1",
         "p-is-promise": "^1.1.0"
@@ -8536,7 +8558,8 @@
     "is-object": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
-      "integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA="
+      "integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA=",
+      "dev": true
     },
     "is-observable": {
       "version": "1.1.0",
@@ -8573,7 +8596,8 @@
     "is-plain-obj": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
+      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
+      "dev": true
     },
     "is-plain-object": {
       "version": "2.0.4",
@@ -8673,7 +8697,8 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
     },
     "isexe": {
       "version": "2.0.0",
@@ -8797,6 +8822,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isurl/-/isurl-1.0.0.tgz",
       "integrity": "sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w==",
+      "dev": true,
       "requires": {
         "has-to-string-tag-x": "^1.2.0",
         "is-object": "^1.0.1"
@@ -11441,7 +11467,8 @@
     "json-buffer": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
-      "integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg="
+      "integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg=",
+      "dev": true
     },
     "json-parse-better-errors": {
       "version": "1.0.2",
@@ -11504,6 +11531,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-3.0.0.tgz",
       "integrity": "sha512-eguHnq22OE3uVoSYG0LVWNP+4ppamWr9+zWBe1bsNcovIMy6huUJFPgy4mGwCd/rnl3vOLGW1MTlu4c57CT1xA==",
+      "dev": true,
       "requires": {
         "json-buffer": "3.0.0"
       }
@@ -11979,7 +12007,8 @@
     "lowercase-keys": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
-      "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA=="
+      "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
+      "dev": true
     },
     "lru-cache": {
       "version": "5.1.1",
@@ -12261,7 +12290,8 @@
     "mimic-response": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
-      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ=="
+      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+      "dev": true
     },
     "minimatch": {
       "version": "3.0.4",
@@ -12545,6 +12575,7 @@
       "version": "3.1.6",
       "resolved": "https://registry.npmjs.org/netrc-parser/-/netrc-parser-3.1.6.tgz",
       "integrity": "sha512-lY+fmkqSwntAAjfP63jB4z5p5WbuZwyMCD3pInT7dpHU/Gc6Vv90SAC6A0aNiqaRGHiuZFBtiwu+pu8W/Eyotw==",
+      "dev": true,
       "requires": {
         "debug": "^3.1.0",
         "execa": "^0.10.0"
@@ -12554,6 +12585,7 @@
           "version": "3.2.6",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
           "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "dev": true,
           "requires": {
             "ms": "^2.1.1"
           }
@@ -12562,6 +12594,7 @@
           "version": "0.10.0",
           "resolved": "https://registry.npmjs.org/execa/-/execa-0.10.0.tgz",
           "integrity": "sha512-7XOMnz8Ynx1gGo/3hyV9loYNPWM94jG3+3T3Y8tsfSstFmETmENCMU/A/zj8Lyaj1lkgEepKepvd6240tBRvlw==",
+          "dev": true,
           "requires": {
             "cross-spawn": "^6.0.0",
             "get-stream": "^3.0.0",
@@ -12575,17 +12608,20 @@
         "get-stream": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
+          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+          "dev": true
         },
         "is-stream": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+          "dev": true
         },
         "npm-run-path": {
           "version": "2.0.2",
           "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
           "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+          "dev": true,
           "requires": {
             "path-key": "^2.0.0"
           }
@@ -12738,6 +12774,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-2.0.1.tgz",
       "integrity": "sha512-D6MUW4K/VzoJ4rJ01JFKxDrtY1v9wrgzCX5f2qj/lzH1m/lW6MhUZFKerVsnyjOhOsYzI9Kqqak+10l4LvLpMw==",
+      "dev": true,
       "requires": {
         "prepend-http": "^2.0.0",
         "query-string": "^5.0.1",
@@ -12974,6 +13011,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/opn/-/opn-3.0.3.tgz",
       "integrity": "sha1-ttmec5n3jWXDuq/+8fsojpuFJDo=",
+      "dev": true,
       "requires": {
         "object-assign": "^4.0.1"
       }
@@ -13070,7 +13108,8 @@
     "p-cancelable": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.4.1.tgz",
-      "integrity": "sha512-HNa1A8LvB1kie7cERyy21VNeHb2CWJJYqyyC2o3klWFfMGlFmWv2Z7sFgZH8ZiaYL95ydToKTFVXgMV/Os0bBQ=="
+      "integrity": "sha512-HNa1A8LvB1kie7cERyy21VNeHb2CWJJYqyyC2o3klWFfMGlFmWv2Z7sFgZH8ZiaYL95ydToKTFVXgMV/Os0bBQ==",
+      "dev": true
     },
     "p-defer": {
       "version": "1.0.0",
@@ -13095,7 +13134,8 @@
     "p-is-promise": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
-      "integrity": "sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4="
+      "integrity": "sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4=",
+      "dev": true
     },
     "p-limit": {
       "version": "1.3.0",
@@ -13154,6 +13194,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-2.0.1.tgz",
       "integrity": "sha512-88em58dDVB/KzPEx1X0N3LwFfYZPyDc4B6eF38M1rk9VTZMbxXXgjugz8mmwpS9Ox4BDZ+t6t3QP5+/gazweIA==",
+      "dev": true,
       "requires": {
         "p-finally": "^1.0.0"
       }
@@ -13417,7 +13458,8 @@
     "prepend-http": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
-      "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc="
+      "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=",
+      "dev": true
     },
     "prettier": {
       "version": "1.18.2",
@@ -13467,7 +13509,8 @@
     "process-nextick-args": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+      "dev": true
     },
     "promise-inflight": {
       "version": "1.0.1",
@@ -13963,6 +14006,7 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
       "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
+      "dev": true,
       "requires": {
         "decode-uri-component": "^0.2.0",
         "object-assign": "^4.1.0",
@@ -14145,6 +14189,7 @@
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+      "dev": true,
       "requires": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -14399,6 +14444,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
       "integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
+      "dev": true,
       "requires": {
         "lowercase-keys": "^1.0.0"
       }
@@ -14810,6 +14856,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-2.0.0.tgz",
       "integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
+      "dev": true,
       "requires": {
         "is-plain-obj": "^1.0.0"
       }
@@ -15038,7 +15085,8 @@
     "strict-uri-encode": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
-      "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
+      "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
+      "dev": true
     },
     "string-argv": {
       "version": "0.0.2",
@@ -15101,6 +15149,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
       "requires": {
         "safe-buffer": "~5.1.0"
       }
@@ -15427,7 +15476,8 @@
     "timed-out": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
-      "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
+      "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
+      "dev": true
     },
     "title-case": {
       "version": "2.1.1",
@@ -15873,6 +15923,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
       "integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
+      "dev": true,
       "requires": {
         "prepend-http": "^2.0.0"
       }
@@ -15880,7 +15931,8 @@
     "url-to-options": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/url-to-options/-/url-to-options-1.0.1.tgz",
-      "integrity": "sha1-FQWgOiiaSMvXpDTvuu7FBV9WM6k="
+      "integrity": "sha1-FQWgOiiaSMvXpDTvuu7FBV9WM6k=",
+      "dev": true
     },
     "use": {
       "version": "3.1.1",
@@ -15891,7 +15943,8 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
     },
     "util-promisify": {
       "version": "2.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3164,6 +3164,12 @@
       "integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==",
       "dev": true
     },
+    "@types/table": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/@types/table/-/table-4.0.7.tgz",
+      "integrity": "sha512-HKtXvBxU8U8evZCSlUi9HbfT/SFW7nSGCoiBEheB06jAhXeW6JbGh8biEAqIFG5rZo9f8xeJVdIn455sddmIcw==",
+      "dev": true
+    },
     "@types/yargs": {
       "version": "13.0.2",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.2.tgz",
@@ -3350,6 +3356,7 @@
         "lodash.pickby": "4.6.0",
         "moment": "2.24.0",
         "strip-ansi": "5.2.0",
+        "table": "5.4.6",
         "tty": "1.0.1",
         "vscode-uri": "1.0.6"
       },
@@ -3864,8 +3871,7 @@
     "astral-regex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
-      "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
-      "dev": true
+      "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg=="
     },
     "async-limiter": {
       "version": "1.0.1",
@@ -6348,8 +6354,7 @@
     "fast-deep-equal": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
-      "dev": true
+      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
     },
     "fast-extend": {
       "version": "0.0.2",
@@ -11452,8 +11457,7 @@
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
     "json-stringify-safe": {
       "version": "5.0.1",
@@ -13574,8 +13578,7 @@
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "dev": true
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "q": {
       "version": "1.5.1",
@@ -15227,6 +15230,55 @@
       "integrity": "sha512-LO95GIW16x69LuND1nuuwM4pjgFGupg7pZ/4lU86AmchPKrhk0o2tpMU2unXRrqo81iAFe1YJ0nAGEVwsrZAgg==",
       "dev": true
     },
+    "table": {
+      "version": "5.4.6",
+      "resolved": "https://registry.npmjs.org/table/-/table-5.4.6.tgz",
+      "integrity": "sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==",
+      "requires": {
+        "ajv": "^6.10.2",
+        "lodash": "^4.17.14",
+        "slice-ansi": "^2.1.0",
+        "string-width": "^3.0.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "6.10.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
+          "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
+          "requires": {
+            "fast-deep-equal": "^2.0.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+        },
+        "slice-ansi": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
+          "integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
+          "requires": {
+            "ansi-styles": "^3.2.0",
+            "astral-regex": "^1.0.0",
+            "is-fullwidth-code-point": "^2.0.0"
+          }
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        }
+      }
+    },
     "tar": {
       "version": "4.4.10",
       "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.10.tgz",
@@ -15791,7 +15843,6 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
       "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
-      "dev": true,
       "requires": {
         "punycode": "^2.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "@types/node": "8.10.54",
     "@types/node-fetch": "2.5.1",
     "@types/table": "^4.0.7",
+    "heroku-cli-util": "8.0.11",
     "husky": "2.7.0",
     "jest": "24.9.0",
     "jest-environment-node": "24.9.0",

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "@types/nock": "10.0.3",
     "@types/node": "8.10.54",
     "@types/node-fetch": "2.5.1",
+    "@types/table": "^4.0.7",
     "husky": "2.7.0",
     "jest": "24.9.0",
     "jest-environment-node": "24.9.0",

--- a/packages/apollo/@types/heroku-cli-util.d.ts
+++ b/packages/apollo/@types/heroku-cli-util.d.ts
@@ -1,1 +1,0 @@
-declare module "heroku-cli-util";

--- a/packages/apollo/package.json
+++ b/packages/apollo/package.json
@@ -62,6 +62,7 @@
     "lodash.pickby": "4.6.0",
     "moment": "2.24.0",
     "strip-ansi": "5.2.0",
+    "table": "5.4.6",
     "tty": "1.0.1",
     "vscode-uri": "1.0.6"
   },

--- a/packages/apollo/package.json
+++ b/packages/apollo/package.json
@@ -56,7 +56,6 @@
     "glob": "7.1.4",
     "graphql": "14.0.2 - 14.2.0 || ^14.3.1",
     "graphql-tag": "2.10.1",
-    "heroku-cli-util": "8.0.11",
     "listr": "0.14.3",
     "lodash.identity": "3.0.0",
     "lodash.pickby": "4.6.0",

--- a/packages/apollo/src/commands/service/__tests__/__snapshots__/check.test.ts.snap
+++ b/packages/apollo/src/commands/service/__tests__/__snapshots__/check.test.ts.snap
@@ -1,41 +1,67 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`service:check formatHumanReadable should have correct output with breaking and non-breaking changes 1`] = `
+"╔════════╤═══════════════════════════╤═════════════════════════════════════════════════════════════════════════════════════════╗
+║ Change │ Code                      │ Description                                                                             ║
+╟────────┼───────────────────────────┼─────────────────────────────────────────────────────────────────────────────────────────╢
+║ FAIL   │ ARG_REMOVED               │ \`ServiceMutation.uploadSchema\` arg \`gitContext\` was removed                             ║
+╟────────┼───────────────────────────┼─────────────────────────────────────────────────────────────────────────────────────────╢
+║ FAIL   │ ARG_REMOVED               │ \`ServiceMutation.uploadSchema\` arg \`schema\` was removed                                 ║
+╟────────┼───────────────────────────┼─────────────────────────────────────────────────────────────────────────────────────────╢
+║ FAIL   │ ARG_REMOVED               │ \`ServiceMutation.uploadSchema\` arg \`tag\` was removed                                    ║
+╟────────┼───────────────────────────┼─────────────────────────────────────────────────────────────────────────────────────────╢
+║ FAIL   │ FIELD_CHANGED_TYPE        │ \`Change.argNode\` changed type from \`NamedIntrospectionArg\` to \`NamedIntrospectionValue\` ║
+╟────────┼───────────────────────────┼─────────────────────────────────────────────────────────────────────────────────────────╢
+║ FAIL   │ FIELD_REMOVED             │ \`Change.affectedClients\` was removed                                                    ║
+╟────────┼───────────────────────────┼─────────────────────────────────────────────────────────────────────────────────────────╢
+║ FAIL   │ FIELD_REMOVED             │ \`NamedIntrospectionValue.printedType\` was removed                                       ║
+╟────────┼───────────────────────────┼─────────────────────────────────────────────────────────────────────────────────────────╢
+║ FAIL   │ TYPE_REMOVED              │ \`NamedIntrospectionArg\` removed                                                         ║
+╟────────┼───────────────────────────┼─────────────────────────────────────────────────────────────────────────────────────────╢
+║ PASS   │ ARG_REMOVED               │ \`ServiceMutation.registerOperations\` arg \`manifestVersion\` was removed                  ║
+╟────────┼───────────────────────────┼─────────────────────────────────────────────────────────────────────────────────────────╢
+║ PASS   │ ARG_REMOVED               │ \`ServiceMutation.uploadSchema\` arg \`historicParameters\` was removed                     ║
+╟────────┼───────────────────────────┼─────────────────────────────────────────────────────────────────────────────────────────╢
+║ PASS   │ FIELD_ADDED               │ \`Service.schemaNotificationChannels\` was added                                          ║
+╟────────┼───────────────────────────┼─────────────────────────────────────────────────────────────────────────────────────────╢
+║ PASS   │ FIELD_ADDED               │ \`ServiceMutation.deregisterSchemaNotificationChannel\` was added                         ║
+╟────────┼───────────────────────────┼─────────────────────────────────────────────────────────────────────────────────────────╢
+║ PASS   │ FIELD_ADDED               │ \`ServiceMutation.registerSchemaNotificationChannel\` was added                           ║
+╟────────┼───────────────────────────┼─────────────────────────────────────────────────────────────────────────────────────────╢
+║ PASS   │ FIELD_DEPRECATION_REMOVED │ \`AffectedClient.clientId\` is no longer deprecated                                       ║
+╟────────┼───────────────────────────┼─────────────────────────────────────────────────────────────────────────────────────────╢
+║ PASS   │ FIELD_DEPRECATION_REMOVED │ \`Change.description\` is no longer deprecated                                            ║
+╟────────┼───────────────────────────┼─────────────────────────────────────────────────────────────────────────────────────────╢
+║ PASS   │ FIELD_REMOVED             │ \`AffectedClient.clientReferenceId\` was removed                                          ║
+╟────────┼───────────────────────────┼─────────────────────────────────────────────────────────────────────────────────────────╢
+║ PASS   │ FIELD_REMOVED             │ \`Change.affectedClientIdVersionPairs\` was removed                                       ║
+╟────────┼───────────────────────────┼─────────────────────────────────────────────────────────────────────────────────────────╢
+║ PASS   │ FIELD_REMOVED             │ \`Change.affectedClientReferenceIds\` was removed                                         ║
+╟────────┼───────────────────────────┼─────────────────────────────────────────────────────────────────────────────────────────╢
+║ PASS   │ FIELD_REMOVED             │ \`SchemaDiff.numberOfCheckedOperations\` was removed                                      ║
+╚════════╧═══════════════════════════╧═════════════════════════════════════════════════════════════════════════════════════════╝
 "
-FAIL    ARG_REMOVED                \`ServiceMutation.uploadSchema\` arg \`gitContext\` was removed
-FAIL    ARG_REMOVED                \`ServiceMutation.uploadSchema\` arg \`schema\` was removed
-FAIL    ARG_REMOVED                \`ServiceMutation.uploadSchema\` arg \`tag\` was removed
-FAIL    FIELD_CHANGED_TYPE         \`Change.argNode\` changed type from \`NamedIntrospectionArg\` to \`NamedIntrospectionValue\`
-FAIL    FIELD_REMOVED              \`Change.affectedClients\` was removed
-FAIL    FIELD_REMOVED              \`NamedIntrospectionValue.printedType\` was removed
-FAIL    TYPE_REMOVED               \`NamedIntrospectionArg\` removed
-
-PASS    ARG_REMOVED                \`ServiceMutation.registerOperations\` arg \`manifestVersion\` was removed
-PASS    ARG_REMOVED                \`ServiceMutation.uploadSchema\` arg \`historicParameters\` was removed
-PASS    FIELD_ADDED                \`Service.schemaNotificationChannels\` was added
-PASS    FIELD_ADDED                \`ServiceMutation.deregisterSchemaNotificationChannel\` was added
-PASS    FIELD_ADDED                \`ServiceMutation.registerSchemaNotificationChannel\` was added
-PASS    FIELD_DEPRECATION_REMOVED  \`AffectedClient.clientId\` is no longer deprecated
-PASS    FIELD_DEPRECATION_REMOVED  \`Change.description\` is no longer deprecated
-PASS    FIELD_REMOVED              \`AffectedClient.clientReferenceId\` was removed
-PASS    FIELD_REMOVED              \`Change.affectedClientIdVersionPairs\` was removed
-PASS    FIELD_REMOVED              \`Change.affectedClientReferenceIds\` was removed
-PASS    FIELD_REMOVED              \`SchemaDiff.numberOfCheckedOperations\` was removed
-
-View full details at: https://engine-dev.apollographql.com/service/engine/checks?schemaTag=Detached%3A%20d664f715645c5f0bb5ad4f2260cd6cb8d19bbc68&schemaTagId=f9f68e7e-1b5f-4eab-a3da-1fd8cd681111&from=2019-03-26T22%3A25%3A12.887Z?graphCompositionId=fff"
 `;
 
 exports[`service:check formatHumanReadable should have correct output with only breaking changes 1`] = `
+"╔════════╤════════════════════╤═════════════════════════════════════════════════════════════════════════════════════════╗
+║ Change │ Code               │ Description                                                                             ║
+╟────────┼────────────────────┼─────────────────────────────────────────────────────────────────────────────────────────╢
+║ FAIL   │ ARG_REMOVED        │ \`ServiceMutation.uploadSchema\` arg \`gitContext\` was removed                             ║
+╟────────┼────────────────────┼─────────────────────────────────────────────────────────────────────────────────────────╢
+║ FAIL   │ ARG_REMOVED        │ \`ServiceMutation.uploadSchema\` arg \`schema\` was removed                                 ║
+╟────────┼────────────────────┼─────────────────────────────────────────────────────────────────────────────────────────╢
+║ FAIL   │ ARG_REMOVED        │ \`ServiceMutation.uploadSchema\` arg \`tag\` was removed                                    ║
+╟────────┼────────────────────┼─────────────────────────────────────────────────────────────────────────────────────────╢
+║ FAIL   │ FIELD_CHANGED_TYPE │ \`Change.argNode\` changed type from \`NamedIntrospectionArg\` to \`NamedIntrospectionValue\` ║
+╟────────┼────────────────────┼─────────────────────────────────────────────────────────────────────────────────────────╢
+║ FAIL   │ FIELD_REMOVED      │ \`Change.affectedClients\` was removed                                                    ║
+╟────────┼────────────────────┼─────────────────────────────────────────────────────────────────────────────────────────╢
+║ FAIL   │ FIELD_REMOVED      │ \`NamedIntrospectionValue.printedType\` was removed                                       ║
+╟────────┼────────────────────┼─────────────────────────────────────────────────────────────────────────────────────────╢
+║ FAIL   │ TYPE_REMOVED       │ \`NamedIntrospectionArg\` removed                                                         ║
+╚════════╧════════════════════╧═════════════════════════════════════════════════════════════════════════════════════════╝
 "
-FAIL    ARG_REMOVED         \`ServiceMutation.uploadSchema\` arg \`gitContext\` was removed
-FAIL    ARG_REMOVED         \`ServiceMutation.uploadSchema\` arg \`schema\` was removed
-FAIL    ARG_REMOVED         \`ServiceMutation.uploadSchema\` arg \`tag\` was removed
-FAIL    FIELD_CHANGED_TYPE  \`Change.argNode\` changed type from \`NamedIntrospectionArg\` to \`NamedIntrospectionValue\`
-FAIL    FIELD_REMOVED       \`Change.affectedClients\` was removed
-FAIL    FIELD_REMOVED       \`NamedIntrospectionValue.printedType\` was removed
-FAIL    TYPE_REMOVED        \`NamedIntrospectionArg\` removed
-
-View full details at: https://engine-dev.apollographql.com/service/engine/checks?schemaTag=Detached%3A%20d664f715645c5f0bb5ad4f2260cd6cb8d19bbc68&schemaTagId=f9f68e7e-1b5f-4eab-a3da-1fd8cd681111&from=2019-03-26T22%3A25%3A12.887Z?graphCompositionId=fff"
 `;
 
 exports[`service:check formatHumanReadable should have correct output with only non-breaking changes 1`] = `
@@ -87,11 +113,17 @@ exports[`service:check integration federated should report composition errors co
 "Loading Apollo Project
 Found 3 graph composition errors for service accounts on graph engine
 
-Service   Field    Message
-────────  ───────  ────────────────────────────────────────────────────────────────────────────────────────
-reviews   User.id  marked @external but it does not have a matching field on on the base service (accounts)
-reviews   User     A @key selects id, but User.id could not be found
-accounts  User     A @key selects id, but User.id could not be found
+╔══════════╤═════════╤════════════════════════════════════════════════════╗
+║ Service  │ Field   │ Message                                            ║
+╟──────────┼─────────┼────────────────────────────────────────────────────╢
+║ reviews  │ User.id │ marked @external but it does not have a matching   ║
+║          │         │ field on on the base service (accounts)            ║
+╟──────────┼─────────┼────────────────────────────────────────────────────╢
+║ reviews  │ User    │ A @key selects id, but User.id could not be found  ║
+╟──────────┼─────────┼────────────────────────────────────────────────────╢
+║ accounts │ User    │ A @key selects id, but User.id could not be found  ║
+╚══════════╧═════════╧════════════════════════════════════════════════════╝
+
 "
 `;
 
@@ -105,11 +137,17 @@ Found 3 graph composition errors for service accounts on graph engine [title cha
 Found 3 graph composition errors for service accounts on graph engine [failed]
 → Federated service composition was unsuccessful. Please see the reasons below.
 
-Service   Field    Message
-────────  ───────  ────────────────────────────────────────────────────────────────────────────────────────
-reviews   User.id  marked @external but it does not have a matching field on on the base service (accounts)
-reviews   User     A @key selects id, but User.id could not be found
-accounts  User     A @key selects id, but User.id could not be found
+╔══════════╤═════════╤════════════════════════════════════════════════════╗
+║ Service  │ Field   │ Message                                            ║
+╟──────────┼─────────┼────────────────────────────────────────────────────╢
+║ reviews  │ User.id │ marked @external but it does not have a matching   ║
+║          │         │ field on on the base service (accounts)            ║
+╟──────────┼─────────┼────────────────────────────────────────────────────╢
+║ reviews  │ User    │ A @key selects id, but User.id could not be found  ║
+╟──────────┼─────────┼────────────────────────────────────────────────────╢
+║ accounts │ User    │ A @key selects id, but User.id could not be found  ║
+╚══════════╧═════════╧════════════════════════════════════════════════════╝
+
 "
 `;
 
@@ -151,10 +189,12 @@ Found 0 graph composition errors for service accounts on graph engine
 Validated composed schema against tag master on graph engine
 Compared 1 schema change against 0 operations over the last 548 days
 Found 0 breaking changes and 1 compatible change
+╔════════╤══════════════════╤═══════════════════════════════════════════════════════════════════════════════╗
+║ Change │ Code             │ Description                                                                   ║
+╟────────┼──────────────────┼───────────────────────────────────────────────────────────────────────────────╢
+║ PASS   │ ARG_CHANGED_TYPE │ \`Query.launches\` argument \`after\` has changed type from \`String\` to \`String!\` ║
+╚════════╧══════════════════╧═══════════════════════════════════════════════════════════════════════════════╝
 
-PASS    ARG_CHANGED_TYPE  \`Query.launches\` argument \`after\` has changed type from \`String\` to \`String!\`
-
-View full details at: https://engine-staging.apollographql.com/service/justin-fullstack-tutorial/check/3acd7765-61b2-4f1a-9227-8b288e42bfdc
 "
 `;
 
@@ -176,10 +216,12 @@ Compared 1 schema change against 0 operations over the last 548 days [completed]
 Reporting result [started]
 Found 0 breaking changes and 1 compatible change [title changed]
 Found 0 breaking changes and 1 compatible change [completed]
+╔════════╤══════════════════╤═══════════════════════════════════════════════════════════════════════════════╗
+║ Change │ Code             │ Description                                                                   ║
+╟────────┼──────────────────┼───────────────────────────────────────────────────────────────────────────────╢
+║ PASS   │ ARG_CHANGED_TYPE │ \`Query.launches\` argument \`after\` has changed type from \`String\` to \`String!\` ║
+╚════════╧══════════════════╧═══════════════════════════════════════════════════════════════════════════════╝
 
-PASS    ARG_CHANGED_TYPE  \`Query.launches\` argument \`after\` has changed type from \`String\` to \`String!\`
-
-View full details at: https://engine-staging.apollographql.com/service/justin-fullstack-tutorial/check/3acd7765-61b2-4f1a-9227-8b288e42bfdc
 "
 `;
 
@@ -230,10 +272,12 @@ Reporting result [started]
 Found 1 breaking change and 0 compatible changes [title changed]
 Found 1 breaking change and 0 compatible changes [failed]
 → breaking changes found
+╔════════╤══════════════════╤═══════════════════════════════════════════════════════════════════════════════╗
+║ Change │ Code             │ Description                                                                   ║
+╟────────┼──────────────────┼───────────────────────────────────────────────────────────────────────────────╢
+║ FAIL   │ ARG_CHANGED_TYPE │ \`Query.launches\` argument \`after\` has changed type from \`String\` to \`String!\` ║
+╚════════╧══════════════════╧═══════════════════════════════════════════════════════════════════════════════╝
 
-FAIL    ARG_CHANGED_TYPE  \`Query.launches\` argument \`after\` has changed type from \`String\` to \`String!\`
-
-View full details at: https://engine-staging.apollographql.com/service/justin-fullstack-tutorial/check/3acd7765-61b2-4f1a-9227-8b288e42bfdc
 "
 `;
 
@@ -283,10 +327,12 @@ Compared 1 schema change against 0 operations over the last 548 days [completed]
 Reporting result [started]
 Found 0 breaking changes and 1 compatible change [title changed]
 Found 0 breaking changes and 1 compatible change [completed]
+╔════════╤══════════════════╤═══════════════════════════════════════════════════════════════════════════════╗
+║ Change │ Code             │ Description                                                                   ║
+╟────────┼──────────────────┼───────────────────────────────────────────────────────────────────────────────╢
+║ PASS   │ ARG_CHANGED_TYPE │ \`Query.launches\` argument \`after\` has changed type from \`String\` to \`String!\` ║
+╚════════╧══════════════════╧═══════════════════════════════════════════════════════════════════════════════╝
 
-PASS    ARG_CHANGED_TYPE  \`Query.launches\` argument \`after\` has changed type from \`String\` to \`String!\`
-
-View full details at: https://engine-staging.apollographql.com/service/justin-fullstack-tutorial/check/3acd7765-61b2-4f1a-9227-8b288e42bfdc
 "
 `;
 

--- a/packages/apollo/src/commands/service/__tests__/__snapshots__/list.test.ts.snap
+++ b/packages/apollo/src/commands/service/__tests__/__snapshots__/list.test.ts.snap
@@ -15,13 +15,19 @@ exports[`service:list integration should list services correctly for a federated
 Loading Apollo Project [completed]
 Fetching list of services for graph engine [started]
 Fetching list of services for graph engine [completed]
+╔═══════════╤═══════════════════════════════╤═══════════════════════════╗
+║ Name      │ URL                           │ Last Updated              ║
+╟───────────┼───────────────────────────────┼───────────────────────────╢
+║ accounts  │ http://localhost:4001/graphql │ 13 May 2019 (a month ago) ║
+╟───────────┼───────────────────────────────┼───────────────────────────╢
+║ inventory │ http://localhost:4002/graphql │ 16 May 2019 (a month ago) ║
+╟───────────┼───────────────────────────────┼───────────────────────────╢
+║ products  │ http://localhost:4003/graphql │ 16 May 2019 (a month ago) ║
+╟───────────┼───────────────────────────────┼───────────────────────────╢
+║ reviews   │ http://localhost:4004/graphql │ 16 May 2019 (a month ago) ║
+╚═══════════╧═══════════════════════════════╧═══════════════════════════╝
 
-name       URL                            last updated
-─────────  ─────────────────────────────  ─────────────────────────
-accounts   http://localhost:4001/graphql  13 May 2019 (a month ago)
-inventory  http://localhost:4002/graphql  16 May 2019 (a month ago)
-products   http://localhost:4003/graphql  16 May 2019 (a month ago)
-reviews    http://localhost:4004/graphql  16 May 2019 (a month ago)
+
 
 View full details at: https://engine-staging.apollographql.com/graph/engine/service-list
 "

--- a/packages/apollo/src/commands/service/check.ts
+++ b/packages/apollo/src/commands/service/check.ts
@@ -658,7 +658,7 @@ export default class ServiceCheck extends ProjectCommand {
         table(
           [
             ["Service", "Field", "Message"],
-            ...compositionErrors.map(error => Object.values(error))
+            ...compositionErrors.map(Object.values)
           ],
           {
             columns: {

--- a/packages/apollo/src/commands/service/list.ts
+++ b/packages/apollo/src/commands/service/list.ts
@@ -2,7 +2,7 @@ import { flags } from "@oclif/command";
 import { ProjectCommand } from "../../Command";
 import { GraphQLSchema } from "graphql";
 import sortBy from "lodash.sortby";
-import { table } from "heroku-cli-util";
+import { table } from "table";
 import moment from "moment";
 import {
   ApolloConfig,
@@ -57,33 +57,28 @@ function formatHumanReadable({
       ListServices_service_implementingServices_FederatedImplementingServices_services
     >(implementingServices.services, [service => service.name.toUpperCase()]);
 
-    table(
-      sortedImplementingServices
-        .map(sortedImplementingService =>
-          formatImplementingService(
-            sortedImplementingService,
-            // Force the time to a specific value if we're running tests. Otherwise the snapshots will break
-            // when the relative time changes.
-            process.env.NODE_ENV === "test" ? new Date("2019-06-13") : undefined
+    console.log(
+      table([
+        ["Name", "URL", "Last Updated"],
+        ...sortedImplementingServices
+          .map(sortedImplementingService =>
+            formatImplementingService(
+              sortedImplementingService,
+              // Force the time to a specific value if we're running tests. Otherwise the snapshots will break
+              // when the relative time changes.
+              process.env.NODE_ENV === "test"
+                ? new Date("2019-06-13")
+                : undefined
+            )
           )
-        )
-        .sort((s1, s2) =>
-          s1.name.toUpperCase() > s2.name.toUpperCase() ? 1 : -1
-        )
-        .filter(Boolean),
-      {
-        columns: [
-          { key: "name", label: "name" },
-          { key: "url", label: "URL" },
-          { key: "updatedAt", label: "last updated" }
-        ],
-        // The default `printLine` will output to the console; we want to capture the output so we can test
-        // it.
-        printLine: line => {
-          result += `\n${line}`;
-        }
-      }
+          .sort((s1, s2) =>
+            s1.name.toUpperCase() > s2.name.toUpperCase() ? 1 : -1
+          )
+          .map(entry => Object.values(entry))
+          .filter(Boolean)
+      ])
     );
+
     const serviceListUrlEnding = `/graph/${graphName}/service-list`;
     const targetUrl = `${frontendUrl}${serviceListUrlEnding}`;
     result += `\n\nView full details at: ${targetUrl}`;

--- a/packages/apollo/src/commands/service/list.ts
+++ b/packages/apollo/src/commands/service/list.ts
@@ -74,7 +74,7 @@ function formatHumanReadable({
           .sort((s1, s2) =>
             s1.name.toUpperCase() > s2.name.toUpperCase() ? 1 : -1
           )
-          .map(entry => Object.values(entry))
+          .map(Object.values)
           .filter(Boolean)
       ])
     );

--- a/packages/apollo/src/commands/service/push.ts
+++ b/packages/apollo/src/commands/service/push.ts
@@ -1,5 +1,5 @@
 import { flags } from "@oclif/command";
-import { table } from "heroku-cli-util";
+import { table } from "table";
 import { introspectionFromSchema, printSchema } from "graphql";
 import { gitInfo } from "../../git";
 import { ProjectCommand } from "../../Command";
@@ -181,19 +181,11 @@ export default class ServicePush extends ProjectCommand {
         }))
       ].filter(x => x !== null);
 
-      table(messages, {
-        columns: [
-          { key: "type", label: "Change" },
-          { key: "description", label: "Description" }
-        ],
-        // Override `printHeader` so we don't print a header
-        printHeader: () => {},
-        // The default `printLine` will output to the console; we want to capture the output so we can test
-        // it.
-        printLine: line => {
-          printed += `\n${line}`;
-        }
-      });
+      this.log(
+        table([["Change", "Description"], ...messages.map(Object.values)], {
+          columns: { 1: { width: 70, wrapWord: true } }
+        })
+      );
 
       this.log(printed);
       this.log("\n");
@@ -212,17 +204,12 @@ export default class ServicePush extends ProjectCommand {
     }
 
     if (!isFederated || result.didUpdateGateway) {
-      table([result], {
-        columns: [
-          {
-            key: "hash",
-            label: "id",
-            format: (hash: string) => hash.slice(0, 6)
-          },
-          { key: "graphId", label: "graph" },
-          { key: "graphVariant", label: "tag" }
-        ]
-      });
+      this.log(
+        table([
+          ["id", "graph", "tag"],
+          [result.hash.slice(0, 6), result.graphId, result.graphVariant]
+        ])
+      );
       this.log("\n");
     }
   }


### PR DESCRIPTION
Federation results in particular can be quite long, causing some
word wrap pandemonium. This package supports word wrap and a
provides a cleaner look overall for tabular output.

This PR does _not_ replace all usages of `heroku-cli-util`s `table` function.
For output that is currently untested or that I couldn't test manually, I didn't
make the switch.

Successful `service:check`
![image](https://user-images.githubusercontent.com/29644393/64741481-9a9e3100-d4ad-11e9-948c-ab7b19a15c9a.png)

Failing `service:check`
![image](https://user-images.githubusercontent.com/29644393/64741497-ab4ea700-d4ad-11e9-8620-1bc7d374fc41.png)

`service:list`
![image](https://user-images.githubusercontent.com/29644393/64741512-b99cc300-d4ad-11e9-8cc0-277bce12fe40.png)

Successful `service:push`
![image](https://user-images.githubusercontent.com/29644393/64741574-ebae2500-d4ad-11e9-8bdd-55cdf7fe5e4e.png)

Failing `service:push`
![image](https://user-images.githubusercontent.com/29644393/64741545-d33e0a80-d4ad-11e9-9161-eb671e9bc280.png)

<!--
  Thanks for filing a pull request on Apollo Tooling!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [x] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass

\*Make sure changelog entries note which project(s) has been affected. See older entries for examples on what this looks like.
