### PR TITLE
Fix multiple localSchemaFile bug

### DIFF
--- a/packages/apollo-language-server/src/config/config.ts
+++ b/packages/apollo-language-server/src/config/config.ts
@@ -108,7 +108,7 @@ export const DefaultClientConfig = {
 export interface ServiceConfigFormat extends ConfigBase {
   name?: string;
   endpoint?: Exclude<RemoteServiceConfig, "name">;
-  localSchemaFile?: string;
+  localSchemaFile?: string | string[];
 }
 
 export const DefaultServiceConfig = {

--- a/packages/apollo-language-server/src/providers/schema/index.ts
+++ b/packages/apollo-language-server/src/providers/schema/index.ts
@@ -27,7 +27,12 @@ export function schemaProviderFromConfig(
 ): GraphQLSchemaProvider {
   if (isServiceConfig(config)) {
     if (config.service.localSchemaFile) {
-      return new FileSchemaProvider({ path: config.service.localSchemaFile });
+      const isListOfSchemaFiles = Array.isArray(config.service.localSchemaFile);
+      return new FileSchemaProvider(
+        isListOfSchemaFiles
+          ? { paths: config.service.localSchemaFile as string[] }
+          : { path: config.service.localSchemaFile as string }
+      );
     }
 
     if (config.service.endpoint) {

--- a/packages/apollo/src/Command.ts
+++ b/packages/apollo/src/Command.ts
@@ -169,18 +169,19 @@ export abstract class ProjectCommand extends Command {
     }
 
     if (flags.localSchemaFile) {
+      const files = flags.localSchemaFile.split(",");
       if (isClientConfig(config)) {
         config.setDefaults({
           client: {
             service: {
-              localSchemaFile: flags.localSchemaFile
+              localSchemaFile: files
             }
           }
         });
       } else if (isServiceConfig(config)) {
         config.setDefaults({
           service: {
-            localSchemaFile: flags.localSchemaFile
+            localSchemaFile: files
           }
         });
       }

--- a/packages/apollo/src/commands/client/codegen.ts
+++ b/packages/apollo/src/commands/client/codegen.ts
@@ -41,8 +41,7 @@ export default class Generate extends ClientCommand {
     }),
     localSchemaFile: flags.string({
       description:
-        "Path to your local GraphQL schema file (introspection result or SDL)",
-      multiple: true
+        "Path to your local GraphQL schema file (introspection result or SDL)"
     }),
     addTypename: flags.boolean({
       description:

--- a/packages/apollo/src/commands/service/check.ts
+++ b/packages/apollo/src/commands/service/check.ts
@@ -287,8 +287,7 @@ export default class ServiceCheck extends ProjectCommand {
     }),
     localSchemaFile: flags.string({
       description:
-        "Path to your local GraphQL schema file (introspection result or SDL)",
-      multiple: true
+        "Path to your local GraphQL schema file (introspection result or SDL)"
     }),
     markdown: flags.boolean({
       description: "Output result in markdown.",

--- a/packages/apollo/src/commands/service/push.ts
+++ b/packages/apollo/src/commands/service/push.ts
@@ -19,8 +19,7 @@ export default class ServicePush extends ProjectCommand {
     }),
     localSchemaFile: flags.string({
       description:
-        "Path to your local GraphQL schema file (introspection result or SDL)",
-      multiple: true
+        "Path to your local GraphQL schema file (introspection result or SDL)"
     }),
     federated: flags.boolean({
       char: "f",


### PR DESCRIPTION
Because of how oclif handles flags, it was possible to incorrectly parse a command with multiple `--localSchemaFile` flags like the following:

`apollo client:codegen --target=swift --localSchemaFile=schema.graphql API.swift`

This command would parse the last `<output>` argument as a schema and fail to parse. This is a bug that currently exists in oclif with how `multiple: true` flags are parsed.

https://github.com/oclif/oclif/issues/190#issuecomment-486473267

This PR changes flag parsing to only accept a single flag for `localSchemaFile`, allowing for a comma-separated-list of schema files like:

```
apollo client:codegen --target=swift --localSchemaFile=schema.graphql,schema2.graphql API.swift`

```

<!--
  Thanks for filing a pull request on Apollo Tooling!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [ ] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [ ] Make sure all of the significant new logic is covered by tests
- [ ] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests and linter rules pass

\*Make sure changelog entries note which project(s) has been affected. See older entries for examples on what this looks like.
