### PR TITLE
swift: Fix initializers with field named `self`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - `apollo-codegen-scala`
   - <First `apollo-codegen-scala` related entry goes here>
 - `apollo-codegen-swift`
+  - Ensure fields named `self` don't cause compilation errors in the generated code [#1533](https://github.com/apollographql/apollo-tooling/pull/1533)
   - Preserve leading/trailing underscores on field names [#1533](https://github.com/apollographql/apollo-tooling/pull/1533)
 - `apollo-codegen-typescript`
   - <First `apollo-codegen-typescript` related entry goes here>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - `apollo-codegen-scala`
   - <First `apollo-codegen-scala` related entry goes here>
 - `apollo-codegen-swift`
-  - <First `apollo-codegen-swift` related entry goes here>
+  - Preserve leading/trailing underscores on field names [#1533](https://github.com/apollographql/apollo-tooling/pull/1533)
 - `apollo-codegen-typescript`
   - <First `apollo-codegen-typescript` related entry goes here>
 - `apollo-env`

--- a/packages/apollo-codegen-swift/src/__tests__/__snapshots__/codeGeneration.ts.snap
+++ b/packages/apollo-codegen-swift/src/__tests__/__snapshots__/codeGeneration.ts.snap
@@ -1185,6 +1185,139 @@ exports[`Swift code generation #structDeclarationForFragment() should generate a
 }"
 `;
 
+exports[`Swift code generation #structDeclarationForSelectionSet() should escape init specially in a struct declaration initializer for a selection set 1`] = `
+"public struct Human: GraphQLSelectionSet {
+  public static let possibleTypes = [\\"Human\\"]
+
+  public static let selections: [GraphQLSelection] = [
+    GraphQLField(\\"friends\\", alias: \\"self\\", type: .list(.object(\`Self\`.selections))),
+  ]
+
+  public private(set) var resultMap: ResultMap
+
+  public init(unsafeResultMap: ResultMap) {
+    self.resultMap = unsafeResultMap
+  }
+
+  public init(\`self\` _self: [\`Self\`?]? = nil) {
+    self.init(unsafeResultMap: [\\"__typename\\": \\"Human\\", \\"self\\": _self.flatMap { (value: [\`Self\`?]) -> [ResultMap?] in value.map { (value: \`Self\`?) -> ResultMap? in value.flatMap { (value: \`Self\`) -> ResultMap in value.resultMap } } }])
+  }
+
+  /// This human's friends, or an empty list if they have none
+  public var \`self\`: [\`Self\`?]? {
+    get {
+      return (resultMap[\\"self\\"] as? [ResultMap?]).flatMap { (value: [ResultMap?]) -> [\`Self\`?] in value.map { (value: ResultMap?) -> \`Self\`? in value.flatMap { (value: ResultMap) -> \`Self\` in \`Self\`(unsafeResultMap: value) } } }
+    }
+    set {
+      resultMap.updateValue(newValue.flatMap { (value: [\`Self\`?]) -> [ResultMap?] in value.map { (value: \`Self\`?) -> ResultMap? in value.flatMap { (value: \`Self\`) -> ResultMap in value.resultMap } } }, forKey: \\"self\\")
+    }
+  }
+
+  public struct \`Self\`: GraphQLSelectionSet {
+    public static let possibleTypes = [\\"Human\\", \\"Droid\\"]
+
+    public static let selections: [GraphQLSelection] = [
+      GraphQLField(\\"id\\", type: .nonNull(.scalar(GraphQLID.self))),
+    ]
+
+    public private(set) var resultMap: ResultMap
+
+    public init(unsafeResultMap: ResultMap) {
+      self.resultMap = unsafeResultMap
+    }
+
+    public static func makeHuman(id: GraphQLID) -> \`Self\` {
+      return \`Self\`(unsafeResultMap: [\\"__typename\\": \\"Human\\", \\"id\\": id])
+    }
+
+    public static func makeDroid(id: GraphQLID) -> \`Self\` {
+      return \`Self\`(unsafeResultMap: [\\"__typename\\": \\"Droid\\", \\"id\\": id])
+    }
+
+    /// The ID of the character
+    public var id: GraphQLID {
+      get {
+        return resultMap[\\"id\\"]! as! GraphQLID
+      }
+      set {
+        resultMap.updateValue(newValue, forKey: \\"id\\")
+      }
+    }
+  }
+}
+
+public struct Human: GraphQLSelectionSet {
+  public static let possibleTypes = [\\"Human\\"]
+
+  public static let selections: [GraphQLSelection] = [
+    GraphQLField(\\"friends\\", alias: \\"self\\", type: .list(.object(\`Self\`.selections))),
+    GraphQLField(\\"name\\", alias: \\"_self\\", type: .nonNull(.scalar(String.self))),
+  ]
+
+  public private(set) var resultMap: ResultMap
+
+  public init(unsafeResultMap: ResultMap) {
+    self.resultMap = unsafeResultMap
+  }
+
+  public init(\`self\` _self_: [\`Self\`?]? = nil, _self: String) {
+    self.init(unsafeResultMap: [\\"__typename\\": \\"Human\\", \\"self\\": _self_.flatMap { (value: [\`Self\`?]) -> [ResultMap?] in value.map { (value: \`Self\`?) -> ResultMap? in value.flatMap { (value: \`Self\`) -> ResultMap in value.resultMap } } }, \\"_self\\": _self])
+  }
+
+  /// This human's friends, or an empty list if they have none
+  public var \`self\`: [\`Self\`?]? {
+    get {
+      return (resultMap[\\"self\\"] as? [ResultMap?]).flatMap { (value: [ResultMap?]) -> [\`Self\`?] in value.map { (value: ResultMap?) -> \`Self\`? in value.flatMap { (value: ResultMap) -> \`Self\` in \`Self\`(unsafeResultMap: value) } } }
+    }
+    set {
+      resultMap.updateValue(newValue.flatMap { (value: [\`Self\`?]) -> [ResultMap?] in value.map { (value: \`Self\`?) -> ResultMap? in value.flatMap { (value: \`Self\`) -> ResultMap in value.resultMap } } }, forKey: \\"self\\")
+    }
+  }
+
+  /// What this human calls themselves
+  public var _self: String {
+    get {
+      return resultMap[\\"_self\\"]! as! String
+    }
+    set {
+      resultMap.updateValue(newValue, forKey: \\"_self\\")
+    }
+  }
+
+  public struct \`Self\`: GraphQLSelectionSet {
+    public static let possibleTypes = [\\"Human\\", \\"Droid\\"]
+
+    public static let selections: [GraphQLSelection] = [
+      GraphQLField(\\"id\\", type: .nonNull(.scalar(GraphQLID.self))),
+    ]
+
+    public private(set) var resultMap: ResultMap
+
+    public init(unsafeResultMap: ResultMap) {
+      self.resultMap = unsafeResultMap
+    }
+
+    public static func makeHuman(id: GraphQLID) -> \`Self\` {
+      return \`Self\`(unsafeResultMap: [\\"__typename\\": \\"Human\\", \\"id\\": id])
+    }
+
+    public static func makeDroid(id: GraphQLID) -> \`Self\` {
+      return \`Self\`(unsafeResultMap: [\\"__typename\\": \\"Droid\\", \\"id\\": id])
+    }
+
+    /// The ID of the character
+    public var id: GraphQLID {
+      get {
+        return resultMap[\\"id\\"]! as! GraphQLID
+      }
+      set {
+        resultMap.updateValue(newValue, forKey: \\"id\\")
+      }
+    }
+  }
+}"
+`;
+
 exports[`Swift code generation #structDeclarationForSelectionSet() should escape reserved keywords in a struct declaration for a selection set 1`] = `
 "public struct Hero: GraphQLSelectionSet {
   public static let possibleTypes = [\\"Human\\", \\"Droid\\"]
@@ -1200,12 +1333,12 @@ exports[`Swift code generation #structDeclarationForSelectionSet() should escape
     self.resultMap = unsafeResultMap
   }
 
-  public static func makeHuman(\`private\`: String, \`self\`: [\`Self\`?]? = nil) -> Hero {
-    return Hero(unsafeResultMap: [\\"__typename\\": \\"Human\\", \\"private\\": \`private\`, \\"self\\": \`self\`.flatMap { (value: [\`Self\`?]) -> [ResultMap?] in value.map { (value: \`Self\`?) -> ResultMap? in value.flatMap { (value: \`Self\`) -> ResultMap in value.resultMap } } }])
+  public static func makeHuman(\`private\`: String, \`self\` _self: [\`Self\`?]? = nil) -> Hero {
+    return Hero(unsafeResultMap: [\\"__typename\\": \\"Human\\", \\"private\\": \`private\`, \\"self\\": _self.flatMap { (value: [\`Self\`?]) -> [ResultMap?] in value.map { (value: \`Self\`?) -> ResultMap? in value.flatMap { (value: \`Self\`) -> ResultMap in value.resultMap } } }])
   }
 
-  public static func makeDroid(\`private\`: String, \`self\`: [\`Self\`?]? = nil) -> Hero {
-    return Hero(unsafeResultMap: [\\"__typename\\": \\"Droid\\", \\"private\\": \`private\`, \\"self\\": \`self\`.flatMap { (value: [\`Self\`?]) -> [ResultMap?] in value.map { (value: \`Self\`?) -> ResultMap? in value.flatMap { (value: \`Self\`) -> ResultMap in value.resultMap } } }])
+  public static func makeDroid(\`private\`: String, \`self\` _self: [\`Self\`?]? = nil) -> Hero {
+    return Hero(unsafeResultMap: [\\"__typename\\": \\"Droid\\", \\"private\\": \`private\`, \\"self\\": _self.flatMap { (value: [\`Self\`?]) -> [ResultMap?] in value.map { (value: \`Self\`?) -> ResultMap? in value.flatMap { (value: \`Self\`) -> ResultMap in value.resultMap } } }])
   }
 
   /// The name of the character

--- a/packages/apollo-codegen-swift/src/__tests__/__snapshots__/codeGeneration.ts.snap
+++ b/packages/apollo-codegen-swift/src/__tests__/__snapshots__/codeGeneration.ts.snap
@@ -1786,6 +1786,51 @@ exports[`Swift code generation #structDeclarationForSelectionSet() should genera
 }"
 `;
 
+exports[`Swift code generation #structDeclarationForSelectionSet() should preserve leading and trailing underscores on fields 1`] = `
+"public struct Hero: GraphQLSelectionSet {
+  public static let possibleTypes = [\\"Human\\", \\"Droid\\"]
+
+  public static let selections: [GraphQLSelection] = [
+    GraphQLField(\\"name\\", alias: \\"_name\\", type: .nonNull(.scalar(String.self))),
+    GraphQLField(\\"id\\", alias: \\"_camel_case_id__\\", type: .nonNull(.scalar(GraphQLID.self))),
+  ]
+
+  public private(set) var resultMap: ResultMap
+
+  public init(unsafeResultMap: ResultMap) {
+    self.resultMap = unsafeResultMap
+  }
+
+  public static func makeHuman(_name: String, _camelCaseId__: GraphQLID) -> Hero {
+    return Hero(unsafeResultMap: [\\"__typename\\": \\"Human\\", \\"_name\\": _name, \\"_camel_case_id__\\": _camelCaseId__])
+  }
+
+  public static func makeDroid(_name: String, _camelCaseId__: GraphQLID) -> Hero {
+    return Hero(unsafeResultMap: [\\"__typename\\": \\"Droid\\", \\"_name\\": _name, \\"_camel_case_id__\\": _camelCaseId__])
+  }
+
+  /// The name of the character
+  public var _name: String {
+    get {
+      return resultMap[\\"_name\\"]! as! String
+    }
+    set {
+      resultMap.updateValue(newValue, forKey: \\"_name\\")
+    }
+  }
+
+  /// The ID of the character
+  public var _camelCaseId__: GraphQLID {
+    get {
+      return resultMap[\\"_camel_case_id__\\"]! as! GraphQLID
+    }
+    set {
+      resultMap.updateValue(newValue, forKey: \\"_camel_case_id__\\")
+    }
+  }
+}"
+`;
+
 exports[`Swift code generation #typeDeclarationForGraphQLType() should escape identifiers in cases of enum declaration for a GraphQLEnumType 1`] = `
 "public enum AlbumPrivacies: RawRepresentable, Equatable, Hashable, CaseIterable, Apollo.JSONDecodable, Apollo.JSONEncodable {
   public typealias RawValue = String

--- a/packages/apollo-codegen-swift/src/__tests__/codeGeneration.ts
+++ b/packages/apollo-codegen-swift/src/__tests__/codeGeneration.ts
@@ -455,6 +455,30 @@ describe("Swift code generation", () => {
       expect(generator.output).toMatchSnapshot();
     });
 
+    it(`should preserve leading and trailing underscores on fields`, () => {
+      const { operations } = compile(`
+        query Hero {
+          hero {
+            _name: name
+            _camel_case_id__: id
+          }
+        }
+      `);
+
+      const selectionSet = (operations["Hero"].selectionSet
+        .selections[0] as Field).selectionSet as SelectionSet;
+
+      generator.structDeclarationForSelectionSet(
+        {
+          structName: "Hero",
+          selectionSet
+        },
+        false
+      );
+
+      expect(generator.output).toMatchSnapshot();
+    });
+
     it(`should escape reserved keywords in a struct declaration for a selection set`, () => {
       const { operations } = compile(`
         query Hero {

--- a/packages/apollo-codegen-swift/src/__tests__/codeGeneration.ts
+++ b/packages/apollo-codegen-swift/src/__tests__/codeGeneration.ts
@@ -505,6 +505,46 @@ describe("Swift code generation", () => {
       expect(generator.output).toMatchSnapshot();
     });
 
+    it(`should escape init specially in a struct declaration initializer for a selection set`, () => {
+      const { operations } = compile(`
+        query Humans {
+          human(id: 0) {
+            self: friends {
+              id
+            }
+          }
+          human(id: 1) {
+            self: friends {
+              id
+            }
+            _self: name
+          }
+        }
+      `);
+
+      const human0 = (operations["Humans"].selectionSet.selections[0] as Field)
+        .selectionSet as SelectionSet;
+      const human1 = (operations["Humans"].selectionSet.selections[1] as Field)
+        .selectionSet as SelectionSet;
+
+      generator.structDeclarationForSelectionSet(
+        {
+          structName: "Human",
+          selectionSet: human0
+        },
+        false
+      );
+      generator.structDeclarationForSelectionSet(
+        {
+          structName: "Human",
+          selectionSet: human1
+        },
+        false
+      );
+
+      expect(generator.output).toMatchSnapshot();
+    });
+
     it(`should generate a nested struct declaration for a selection set with subselections`, () => {
       const { operations } = compile(`
         query Hero {

--- a/packages/apollo-codegen-swift/src/helpers.ts
+++ b/packages/apollo-codegen-swift/src/helpers.ts
@@ -15,7 +15,10 @@ import {
   isEnumType
 } from "graphql";
 
-import { camelCase, pascalCase } from "change-case";
+import {
+  camelCase as _camelCase,
+  pascalCase as _pascalCase
+} from "change-case";
 import * as Inflector from "inflected";
 import { join, wrap } from "apollo-codegen-core/lib/utilities/printing";
 
@@ -346,4 +349,34 @@ function makeClosureSignature(
   }
   closureSignature.append(swift` in`);
   return closureSignature;
+}
+
+/**
+ * Converts a value from "underscore_case" to "camelCase".
+ *
+ * This preserves any leading/trailing underscores.
+ */
+function camelCase(value: string): string {
+  const [_, prefix, middle, suffix] = value.match(/^(_*)(.*?)(_*)$/) || [
+    "",
+    "",
+    value,
+    ""
+  ];
+  return `${prefix}${_camelCase(middle)}${suffix}`;
+}
+
+/**
+ * Converts a value from "underscore_case" to "PascalCase".
+ *
+ * This preserves any leading/trailing underscores.
+ */
+function pascalCase(value: string): string {
+  const [_, prefix, middle, suffix] = value.match(/^(_*)(.*?)(_*)$/) || [
+    "",
+    "",
+    value,
+    ""
+  ];
+  return `${prefix}${_pascalCase(middle)}${suffix}`;
 }

--- a/packages/apollo-codegen-swift/src/helpers.ts
+++ b/packages/apollo-codegen-swift/src/helpers.ts
@@ -135,6 +135,24 @@ export class Helpers {
     );
   }
 
+  /**
+   * Returns the internal parameter name for a given property name.
+   *
+   * If the property name is valid to use, it's returned directly. Otherwise it's prefixed with an
+   * underscore and modified until it's unique among the given property set.
+   * @param propertyName The name of the property.
+   * @param properties A list of properties that should be consulted when producing a unique name.
+   * @returns The name to use for the internal parameter name for the property.
+   */
+  internalParameterName(
+    propertyName: string,
+    properties: { propertyName: string }[]
+  ): string {
+    return SwiftSource.isValidParameterName(propertyName)
+      ? propertyName
+      : makeUniqueName(`_${propertyName}`, properties);
+  }
+
   // Properties
 
   propertyFromField(
@@ -349,6 +367,25 @@ function makeClosureSignature(
   }
   closureSignature.append(swift` in`);
   return closureSignature;
+}
+
+/**
+ * Takes a proposed name and modifies it to be unique given a list of properties.
+ * @param proposedName The proposed name that shouldn't conflict with any property.
+ * @param properties A list of properties the name shouldn't conflict with.
+ * @returns A name based on `proposedName` that doesn't match any existing property name.
+ */
+function makeUniqueName(
+  proposedName: string,
+  properties: { propertyName: string }[]
+): string {
+  // Assume conflicts are very rare and property lists are short, and just do a linear search. If
+  // we find a conflict, start over with the modified name.
+  for (let name = proposedName; ; name += "_") {
+    if (properties.every(prop => prop.propertyName != name)) {
+      return name;
+    }
+  }
 }
 
 /**

--- a/packages/apollo-codegen-swift/src/language.ts
+++ b/packages/apollo-codegen-swift/src/language.ts
@@ -216,6 +216,21 @@ export class SwiftSource {
   }
 
   /**
+   * Returns whether the given name is valid as a method parameter name.
+   *
+   * Certain tokens aren't valid as method parameter names, even when escaped with backticks, as
+   * the compiler interprets the keyword and identifier as the same thing. In particular, `self`
+   * works this way.
+   * @param input The proposed parameter name.
+   * @returns `true` if the name can be used, or `false` if it needs a separate internal parameter
+   * name.
+   */
+  static isValidParameterName(input: string): boolean {
+    // Right now `self` is the only known token that we can't use with escaping.
+    return input !== "self";
+  }
+
+  /**
    * Template tag for producing a `SwiftSource` value without performing escaping.
    *
    * This is identical to evaluating the template without the tag and passing the result to `new


### PR DESCRIPTION
When a field is named `self`, escaping it with backticks (e.g. <code>\`self\`</code>) when used as a method parameter is not sufficient, as Swift interprets the escaped identifier the same as the keyword. Instead we need to synthesize a safe internal parameter name. This PR picks `_self` by default, but checks for conflicts and will go with `_self_`, `_self__`, etc. until it finds a unique name.

I've updated all of the logic I can find that emits initializers to do this, but my tests only cover some of this as I'm not sure when the other code is used.

This PR also fixes a bug where leading/trailing underscores were being stripped, so e.g. a field named `_foo` would show up as just `foo` in the generated code. This is a breaking change, which but it's unlikely to affect many people.

Fixes #1530.

TODO:

- [x] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [X] Make sure all of the significant new logic is covered by tests
- [X] Rebase your changes on master so that they can be merged easily
- [X] Make sure all tests and linter rules pass