### PR TITLE
[swift] Improve multi-line string literal usage

### DIFF
--- a/packages/apollo-codegen-swift/src/__tests__/__snapshots__/codeGeneration.ts.snap
+++ b/packages/apollo-codegen-swift/src/__tests__/__snapshots__/codeGeneration.ts.snap
@@ -4,7 +4,18 @@ exports[`Swift code generation #classDeclarationForOperation() should correctly 
 "public final class CreateReviewMutation: GraphQLMutation {
   /// The raw GraphQL definition of this operation
   public let operationDefinition =
-    \\"mutation CreateReview($episode: Episode) {\\\\n  createReview(episode: $episode, review: {stars: 5, commentary: \\\\\\"\\\\\\"\\\\\\"\\\\n    Wow!\\\\n     I thought\\\\n      This movie ROCKED!\\\\n  \\\\\\"\\\\\\"\\\\\\"}) {\\\\n    stars\\\\n    commentary\\\\n  }\\\\n}\\"
+    #\\"\\"\\"
+    mutation CreateReview($episode: Episode) {
+      createReview(episode: $episode, review: {stars: 5, commentary: \\"\\"\\"
+        Wow!
+         I thought
+          This movie ROCKED!
+      \\"\\"\\"}) {
+        stars
+        commentary
+      }
+    }
+    \\"\\"\\"#
 
   public let operationName = \\"CreateReview\\"
 
@@ -90,7 +101,18 @@ exports[`Swift code generation #classDeclarationForOperation() should correctly 
 "public final class CreateReviewMutation: GraphQLMutation {
   /// The raw GraphQL definition of this operation
   public let operationDefinition =
-    \\"mutation CreateReview($episode: Episode) {\\\\n  createReview(episode: $episode, review: {stars: 5, commentary: \\\\\\"\\\\\\"\\\\\\"\\\\n    Wow!\\\\n     I thought\\\\n      This movie \\\\\\\\ ROCKED!\\\\n  \\\\\\"\\\\\\"\\\\\\"}) {\\\\n    stars\\\\n    commentary\\\\n  }\\\\n}\\"
+    #\\"\\"\\"
+    mutation CreateReview($episode: Episode) {
+      createReview(episode: $episode, review: {stars: 5, commentary: \\"\\"\\"
+        Wow!
+         I thought
+          This movie \\\\ ROCKED!
+      \\"\\"\\"}) {
+        stars
+        commentary
+      }
+    }
+    \\"\\"\\"#
 
   public let operationName = \\"CreateReview\\"
 

--- a/packages/apollo-codegen-swift/src/__tests__/language.ts
+++ b/packages/apollo-codegen-swift/src/__tests__/language.ts
@@ -313,6 +313,33 @@ describe("Swift code generation: Escaping", () => {
       expect(SwiftSource.string("foo\n  bar  ", true).source).toBe('"foo bar"');
     });
 
+    it(`should generate multiline strings`, () => {
+      expect(SwiftSource.multilineString("foobar").source).toBe(
+        '"""\nfoobar\n"""'
+      );
+      expect(SwiftSource.multilineString("foo\n  bar  ").source).toBe(
+        '"""\nfoo\n  bar  \n"""'
+      );
+      expect(SwiftSource.multilineString(`"""foo"""`).source).toBe(
+        '#"""\n"""foo"""\n"""#'
+      );
+      expect(SwiftSource.multilineString("foo\\nbar").source).toBe(
+        '#"""\nfoo\\nbar\n"""#'
+      );
+      expect(SwiftSource.multilineString(`"""\\"""#"""`).source).toBe(
+        '##"""\n"""\\"""#"""\n"""##'
+      );
+      expect(SwiftSource.multilineString(`foo\\\\#bar`).source).toBe(
+        '##"""\nfoo\\\\#bar\n"""##'
+      );
+      expect(SwiftSource.multilineString(`foo\\\\#\\##bar`).source).toBe(
+        '###"""\nfoo\\\\#\\##bar\n"""###'
+      );
+      expect(SwiftSource.multilineString("foo\\###nbar").source).toBe(
+        '####"""\nfoo\\###nbar\n"""####'
+      );
+    });
+
     it(`should support concatenation`, () => {
       expect(swift`one`.concat().source).toBe("one");
       expect(swift`one`.concat(swift`two`).source).toBe("onetwo");

--- a/packages/apollo-codegen-swift/src/language.ts
+++ b/packages/apollo-codegen-swift/src/language.ts
@@ -120,6 +120,44 @@ export class SwiftSource {
   }
 
   /**
+   * Returns the input wrapped in a Swift multiline string with escaping.
+   * @param string The input string, to be represented as a Swift multiline string.
+   * @returns A `SwiftSource` containing the Swift multiline string literal.
+   */
+  static multilineString(string: string): SwiftSource {
+    let rawCount = 0;
+    if (/"""|\\/.test(string)) {
+      // There's a """ (which would need escaping) or a backslash. Let's do a raw string literal instead.
+      // We can't just assume a single # is sufficient as it's possible to include the tokens `"""#` or
+      // `\#n` in a GraphQL multiline string so let's look for those.
+      let re = /"""(#+)|\\(#+)/g;
+      for (let ary = re.exec(string); ary !== null; ary = re.exec(string)) {
+        rawCount = Math.max(
+          rawCount,
+          (ary[1] || "").length,
+          (ary[2] || "").length
+        );
+      }
+      rawCount += 1; // add 1 to get whatever won't collide with the string
+    }
+    const rawToken = "#".repeat(rawCount);
+    return new SwiftSource(
+      `${rawToken}"""\n${string.replace(/[\0\r]/g, c => {
+        // Even in a raw string, we want to escape a couple of characters.
+        // It would be exceedingly weird to have these, but we can still handle them.
+        switch (c) {
+          case "\0":
+            return `\\${rawToken}0`;
+          case "\r":
+            return `\\${rawToken}r`;
+          default:
+            return c;
+        }
+      })}\n"""${rawToken}`
+    );
+  }
+
+  /**
    * Escapes the input if it contains a reserved keyword.
    *
    * For example, the input `Self?` requires escaping or it will match the keyword `Self`.


### PR DESCRIPTION
This PR updates #1537 to emit multiline string literals more correctly, and enables the use of multiline string literals even when the source text includes the `"""` token.