### PR TITLE
[swift] Use multi-line string literals for queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@
 - `apollo-codegen-scala`
   - <First `apollo-codegen-scala` related entry goes here>
 - `apollo-codegen-swift`
-  - <First `apollo-codegen-swift` related entry goes here>
+  - Switch operations and fragments to default to printing queries as multiline strings rather than including queries as multiline comments
+  - Add `--suppressSwiftMultilineStringLiterals` flag to allow a version which strips unnecessary whitespace.
 - `apollo-codegen-typescript`
   - <First `apollo-codegen-typescript` related entry goes here>
 - `apollo-env`

--- a/packages/apollo-codegen-core/src/compiler/index.ts
+++ b/packages/apollo-codegen-core/src/compiler/index.ts
@@ -46,6 +46,7 @@ export interface CompilerOptions {
   // `ts` fileExtension for now.
   tsFileExtension?: string;
   useReadOnlyTypes?: boolean;
+  suppressSwiftMultilineStringLiterals?: boolean;
 }
 
 export interface CompilerContext {

--- a/packages/apollo-codegen-swift/src/__tests__/__snapshots__/codeGeneration.ts.snap
+++ b/packages/apollo-codegen-swift/src/__tests__/__snapshots__/codeGeneration.ts.snap
@@ -4,7 +4,18 @@ exports[`Swift code generation #classDeclarationForOperation() should correctly 
 "public final class CreateReviewMutation: GraphQLMutation {
   /// The raw GraphQL definition of this operation
   public let operationDefinition =
-    \\"mutation CreateReview($episode: Episode) {\\\\n  createReview(episode: $episode, review: {stars: 5, commentary: \\\\\\"\\\\\\"\\\\\\"\\\\n    Wow!\\\\n     I thought\\\\n      This movie ROCKED!\\\\n  \\\\\\"\\\\\\"\\\\\\"}) {\\\\n    stars\\\\n    commentary\\\\n  }\\\\n}\\"
+    #\\"\\"\\"
+    mutation CreateReview($episode: Episode) {
+      createReview(episode: $episode, review: {stars: 5, commentary: \\"\\"\\"
+        Wow!
+         I thought
+          This movie ROCKED!
+      \\"\\"\\"}) {
+        stars
+        commentary
+      }
+    }
+    \\"\\"\\"#
 
   public let operationName = \\"CreateReview\\"
 
@@ -90,7 +101,18 @@ exports[`Swift code generation #classDeclarationForOperation() should correctly 
 "public final class CreateReviewMutation: GraphQLMutation {
   /// The raw GraphQL definition of this operation
   public let operationDefinition =
-    \\"mutation CreateReview($episode: Episode) {\\\\n  createReview(episode: $episode, review: {stars: 5, commentary: \\\\\\"\\\\\\"\\\\\\"\\\\n    Wow!\\\\n     I thought\\\\n      This movie \\\\\\\\ ROCKED!\\\\n  \\\\\\"\\\\\\"\\\\\\"}) {\\\\n    stars\\\\n    commentary\\\\n  }\\\\n}\\"
+    #\\"\\"\\"
+    mutation CreateReview($episode: Episode) {
+      createReview(episode: $episode, review: {stars: 5, commentary: \\"\\"\\"
+        Wow!
+         I thought
+          This movie \\\\ ROCKED!
+      \\"\\"\\"}) {
+        stars
+        commentary
+      }
+    }
+    \\"\\"\\"#
 
   public let operationName = \\"CreateReview\\"
 

--- a/packages/apollo-codegen-swift/src/__tests__/__snapshots__/codeGeneration.ts.snap
+++ b/packages/apollo-codegen-swift/src/__tests__/__snapshots__/codeGeneration.ts.snap
@@ -2,16 +2,7 @@
 
 exports[`Swift code generation #classDeclarationForOperation() should correctly escape a mutli-line string literal 1`] = `
 "public final class CreateReviewMutation: GraphQLMutation {
-  /// mutation CreateReview($episode: Episode) {
-  ///   createReview(episode: $episode, review: {stars: 5, commentary: \\"\\"\\"
-  ///     Wow!
-  ///      I thought
-  ///       This movie ROCKED!
-  ///   \\"\\"\\"}) {
-  ///     stars
-  ///     commentary
-  ///   }
-  /// }
+  /// The raw GraphQL definition of this operation
   public let operationDefinition =
     \\"mutation CreateReview($episode: Episode) {\\\\n  createReview(episode: $episode, review: {stars: 5, commentary: \\\\\\"\\\\\\"\\\\\\"\\\\n    Wow!\\\\n     I thought\\\\n      This movie ROCKED!\\\\n  \\\\\\"\\\\\\"\\\\\\"}) {\\\\n    stars\\\\n    commentary\\\\n  }\\\\n}\\"
 
@@ -97,16 +88,7 @@ exports[`Swift code generation #classDeclarationForOperation() should correctly 
 
 exports[`Swift code generation #classDeclarationForOperation() should correctly escape a mutli-line string literal with backslashes 1`] = `
 "public final class CreateReviewMutation: GraphQLMutation {
-  /// mutation CreateReview($episode: Episode) {
-  ///   createReview(episode: $episode, review: {stars: 5, commentary: \\"\\"\\"
-  ///     Wow!
-  ///      I thought
-  ///       This movie \\\\ ROCKED!
-  ///   \\"\\"\\"}) {
-  ///     stars
-  ///     commentary
-  ///   }
-  /// }
+  /// The raw GraphQL definition of this operation
   public let operationDefinition =
     \\"mutation CreateReview($episode: Episode) {\\\\n  createReview(episode: $episode, review: {stars: 5, commentary: \\\\\\"\\\\\\"\\\\\\"\\\\n    Wow!\\\\n     I thought\\\\n      This movie \\\\\\\\ ROCKED!\\\\n  \\\\\\"\\\\\\"\\\\\\"}) {\\\\n    stars\\\\n    commentary\\\\n  }\\\\n}\\"
 
@@ -192,14 +174,16 @@ exports[`Swift code generation #classDeclarationForOperation() should correctly 
 
 exports[`Swift code generation #classDeclarationForOperation() should generate a class declaration for a mutation with variables 1`] = `
 "public final class CreateReviewMutation: GraphQLMutation {
-  /// mutation CreateReview($episode: Episode) {
-  ///   createReview(episode: $episode, review: {stars: 5, commentary: \\"Wow!\\"}) {
-  ///     stars
-  ///     commentary
-  ///   }
-  /// }
+  /// The raw GraphQL definition of this operation
   public let operationDefinition =
-    \\"mutation CreateReview($episode: Episode) { createReview(episode: $episode, review: {stars: 5, commentary: \\\\\\"Wow!\\\\\\"}) { stars commentary } }\\"
+    \\"\\"\\"
+    mutation CreateReview($episode: Episode) {
+      createReview(episode: $episode, review: {stars: 5, commentary: \\"Wow!\\"}) {
+        stars
+        commentary
+      }
+    }
+    \\"\\"\\"
 
   public let operationName = \\"CreateReview\\"
 
@@ -283,15 +267,17 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
 
 exports[`Swift code generation #classDeclarationForOperation() should generate a class declaration for a query with a fragment spread nested in an inline fragment 1`] = `
 "public final class HeroQuery: GraphQLQuery {
-  /// query Hero {
-  ///   hero {
-  ///     ... on Droid {
-  ///       ...HeroDetails
-  ///     }
-  ///   }
-  /// }
+  /// The raw GraphQL definition of this operation
   public let operationDefinition =
-    \\"query Hero { hero { ... on Droid { ...HeroDetails } } }\\"
+    \\"\\"\\"
+    query Hero {
+      hero {
+        ... on Droid {
+          ...HeroDetails
+        }
+      }
+    }
+    \\"\\"\\"
 
   public let operationName = \\"Hero\\"
 
@@ -422,13 +408,15 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
 
 exports[`Swift code generation #classDeclarationForOperation() should generate a class declaration for a query with conditional fragment spreads 1`] = `
 "public final class HeroQuery: GraphQLQuery {
-  /// query Hero {
-  ///   hero {
-  ///     ...DroidDetails
-  ///   }
-  /// }
+  /// The raw GraphQL definition of this operation
   public let operationDefinition =
-    \\"query Hero { hero { ...DroidDetails } }\\"
+    \\"\\"\\"
+    query Hero {
+      hero {
+        ...DroidDetails
+      }
+    }
+    \\"\\"\\"
 
   public let operationName = \\"Hero\\"
 
@@ -587,13 +575,15 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
 
 exports[`Swift code generation #classDeclarationForOperation() should generate a class declaration for a query with fragment spreads 1`] = `
 "public final class HeroQuery: GraphQLQuery {
-  /// query Hero {
-  ///   hero {
-  ///     ...HeroDetails
-  ///   }
-  /// }
+  /// The raw GraphQL definition of this operation
   public let operationDefinition =
-    \\"query Hero { hero { ...HeroDetails } }\\"
+    \\"\\"\\"
+    query Hero {
+      hero {
+        ...HeroDetails
+      }
+    }
+    \\"\\"\\"
 
   public let operationName = \\"Hero\\"
 
@@ -691,13 +681,15 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
 
 exports[`Swift code generation #classDeclarationForOperation() should generate a class declaration for a query with variables 1`] = `
 "public final class HeroNameQuery: GraphQLQuery {
-  /// query HeroName($episode: Episode) {
-  ///   hero(episode: $episode) {
-  ///     name
-  ///   }
-  /// }
+  /// The raw GraphQL definition of this operation
   public let operationDefinition =
-    \\"query HeroName($episode: Episode) { hero(episode: $episode) { name } }\\"
+    \\"\\"\\"
+    query HeroName($episode: Episode) {
+      hero(episode: $episode) {
+        name
+      }
+    }
+    \\"\\"\\"
 
   public let operationName = \\"HeroName\\"
 
@@ -774,13 +766,15 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
 
 exports[`Swift code generation #classDeclarationForOperation() should generate a class declaration with an operationIdentifier property when generateOperationIds is specified 1`] = `
 "public final class HeroQuery: GraphQLQuery {
-  /// query Hero {
-  ///   hero {
-  ///     ...HeroDetails
-  ///   }
-  /// }
+  /// The raw GraphQL definition of this operation
   public let operationDefinition =
-    \\"query Hero { hero { ...HeroDetails } }\\"
+    \\"\\"\\"
+    query Hero {
+      hero {
+        ...HeroDetails
+      }
+    }
+    \\"\\"\\"
 
   public let operationName = \\"Hero\\"
 
@@ -899,12 +893,14 @@ exports[`Swift code generation #initializerDeclarationForProperties() should gen
 
 exports[`Swift code generation #structDeclarationForFragment() should generate a struct declaration for a fragment that includes a fragment spread 1`] = `
 "public struct HeroDetails: GraphQLFragment {
-  /// fragment HeroDetails on Character {
-  ///   name
-  ///   ...MoreHeroDetails
-  /// }
+  /// The raw GraphQL definition of this fragment
   public static let fragmentDefinition =
-    \\"fragment HeroDetails on Character { name ...MoreHeroDetails }\\"
+    \\"\\"\\"
+    fragment HeroDetails on Character {
+      name
+      ...MoreHeroDetails
+    }
+    \\"\\"\\"
 
   public static let possibleTypes = [\\"Human\\", \\"Droid\\"]
 
@@ -977,12 +973,14 @@ exports[`Swift code generation #structDeclarationForFragment() should generate a
 
 exports[`Swift code generation #structDeclarationForFragment() should generate a struct declaration for a fragment with a concrete type condition 1`] = `
 "public struct DroidDetails: GraphQLFragment {
-  /// fragment DroidDetails on Droid {
-  ///   name
-  ///   primaryFunction
-  /// }
+  /// The raw GraphQL definition of this fragment
   public static let fragmentDefinition =
-    \\"fragment DroidDetails on Droid { name primaryFunction }\\"
+    \\"\\"\\"
+    fragment DroidDetails on Droid {
+      name
+      primaryFunction
+    }
+    \\"\\"\\"
 
   public static let possibleTypes = [\\"Droid\\"]
 
@@ -1025,14 +1023,16 @@ exports[`Swift code generation #structDeclarationForFragment() should generate a
 
 exports[`Swift code generation #structDeclarationForFragment() should generate a struct declaration for a fragment with a subselection 1`] = `
 "public struct HeroDetails: GraphQLFragment {
-  /// fragment HeroDetails on Character {
-  ///   name
-  ///   friends {
-  ///     name
-  ///   }
-  /// }
+  /// The raw GraphQL definition of this fragment
   public static let fragmentDefinition =
-    \\"fragment HeroDetails on Character { name friends { name } }\\"
+    \\"\\"\\"
+    fragment HeroDetails on Character {
+      name
+      friends {
+        name
+      }
+    }
+    \\"\\"\\"
 
   public static let possibleTypes = [\\"Human\\", \\"Droid\\"]
 
@@ -1111,12 +1111,14 @@ exports[`Swift code generation #structDeclarationForFragment() should generate a
 
 exports[`Swift code generation #structDeclarationForFragment() should generate a struct declaration for a fragment with an abstract type condition 1`] = `
 "public struct HeroDetails: GraphQLFragment {
-  /// fragment HeroDetails on Character {
-  ///   name
-  ///   appearsIn
-  /// }
+  /// The raw GraphQL definition of this fragment
   public static let fragmentDefinition =
-    \\"fragment HeroDetails on Character { name appearsIn }\\"
+    \\"\\"\\"
+    fragment HeroDetails on Character {
+      name
+      appearsIn
+    }
+    \\"\\"\\"
 
   public static let possibleTypes = [\\"Human\\", \\"Droid\\"]
 

--- a/packages/apollo-codegen-swift/src/__tests__/__snapshots__/codeGeneration.ts.snap
+++ b/packages/apollo-codegen-swift/src/__tests__/__snapshots__/codeGeneration.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`Swift code generation #classDeclarationForOperation() should correctly escape a mutli-line string literal 1`] = `
 "public final class CreateReviewMutation: GraphQLMutation {
-  /// The raw GraphQL definition of this operation
+  /// The raw GraphQL definition of this operation.
   public let operationDefinition =
     #\\"\\"\\"
     mutation CreateReview($episode: Episode) {
@@ -99,7 +99,7 @@ exports[`Swift code generation #classDeclarationForOperation() should correctly 
 
 exports[`Swift code generation #classDeclarationForOperation() should correctly escape a mutli-line string literal with backslashes 1`] = `
 "public final class CreateReviewMutation: GraphQLMutation {
-  /// The raw GraphQL definition of this operation
+  /// The raw GraphQL definition of this operation.
   public let operationDefinition =
     #\\"\\"\\"
     mutation CreateReview($episode: Episode) {
@@ -196,7 +196,7 @@ exports[`Swift code generation #classDeclarationForOperation() should correctly 
 
 exports[`Swift code generation #classDeclarationForOperation() should generate a class declaration for a mutation with variables 1`] = `
 "public final class CreateReviewMutation: GraphQLMutation {
-  /// The raw GraphQL definition of this operation
+  /// The raw GraphQL definition of this operation.
   public let operationDefinition =
     \\"\\"\\"
     mutation CreateReview($episode: Episode) {
@@ -289,7 +289,7 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
 
 exports[`Swift code generation #classDeclarationForOperation() should generate a class declaration for a query with a fragment spread nested in an inline fragment 1`] = `
 "public final class HeroQuery: GraphQLQuery {
-  /// The raw GraphQL definition of this operation
+  /// The raw GraphQL definition of this operation.
   public let operationDefinition =
     \\"\\"\\"
     query Hero {
@@ -430,7 +430,7 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
 
 exports[`Swift code generation #classDeclarationForOperation() should generate a class declaration for a query with conditional fragment spreads 1`] = `
 "public final class HeroQuery: GraphQLQuery {
-  /// The raw GraphQL definition of this operation
+  /// The raw GraphQL definition of this operation.
   public let operationDefinition =
     \\"\\"\\"
     query Hero {
@@ -597,7 +597,7 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
 
 exports[`Swift code generation #classDeclarationForOperation() should generate a class declaration for a query with fragment spreads 1`] = `
 "public final class HeroQuery: GraphQLQuery {
-  /// The raw GraphQL definition of this operation
+  /// The raw GraphQL definition of this operation.
   public let operationDefinition =
     \\"\\"\\"
     query Hero {
@@ -703,7 +703,7 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
 
 exports[`Swift code generation #classDeclarationForOperation() should generate a class declaration for a query with variables 1`] = `
 "public final class HeroNameQuery: GraphQLQuery {
-  /// The raw GraphQL definition of this operation
+  /// The raw GraphQL definition of this operation.
   public let operationDefinition =
     \\"\\"\\"
     query HeroName($episode: Episode) {
@@ -788,7 +788,7 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
 
 exports[`Swift code generation #classDeclarationForOperation() should generate a class declaration with an operationIdentifier property when generateOperationIds is specified 1`] = `
 "public final class HeroQuery: GraphQLQuery {
-  /// The raw GraphQL definition of this operation
+  /// The raw GraphQL definition of this operation.
   public let operationDefinition =
     \\"\\"\\"
     query Hero {
@@ -915,7 +915,7 @@ exports[`Swift code generation #initializerDeclarationForProperties() should gen
 
 exports[`Swift code generation #structDeclarationForFragment() should generate a struct declaration for a fragment that includes a fragment spread 1`] = `
 "public struct HeroDetails: GraphQLFragment {
-  /// The raw GraphQL definition of this fragment
+  /// The raw GraphQL definition of this fragment.
   public static let fragmentDefinition =
     \\"\\"\\"
     fragment HeroDetails on Character {
@@ -995,7 +995,7 @@ exports[`Swift code generation #structDeclarationForFragment() should generate a
 
 exports[`Swift code generation #structDeclarationForFragment() should generate a struct declaration for a fragment with a concrete type condition 1`] = `
 "public struct DroidDetails: GraphQLFragment {
-  /// The raw GraphQL definition of this fragment
+  /// The raw GraphQL definition of this fragment.
   public static let fragmentDefinition =
     \\"\\"\\"
     fragment DroidDetails on Droid {
@@ -1045,7 +1045,7 @@ exports[`Swift code generation #structDeclarationForFragment() should generate a
 
 exports[`Swift code generation #structDeclarationForFragment() should generate a struct declaration for a fragment with a subselection 1`] = `
 "public struct HeroDetails: GraphQLFragment {
-  /// The raw GraphQL definition of this fragment
+  /// The raw GraphQL definition of this fragment.
   public static let fragmentDefinition =
     \\"\\"\\"
     fragment HeroDetails on Character {
@@ -1133,7 +1133,7 @@ exports[`Swift code generation #structDeclarationForFragment() should generate a
 
 exports[`Swift code generation #structDeclarationForFragment() should generate a struct declaration for a fragment with an abstract type condition 1`] = `
 "public struct HeroDetails: GraphQLFragment {
-  /// The raw GraphQL definition of this fragment
+  /// The raw GraphQL definition of this fragment.
   public static let fragmentDefinition =
     \\"\\"\\"
     fragment HeroDetails on Character {

--- a/packages/apollo-codegen-swift/src/__tests__/codeGeneration.ts
+++ b/packages/apollo-codegen-swift/src/__tests__/codeGeneration.ts
@@ -49,7 +49,11 @@ describe("Swift code generation", () => {
         }
       `);
 
-      generator.classDeclarationForOperation(operations["HeroName"], false);
+      generator.classDeclarationForOperation(
+        operations["HeroName"],
+        false,
+        false
+      );
 
       expect(generator.output).toMatchSnapshot();
     });
@@ -67,7 +71,7 @@ describe("Swift code generation", () => {
         }
       `);
 
-      generator.classDeclarationForOperation(operations["Hero"], false);
+      generator.classDeclarationForOperation(operations["Hero"], false, false);
 
       expect(generator.output).toMatchSnapshot();
     });
@@ -85,7 +89,7 @@ describe("Swift code generation", () => {
         }
       `);
 
-      generator.classDeclarationForOperation(operations["Hero"], false);
+      generator.classDeclarationForOperation(operations["Hero"], false, false);
 
       expect(generator.output).toMatchSnapshot();
     });
@@ -127,7 +131,11 @@ describe("Swift code generation", () => {
         }
       `);
 
-      generator.classDeclarationForOperation(operations["CreateReview"], false);
+      generator.classDeclarationForOperation(
+        operations["CreateReview"],
+        false,
+        false
+      );
 
       expect(generator.output).toMatchSnapshot();
     });
@@ -147,7 +155,7 @@ describe("Swift code generation", () => {
         }
       `);
 
-      generator.classDeclarationForOperation(operations["Hero"], false);
+      generator.classDeclarationForOperation(operations["Hero"], false, false);
 
       expect(generator.output).toMatchSnapshot();
     });
@@ -182,7 +190,7 @@ describe("Swift code generation", () => {
         { generateOperationIds: true, mergeInFieldsFromFragmentSpreads: true }
       );
 
-      generator.classDeclarationForOperation(operations["Hero"], false);
+      generator.classDeclarationForOperation(operations["Hero"], false, false);
 
       expect(generator.output).toMatchSnapshot();
     });
@@ -373,7 +381,11 @@ describe("Swift code generation", () => {
         }
       `);
 
-      generator.structDeclarationForFragment(fragments["DroidDetails"], false);
+      generator.structDeclarationForFragment(
+        fragments["DroidDetails"],
+        false,
+        false
+      );
 
       expect(generator.output).toMatchSnapshot();
     });
@@ -388,7 +400,11 @@ describe("Swift code generation", () => {
         }
       `);
 
-      generator.structDeclarationForFragment(fragments["HeroDetails"], false);
+      generator.structDeclarationForFragment(
+        fragments["HeroDetails"],
+        false,
+        false
+      );
 
       expect(generator.output).toMatchSnapshot();
     });
@@ -405,7 +421,11 @@ describe("Swift code generation", () => {
         }
       `);
 
-      generator.structDeclarationForFragment(fragments["HeroDetails"], false);
+      generator.structDeclarationForFragment(
+        fragments["HeroDetails"],
+        false,
+        false
+      );
 
       expect(generator.output).toMatchSnapshot();
     });

--- a/packages/apollo-codegen-swift/src/__tests__/language.ts
+++ b/packages/apollo-codegen-swift/src/__tests__/language.ts
@@ -313,6 +313,33 @@ describe("Swift code generation: Escaping", () => {
       expect(SwiftSource.string("foo\n  bar  ", true).source).toBe('"foo bar"');
     });
 
+    it(`should generate multiline strings`, () => {
+      expect(SwiftSource.multilineString("foobar").source).toBe(
+        '"""\nfoobar\n"""'
+      );
+      expect(SwiftSource.multilineString("foo\n  bar  ").source).toBe(
+        '"""\nfoo\n  bar  \n"""'
+      );
+      expect(SwiftSource.multilineString(`"""foo"""`).source).toBe(
+        '#"""\n"""foo"""\n"""#'
+      );
+      expect(SwiftSource.multilineString("foo\\nbar").source).toBe(
+        '#"""\nfoo\\nbar\n"""#'
+      );
+      expect(SwiftSource.multilineString(`"""\\"""#"""`).source).toBe(
+        '##"""\n"""\\"""#"""\n"""##'
+      );
+      expect(SwiftSource.multilineString(`foo\\\\#bar`).source).toBe(
+        '##"""\nfoo\\\\#bar\n"""##'
+      );
+      expect(SwiftSource.multilineString(`foo\\\\#\\##bar`).source).toBe(
+        '###"""\nfoo\\\\#\\##bar\n"""###'
+      );
+      expect(SwiftSource.multilineString("foo\\###nbar").source).toBe(
+        '####"""\nfoo\\###nbar\n"""####'
+      );
+    });
+
     it(`should support concatenation`, () => {
       expect(swift`one`.concat().source).toBe("one");
       expect(swift`one`.concat(swift`two`).source).toBe("onetwo");

--- a/packages/apollo-codegen-swift/src/__tests__/language.ts
+++ b/packages/apollo-codegen-swift/src/__tests__/language.ts
@@ -338,14 +338,20 @@ describe("Swift code generation: Escaping", () => {
       generator = new SwiftGenerator({});
     });
 
-    it(`should trim with multilineString`, () => {
-      generator.multilineString("foo\n  bar  ");
+    it(`should not trim with multiline string if multiline strings are not suppressed and there is no triple quote`, () => {
+      generator.multilineString("foo\n  bar  ", false);
+
+      expect(generator.output).toBe('"""\nfoo\n  bar  \n"""');
+    });
+
+    it(`should trim with multilineString if multiline strings are suppressed`, () => {
+      generator.multilineString("foo\n  bar  ", true);
 
       expect(generator.output).toBe('"foo bar"');
     });
 
-    it(`shouldn't trim with multilineString when using """`, () => {
-      generator.multilineString('"""\nfoo\n  bar  \n"""');
+    it(`shouldn't trim with multilineString when using """ even when multiline strings are suppressed`, () => {
+      generator.multilineString('"""\nfoo\n  bar  \n"""', true);
       expect(generator.output).toBe('"\\"\\"\\"\\nfoo\\n  bar  \\n\\"\\"\\""');
     });
   });

--- a/packages/apollo-codegen-swift/src/codeGeneration.ts
+++ b/packages/apollo-codegen-swift/src/codeGeneration.ts
@@ -99,13 +99,21 @@ export function generateSource(
           () => {
             Object.values(context.operations).forEach(operation => {
               if (operation.filePath === inputFilePath) {
-                generator.classDeclarationForOperation(operation, true, false);
+                generator.classDeclarationForOperation(
+                  operation,
+                  true,
+                  suppressMultilineStringLiterals
+                );
               }
             });
 
             Object.values(context.fragments).forEach(fragment => {
               if (fragment.filePath === inputFilePath) {
-                generator.structDeclarationForFragment(fragment, true, false);
+                generator.structDeclarationForFragment(
+                  fragment,
+                  true,
+                  suppressMultilineStringLiterals
+                );
               }
             });
           }
@@ -121,11 +129,19 @@ export function generateSource(
       });
 
       Object.values(context.operations).forEach(operation => {
-        generator.classDeclarationForOperation(operation, false, false);
+        generator.classDeclarationForOperation(
+          operation,
+          false,
+          suppressMultilineStringLiterals
+        );
       });
 
       Object.values(context.fragments).forEach(fragment => {
-        generator.structDeclarationForFragment(fragment, false, false);
+        generator.structDeclarationForFragment(
+          fragment,
+          false,
+          suppressMultilineStringLiterals
+        );
       });
     });
   }

--- a/packages/apollo-codegen-swift/src/codeGeneration.ts
+++ b/packages/apollo-codegen-swift/src/codeGeneration.ts
@@ -62,6 +62,7 @@ export interface Options {
 export function generateSource(
   context: CompilerContext,
   outputIndividualFiles: boolean,
+  suppressMultilineStringLiterals: boolean,
   only?: string
 ): SwiftAPIGenerator {
   const generator = new SwiftAPIGenerator(context);
@@ -98,13 +99,13 @@ export function generateSource(
           () => {
             Object.values(context.operations).forEach(operation => {
               if (operation.filePath === inputFilePath) {
-                generator.classDeclarationForOperation(operation, true);
+                generator.classDeclarationForOperation(operation, true, false);
               }
             });
 
             Object.values(context.fragments).forEach(fragment => {
               if (fragment.filePath === inputFilePath) {
-                generator.structDeclarationForFragment(fragment, true);
+                generator.structDeclarationForFragment(fragment, true, false);
               }
             });
           }
@@ -120,11 +121,11 @@ export function generateSource(
       });
 
       Object.values(context.operations).forEach(operation => {
-        generator.classDeclarationForOperation(operation, false);
+        generator.classDeclarationForOperation(operation, false, false);
       });
 
       Object.values(context.fragments).forEach(fragment => {
-        generator.structDeclarationForFragment(fragment, false);
+        generator.structDeclarationForFragment(fragment, false, false);
       });
     });
   }
@@ -158,7 +159,8 @@ export class SwiftAPIGenerator extends SwiftGenerator<CompilerContext> {
    */
   classDeclarationForOperation(
     operation: Operation,
-    outputIndividualFiles: boolean
+    outputIndividualFiles: boolean,
+    suppressMultilineStringLiterals: boolean
   ) {
     const {
       operationName,
@@ -208,7 +210,7 @@ export class SwiftAPIGenerator extends SwiftGenerator<CompilerContext> {
           this.comment("The raw GraphQL definition of this operation");
           this.printOnNewline(swift`public let operationDefinition =`);
           this.withIndent(() => {
-            this.multilineString(source);
+            this.multilineString(source, suppressMultilineStringLiterals);
           });
         }
 
@@ -310,7 +312,8 @@ export class SwiftAPIGenerator extends SwiftGenerator<CompilerContext> {
    */
   structDeclarationForFragment(
     { fragmentName, selectionSet, source }: Fragment,
-    outputIndividualFiles: boolean
+    outputIndividualFiles: boolean,
+    suppressMultilineStringLiterals: boolean
   ) {
     const structName = this.helpers.structNameForFragmentName(fragmentName);
 
@@ -326,7 +329,7 @@ export class SwiftAPIGenerator extends SwiftGenerator<CompilerContext> {
           this.comment("The raw GraphQL definition of this fragment");
           this.printOnNewline(swift`public static let fragmentDefinition =`);
           this.withIndent(() => {
-            this.multilineString(source);
+            this.multilineString(source, suppressMultilineStringLiterals);
           });
         }
       }

--- a/packages/apollo-codegen-swift/src/codeGeneration.ts
+++ b/packages/apollo-codegen-swift/src/codeGeneration.ts
@@ -223,7 +223,7 @@ export class SwiftAPIGenerator extends SwiftGenerator<CompilerContext> {
       },
       () => {
         if (source) {
-          this.comment("The raw GraphQL definition of this operation");
+          this.comment("The raw GraphQL definition of this operation.");
           this.printOnNewline(swift`public let operationDefinition =`);
           this.withIndent(() => {
             this.multilineString(source, suppressMultilineStringLiterals);
@@ -342,7 +342,7 @@ export class SwiftAPIGenerator extends SwiftGenerator<CompilerContext> {
       outputIndividualFiles,
       () => {
         if (source) {
-          this.comment("The raw GraphQL definition of this fragment");
+          this.comment("The raw GraphQL definition of this fragment.");
           this.printOnNewline(swift`public static let fragmentDefinition =`);
           this.withIndent(() => {
             this.multilineString(source, suppressMultilineStringLiterals);

--- a/packages/apollo-codegen-swift/src/codeGeneration.ts
+++ b/packages/apollo-codegen-swift/src/codeGeneration.ts
@@ -205,7 +205,6 @@ export class SwiftAPIGenerator extends SwiftGenerator<CompilerContext> {
       },
       () => {
         if (source) {
-          this.commentWithoutTrimming(source);
           this.printOnNewline(swift`public let operationDefinition =`);
           this.withIndent(() => {
             this.multilineString(source);
@@ -323,7 +322,6 @@ export class SwiftAPIGenerator extends SwiftGenerator<CompilerContext> {
       outputIndividualFiles,
       () => {
         if (source) {
-          this.commentWithoutTrimming(source);
           this.printOnNewline(swift`public static let fragmentDefinition =`);
           this.withIndent(() => {
             this.multilineString(source);

--- a/packages/apollo-codegen-swift/src/codeGeneration.ts
+++ b/packages/apollo-codegen-swift/src/codeGeneration.ts
@@ -205,6 +205,7 @@ export class SwiftAPIGenerator extends SwiftGenerator<CompilerContext> {
       },
       () => {
         if (source) {
+          this.comment("The raw GraphQL definition of this operation");
           this.printOnNewline(swift`public let operationDefinition =`);
           this.withIndent(() => {
             this.multilineString(source);
@@ -322,6 +323,7 @@ export class SwiftAPIGenerator extends SwiftGenerator<CompilerContext> {
       outputIndividualFiles,
       () => {
         if (source) {
+          this.comment("The raw GraphQL definition of this fragment");
           this.printOnNewline(swift`public static let fragmentDefinition =`);
           this.withIndent(() => {
             this.multilineString(source);

--- a/packages/apollo-codegen-swift/src/language.ts
+++ b/packages/apollo-codegen-swift/src/language.ts
@@ -314,9 +314,18 @@ export class SwiftGenerator<Context> extends CodeGenerator<
   multilineString(string: string) {
     // Disable trimming if the string contains """ as this means we're probably printing an
     // operation definition where trimming is destructive.
-    this.printOnNewline(
-      SwiftSource.string(string, /* trim */ !string.includes('"""'))
-    );
+    if (string.includes('"""')) {
+      this.printOnNewline(SwiftSource.string(string, /* trim */ false));
+    } else {
+      this.printOnNewline(SwiftSource.raw`"""`);
+      string.split("\n").forEach(line => {
+        this.printOnNewline(SwiftSource.raw`${line}`);
+      });
+      this.printOnNewline(SwiftSource.raw`"""`);
+    }
+    // this.printOnNewline(
+    //   SwiftSource.string(string, /* trim */ !string.includes('"""'))
+    // );
   }
 
   comment(comment?: string) {

--- a/packages/apollo-codegen-swift/src/language.ts
+++ b/packages/apollo-codegen-swift/src/language.ts
@@ -335,13 +335,6 @@ export class SwiftGenerator<Context> extends CodeGenerator<
       });
   }
 
-  commentWithoutTrimming(comment?: string) {
-    comment &&
-      comment.split("\n").forEach(line => {
-        this.printOnNewline(SwiftSource.raw`/// ${line}`);
-      });
-  }
-
   deprecationAttributes(
     isDeprecated: boolean | undefined,
     deprecationReason: string | undefined

--- a/packages/apollo-codegen-swift/src/language.ts
+++ b/packages/apollo-codegen-swift/src/language.ts
@@ -311,21 +311,33 @@ export class SwiftGenerator<Context> extends CodeGenerator<
     super(context);
   }
 
-  multilineString(string: string) {
+  /**
+   * Outputs a multi-line string
+   *
+   * @param string - The Multi-lined string to output
+   * @param suppressMultilineStringLiterals - If true, will output the multiline string as a single trimmed
+   *                                          string to save bandwidth.
+   *                                          NOTE: This preference will be ignored if your GraphQL query
+   *                                          contains a triple-quote GraphQL string literal, since that's
+   *                                          the same as Swift's string literal and will break the query.
+   */
+  multilineString(string: string, suppressMultilineStringLiterals: Boolean) {
     // Disable trimming if the string contains """ as this means we're probably printing an
     // operation definition where trimming is destructive.
     if (string.includes('"""')) {
       this.printOnNewline(SwiftSource.string(string, /* trim */ false));
     } else {
-      this.printOnNewline(SwiftSource.raw`"""`);
-      string.split("\n").forEach(line => {
-        this.printOnNewline(SwiftSource.raw`${line}`);
-      });
-      this.printOnNewline(SwiftSource.raw`"""`);
+      if (suppressMultilineStringLiterals) {
+        this.printOnNewline(SwiftSource.string(string, /* trim */ true));
+      } else {
+        // Use a multiline string literal
+        this.printOnNewline(SwiftSource.raw`"""`);
+        string.split("\n").forEach(line => {
+          this.printOnNewline(SwiftSource.raw`${line}`);
+        });
+        this.printOnNewline(SwiftSource.raw`"""`);
+      }
     }
-    // this.printOnNewline(
-    //   SwiftSource.string(string, /* trim */ !string.includes('"""'))
-    // );
   }
 
   comment(comment?: string) {

--- a/packages/apollo-codegen-swift/src/language.ts
+++ b/packages/apollo-codegen-swift/src/language.ts
@@ -120,6 +120,44 @@ export class SwiftSource {
   }
 
   /**
+   * Returns the input wrapped in a Swift multiline string with escaping.
+   * @param string The input string, to be represented as a Swift multiline string.
+   * @returns A `SwiftSource` containing the Swift multiline string literal.
+   */
+  static multilineString(string: string): SwiftSource {
+    let rawCount = 0;
+    if (/"""|\\/.test(string)) {
+      // There's a """ (which would need escaping) or a backslash. Let's do a raw string literal instead.
+      // We can't just assume a single # is sufficient as it's possible to include the tokens `"""#` or
+      // `\#n` in a GraphQL multiline string so let's look for those.
+      let re = /"""(#+)|\\(#+)/g;
+      for (let ary = re.exec(string); ary !== null; ary = re.exec(string)) {
+        rawCount = Math.max(
+          rawCount,
+          (ary[1] || "").length,
+          (ary[2] || "").length
+        );
+      }
+      rawCount += 1; // add 1 to get whatever won't collide with the string
+    }
+    const rawToken = "#".repeat(rawCount);
+    return new SwiftSource(
+      `${rawToken}"""\n${string.replace(/[\0\r]/g, c => {
+        // Even in a raw string, we want to escape a couple of characters.
+        // It would be exceedingly weird to have these, but we can still handle them.
+        switch (c) {
+          case "\0":
+            return `\\${rawToken}0`;
+          case "\r":
+            return `\\${rawToken}r`;
+          default:
+            return c;
+        }
+      })}\n"""${rawToken}`
+    );
+  }
+
+  /**
    * Escapes the input if it contains a reserved keyword.
    *
    * For example, the input `Self?` requires escaping or it will match the keyword `Self`.

--- a/packages/apollo/README.md
+++ b/packages/apollo/README.md
@@ -164,6 +164,8 @@ OPTIONS
   --passthroughCustomScalars                 Use your own types for custom scalars
 
   --queries=queries                          Deprecated in favor of the includes flag
+  
+  --suppressSwiftMultilineStringLiterals     Prevents operations from being rendered as multiline strings [Swift only]
 
   --tagName=tagName                          Name of the template literal tag used to identify template literals
                                              containing GraphQL queries in Javascript/Typescript code

--- a/packages/apollo/src/commands/client/__tests__/__snapshots__/generate.test.ts.snap
+++ b/packages/apollo/src/commands/client/__tests__/__snapshots__/generate.test.ts.snap
@@ -176,11 +176,13 @@ exports[`client:codegen writes swift types from local schema 1`] = `
 import Apollo
 
 public final class SimpleQueryQuery: GraphQLQuery {
-  /// query SimpleQuery {
-  ///   hello
-  /// }
+  /// The raw GraphQL definition of this operation
   public let operationDefinition =
-    \\"query SimpleQuery { hello }\\"
+    \\"\\"\\"
+    query SimpleQuery {
+      hello
+    }
+    \\"\\"\\"
 
   public let operationName = \\"SimpleQuery\\"
 
@@ -223,11 +225,13 @@ exports[`client:codegen writes swift types from local schema in a graphql file 1
 import Apollo
 
 public final class SimpleQueryQuery: GraphQLQuery {
-  /// query SimpleQuery {
-  ///   hello
-  /// }
+  /// The raw GraphQL definition of this operation
   public let operationDefinition =
-    \\"query SimpleQuery { hello }\\"
+    \\"\\"\\"
+    query SimpleQuery {
+      hello
+    }
+    \\"\\"\\"
 
   public let operationName = \\"SimpleQuery\\"
 

--- a/packages/apollo/src/commands/client/__tests__/__snapshots__/generate.test.ts.snap
+++ b/packages/apollo/src/commands/client/__tests__/__snapshots__/generate.test.ts.snap
@@ -176,7 +176,7 @@ exports[`client:codegen writes swift types from local schema 1`] = `
 import Apollo
 
 public final class SimpleQueryQuery: GraphQLQuery {
-  /// The raw GraphQL definition of this operation
+  /// The raw GraphQL definition of this operation.
   public let operationDefinition =
     \\"\\"\\"
     query SimpleQuery {
@@ -225,7 +225,7 @@ exports[`client:codegen writes swift types from local schema in a graphql file 1
 import Apollo
 
 public final class SimpleQueryQuery: GraphQLQuery {
-  /// The raw GraphQL definition of this operation
+  /// The raw GraphQL definition of this operation.
   public let operationDefinition =
     \\"\\"\\"
     query SimpleQuery {

--- a/packages/apollo/src/commands/client/codegen.ts
+++ b/packages/apollo/src/commands/client/codegen.ts
@@ -72,6 +72,10 @@ export default class Generate extends ClientCommand {
       description:
         "Parse all input files, but only output generated code for the specified file [Swift only]"
     }),
+    suppressSwiftMultilineStringLiterals: flags.boolean({
+      description:
+        "Prevents operations from being rendered as multiline strings [Swift only]"
+    }),
 
     // flow
     useFlowExactObjects: flags.boolean({
@@ -205,7 +209,9 @@ export default class Generate extends ClientCommand {
                     useReadOnlyTypes:
                       flags.useReadOnlyTypes || flags.useFlowReadOnlyTypes,
                     globalTypesFile: flags.globalTypesFile,
-                    tsFileExtension: flags.tsFileExtension
+                    tsFileExtension: flags.tsFileExtension,
+                    suppressSwiftMultilineStringLiterals:
+                      flags.suppressSwiftMultilineStringLiterals
                   }
                 );
               };

--- a/packages/apollo/src/generate.ts
+++ b/packages/apollo/src/generate.ts
@@ -72,7 +72,19 @@ export default function generate(
     const outputIndividualFiles =
       fs.existsSync(outputPath) && fs.statSync(outputPath).isDirectory();
 
-    const generator = generateSwiftSource(context, outputIndividualFiles, only);
+    var suppressSwiftMultilineStringLiterals: boolean;
+    if (options.suppressSwiftMultilineStringLiterals == true) {
+      suppressSwiftMultilineStringLiterals = true;
+    } else {
+      suppressSwiftMultilineStringLiterals = false;
+    }
+
+    const generator = generateSwiftSource(
+      context,
+      outputIndividualFiles,
+      suppressSwiftMultilineStringLiterals,
+      only
+    );
 
     if (outputIndividualFiles) {
       writeGeneratedFiles(generator.generatedFiles, outputPath, "\n");

--- a/packages/apollo/src/generate.ts
+++ b/packages/apollo/src/generate.ts
@@ -72,12 +72,9 @@ export default function generate(
     const outputIndividualFiles =
       fs.existsSync(outputPath) && fs.statSync(outputPath).isDirectory();
 
-    var suppressSwiftMultilineStringLiterals: boolean;
-    if (options.suppressSwiftMultilineStringLiterals == true) {
-      suppressSwiftMultilineStringLiterals = true;
-    } else {
-      suppressSwiftMultilineStringLiterals = false;
-    }
+    const suppressSwiftMultilineStringLiterals = Boolean(
+      options.suppressSwiftMultilineStringLiterals
+    );
 
     const generator = generateSwiftSource(
       context,


### PR DESCRIPTION
In this PR there are a few changes to the Swift codegen: 

- Defaulted to printing queries as multi-line string literals to make sure the queries match the SHA256 hash being generated in `operationIdentifier`
- Added `--suppressSwiftMultilineStringLiterals` flag which defaults to false if you'd rather strip out all whitespace. 
- Removed comments showing the query since this is now covered by multi-line string literals

- [x] Update CHANGELOG.md with your change (include reference to issue & this PR)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass

