### PR TITLE
Modify service:check command to use combined mutation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - `apollo`
   - Use "table" package for tabular output and word wrap support [#1524](https://github.com/apollographql/apollo-tooling/pull/1524)
-  - Use new single-step mutation for checking federated service schemas [#1539](https://github.com/apollographql/apollo-tooling/pull/1539)
+  - Use new single step mutation for checking federated service schemas [#1539](https://github.com/apollographql/apollo-tooling/pull/1539)
 - `apollo-codegen-core`
   - <First `apollo-codegen-core` related entry goes here>
 - `apollo-codegen-flow`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - `apollo`
   - Use "table" package for tabular output and word wrap support [#1524](https://github.com/apollographql/apollo-tooling/pull/1524)
+  - Use new single-step mutation for checking federated service schemas [#1539](https://github.com/apollographql/apollo-tooling/pull/1539)
 - `apollo-codegen-core`
   - <First `apollo-codegen-core` related entry goes here>
 - `apollo-codegen-flow`
@@ -20,7 +21,7 @@
 - `apollo-graphql`
   - <First `apollo-graphql` related entry goes here>
 - `apollo-language-server`
-  - <First `apollo-language-server` related entry goes here>
+  - Replace old mutation used for checking partial service schemas to use `checkPartialSchema` [#1539](https://github.com/apollographql/apollo-tooling/pull/1539)
 - `apollo-tools`
   - <First `apollo-tools` related entry goes here>
 - `vscode-apollo`

--- a/packages/apollo-codegen-core/package.json
+++ b/packages/apollo-codegen-core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "apollo-codegen-core",
   "description": "Core generator APIs for Apollo Codegen",
-  "version": "0.35.4-alpha.0",
+  "version": "0.35.4-alpha.1",
   "author": "Apollo GraphQL <opensource@apollographql.com>",
   "license": "MIT",
   "repository": {

--- a/packages/apollo-codegen-core/package.json
+++ b/packages/apollo-codegen-core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "apollo-codegen-core",
   "description": "Core generator APIs for Apollo Codegen",
-  "version": "0.35.3",
+  "version": "0.35.4-alpha.0",
   "author": "Apollo GraphQL <opensource@apollographql.com>",
   "license": "MIT",
   "repository": {

--- a/packages/apollo-codegen-flow/package.json
+++ b/packages/apollo-codegen-flow/package.json
@@ -1,7 +1,7 @@
 {
   "name": "apollo-codegen-flow",
   "description": "Flow generator module for Apollo Codegen",
-  "version": "0.33.28",
+  "version": "0.33.29-alpha.0",
   "author": "Apollo GraphQL <opensource@apollographql.com>",
   "license": "MIT",
   "repository": {

--- a/packages/apollo-codegen-flow/package.json
+++ b/packages/apollo-codegen-flow/package.json
@@ -1,7 +1,7 @@
 {
   "name": "apollo-codegen-flow",
   "description": "Flow generator module for Apollo Codegen",
-  "version": "0.33.29-alpha.0",
+  "version": "0.33.29-alpha.1",
   "author": "Apollo GraphQL <opensource@apollographql.com>",
   "license": "MIT",
   "repository": {

--- a/packages/apollo-codegen-scala/package.json
+++ b/packages/apollo-codegen-scala/package.json
@@ -1,7 +1,7 @@
 {
   "name": "apollo-codegen-scala",
   "description": "Scala generator module for Apollo Codegen",
-  "version": "0.34.29-alpha.0",
+  "version": "0.34.29-alpha.1",
   "author": "Apollo GraphQL <opensource@apollographql.com>",
   "license": "MIT",
   "repository": {

--- a/packages/apollo-codegen-scala/package.json
+++ b/packages/apollo-codegen-scala/package.json
@@ -1,7 +1,7 @@
 {
   "name": "apollo-codegen-scala",
   "description": "Scala generator module for Apollo Codegen",
-  "version": "0.34.28",
+  "version": "0.34.29-alpha.0",
   "author": "Apollo GraphQL <opensource@apollographql.com>",
   "license": "MIT",
   "repository": {

--- a/packages/apollo-codegen-swift/package.json
+++ b/packages/apollo-codegen-swift/package.json
@@ -1,7 +1,7 @@
 {
   "name": "apollo-codegen-swift",
   "description": "Swift generator module for Apollo Codegen",
-  "version": "0.35.9-alpha.0",
+  "version": "0.35.9-alpha.1",
   "author": "Apollo GraphQL <opensource@apollographql.com>",
   "license": "MIT",
   "repository": {

--- a/packages/apollo-codegen-swift/package.json
+++ b/packages/apollo-codegen-swift/package.json
@@ -1,7 +1,7 @@
 {
   "name": "apollo-codegen-swift",
   "description": "Swift generator module for Apollo Codegen",
-  "version": "0.35.8",
+  "version": "0.35.9-alpha.0",
   "author": "Apollo GraphQL <opensource@apollographql.com>",
   "license": "MIT",
   "repository": {

--- a/packages/apollo-codegen-typescript/package.json
+++ b/packages/apollo-codegen-typescript/package.json
@@ -1,7 +1,7 @@
 {
   "name": "apollo-codegen-typescript",
   "description": "TypeScript generator module for Apollo Codegen",
-  "version": "0.35.3",
+  "version": "0.35.4-alpha.0",
   "author": "Apollo GraphQL <opensource@apollographql.com>",
   "license": "MIT",
   "repository": {

--- a/packages/apollo-codegen-typescript/package.json
+++ b/packages/apollo-codegen-typescript/package.json
@@ -1,7 +1,7 @@
 {
   "name": "apollo-codegen-typescript",
   "description": "TypeScript generator module for Apollo Codegen",
-  "version": "0.35.4-alpha.0",
+  "version": "0.35.4-alpha.1",
   "author": "Apollo GraphQL <opensource@apollographql.com>",
   "license": "MIT",
   "repository": {

--- a/packages/apollo-language-server/package.json
+++ b/packages/apollo-language-server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "apollo-language-server",
   "description": "A language server for Apollo GraphQL projects",
-  "version": "1.15.4-alpha.0",
+  "version": "1.15.4-alpha.1",
   "author": "Apollo GraphQL <opensource@apollographql.com>",
   "license": "MIT",
   "repository": {

--- a/packages/apollo-language-server/package.json
+++ b/packages/apollo-language-server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "apollo-language-server",
   "description": "A language server for Apollo GraphQL projects",
-  "version": "1.15.3",
+  "version": "1.15.4-alpha.0",
   "author": "Apollo GraphQL <opensource@apollographql.com>",
   "license": "MIT",
   "repository": {

--- a/packages/apollo-language-server/src/engine/index.ts
+++ b/packages/apollo-language-server/src/engine/index.ts
@@ -26,7 +26,8 @@ import {
   CheckPartialSchema,
   CheckPartialSchemaVariables,
   RemoveServiceAndCompose,
-  RemoveServiceAndComposeVariables
+  RemoveServiceAndComposeVariables,
+  CheckPartialSchema_service_checkPartialSchema
 } from "../graphqlTypes";
 
 export interface ClientIdentity {
@@ -174,7 +175,9 @@ export class ApolloEngineClient extends GraphQLDataSource {
     });
   }
 
-  public async checkPartialSchema(variables: CheckPartialSchemaVariables) {
+  public async checkPartialSchema(
+    variables: CheckPartialSchemaVariables
+  ): Promise<CheckPartialSchema_service_checkPartialSchema> {
     return this.execute<CheckPartialSchema>({
       query: CHECK_PARTIAL_SCHEMA,
       variables
@@ -193,8 +196,7 @@ export class ApolloEngineClient extends GraphQLDataSource {
       if (!(data && data.service)) {
         throw new Error("Error in request from Engine");
       }
-      return data.service
-        .validatePartialSchemaOfImplementingServiceAgainstGraph;
+      return data.service.checkPartialSchema;
     });
   }
 

--- a/packages/apollo-language-server/src/engine/operations/checkPartialSchema.ts
+++ b/packages/apollo-language-server/src/engine/operations/checkPartialSchema.ts
@@ -6,19 +6,49 @@ export const CHECK_PARTIAL_SCHEMA = gql`
     $graphVariant: String!
     $implementingServiceName: String!
     $partialSchema: PartialSchemaInput!
+    $gitContext: GitContextInput
+    $historicParameters: HistoricQueryParameters
   ) {
     service(id: $id) {
-      validatePartialSchemaOfImplementingServiceAgainstGraph(
+      checkPartialSchema(
         graphVariant: $graphVariant
         implementingServiceName: $implementingServiceName
         partialSchema: $partialSchema
+        gitContext: $gitContext
+        historicParameters: $historicParameters
       ) {
-        compositionValidationDetails {
-          schemaHash
+        compositionValidationResult {
+          compositionValidationDetails {
+            schemaHash
+          }
+          graphCompositionID
+          errors {
+            message
+          }
         }
-        graphCompositionID
-        errors {
-          message
+        checkSchemaResult {
+          diffToPrevious {
+            severity
+            affectedClients {
+              __typename
+            }
+            affectedQueries {
+              __typename
+            }
+            numberOfCheckedOperations
+            changes {
+              severity
+              code
+              description
+            }
+            validationConfig {
+              from
+              to
+              queryCountThreshold
+              queryCountThresholdPercentage
+            }
+          }
+          targetUrl
         }
       }
     }

--- a/packages/apollo-language-server/src/graphqlTypes.ts
+++ b/packages/apollo-language-server/src/graphqlTypes.ts
@@ -6,7 +6,7 @@
 // GraphQL mutation operation: CheckPartialSchema
 // ====================================================
 
-export interface CheckPartialSchema_service_validatePartialSchemaOfImplementingServiceAgainstGraph_compositionValidationDetails {
+export interface CheckPartialSchema_service_checkPartialSchema_compositionValidationResult_compositionValidationDetails {
   __typename: "CompositionValidationDetails";
   /**
    * Hash of the composed schema
@@ -14,19 +14,19 @@ export interface CheckPartialSchema_service_validatePartialSchemaOfImplementingS
   schemaHash: string | null;
 }
 
-export interface CheckPartialSchema_service_validatePartialSchemaOfImplementingServiceAgainstGraph_errors {
+export interface CheckPartialSchema_service_checkPartialSchema_compositionValidationResult_errors {
   __typename: "SchemaCompositionError";
   message: string;
 }
 
-export interface CheckPartialSchema_service_validatePartialSchemaOfImplementingServiceAgainstGraph {
+export interface CheckPartialSchema_service_checkPartialSchema_compositionValidationResult {
   __typename: "CompositionValidationResult";
   /**
    * Akin to a composition config, represents the partial schemas and implementing services that were used
    * in running composition. Will be null if any errors are encountered. Also may contain a schema hash if
    * one could be computed, which can be used for schema validation.
    */
-  compositionValidationDetails: CheckPartialSchema_service_validatePartialSchemaOfImplementingServiceAgainstGraph_compositionValidationDetails | null;
+  compositionValidationDetails: CheckPartialSchema_service_checkPartialSchema_compositionValidationResult_compositionValidationDetails | null;
   /**
    * ID that points to the results of this composition.
    */
@@ -36,19 +36,122 @@ export interface CheckPartialSchema_service_validatePartialSchemaOfImplementingS
    * graph's implementing services into a GraphQL schema. This partial schema should not be
    * published to the implementing service if there were any errors encountered
    */
-  errors: (CheckPartialSchema_service_validatePartialSchemaOfImplementingServiceAgainstGraph_errors | null)[];
+  errors: (CheckPartialSchema_service_checkPartialSchema_compositionValidationResult_errors | null)[];
+}
+
+export interface CheckPartialSchema_service_checkPartialSchema_checkSchemaResult_diffToPrevious_affectedClients {
+  __typename: "AffectedClient";
+}
+
+export interface CheckPartialSchema_service_checkPartialSchema_checkSchemaResult_diffToPrevious_affectedQueries {
+  __typename: "AffectedQuery";
+}
+
+export interface CheckPartialSchema_service_checkPartialSchema_checkSchemaResult_diffToPrevious_changes {
+  __typename: "Change";
+  /**
+   * Indication of the success of the overall change, either failure, warning, or notice.
+   */
+  severity: ChangeSeverity;
+  /**
+   * Indication of the kind of target and action of the change, e.g. 'TYPE_REMOVED'.
+   */
+  code: string;
+  /**
+   * Explanation of both the target of the change and how it was changed.
+   */
+  description: string;
+}
+
+export interface CheckPartialSchema_service_checkPartialSchema_checkSchemaResult_diffToPrevious_validationConfig {
+  __typename: "SchemaDiffValidationConfig";
+  /**
+   * delta in seconds from current time that determines the start of the window
+   * for reported metrics included in a schema diff. A day window from the present
+   * day would have a \`from\` value of -86400. In rare cases, this could be an ISO
+   * timestamp if the user passed one in on diff creation
+   */
+  from: any | null;
+  /**
+   * delta in seconds from current time that determines the end of the
+   * window for reported metrics included in a schema diff. A day window
+   * from the present day would have a \`to\` value of -0. In rare
+   * cases, this could be an ISO timestamp if the user passed one in on diff
+   * creation
+   */
+  to: any | null;
+  /**
+   * Minimum number of requests within the window for a query to be considered.
+   */
+  queryCountThreshold: number | null;
+  /**
+   * Number of requests within the window for a query to be considered, relative to
+   * total request count. Expected values are between 0 and 0.05 (minimum 5% of
+   * total request volume)
+   */
+  queryCountThresholdPercentage: number | null;
+}
+
+export interface CheckPartialSchema_service_checkPartialSchema_checkSchemaResult_diffToPrevious {
+  __typename: "SchemaDiff";
+  /**
+   * Indication of the success of the change, either failure, warning, or notice.
+   */
+  severity: ChangeSeverity;
+  /**
+   * Clients affected by all changes in diff
+   */
+  affectedClients: CheckPartialSchema_service_checkPartialSchema_checkSchemaResult_diffToPrevious_affectedClients[] | null;
+  /**
+   * Operations affected by all changes in diff
+   */
+  affectedQueries: CheckPartialSchema_service_checkPartialSchema_checkSchemaResult_diffToPrevious_affectedQueries[] | null;
+  /**
+   * Number of operations that were validated during schema diff
+   */
+  numberOfCheckedOperations: number | null;
+  /**
+   * List of schema changes with associated affected clients and operations
+   */
+  changes: CheckPartialSchema_service_checkPartialSchema_checkSchemaResult_diffToPrevious_changes[];
+  /**
+   * Configuration of validation
+   */
+  validationConfig: CheckPartialSchema_service_checkPartialSchema_checkSchemaResult_diffToPrevious_validationConfig | null;
+}
+
+export interface CheckPartialSchema_service_checkPartialSchema_checkSchemaResult {
+  __typename: "CheckSchemaResult";
+  /**
+   * Schema diff and affected operations generated by the schema check
+   */
+  diffToPrevious: CheckPartialSchema_service_checkPartialSchema_checkSchemaResult_diffToPrevious;
+  /**
+   * Generated url to view schema diff in Engine
+   */
+  targetUrl: string | null;
+}
+
+export interface CheckPartialSchema_service_checkPartialSchema {
+  __typename: "CheckPartialSchemaResult";
+  /**
+   * Result of composition validation run before the schema check.
+   */
+  compositionValidationResult: CheckPartialSchema_service_checkPartialSchema_compositionValidationResult;
+  /**
+   * Result of traffic validation. This will be null if composition validation was unsuccessful.
+   */
+  checkSchemaResult: CheckPartialSchema_service_checkPartialSchema_checkSchemaResult | null;
 }
 
 export interface CheckPartialSchema_service {
   __typename: "ServiceMutation";
   /**
-   * This mutation will not result in any changes to the implementing service
-   * Run composition with the Implementing Service's partial schema replaced with the one provided
-   * in the mutation's input. Store the composed schema, return the hash of the composed schema,
-   * and any warnings and errors pertaining to composition.
-   * This mutation will not run validation against operations.
+   * Compose an implementing service's partial schema, diff the composed schema, validate traffic against that schema,
+   * and store the result so the details can be viewed by users in the UI.
+   * This mutation will not mark the schema as "published".
    */
-  validatePartialSchemaOfImplementingServiceAgainstGraph: CheckPartialSchema_service_validatePartialSchemaOfImplementingServiceAgainstGraph;
+  checkPartialSchema: CheckPartialSchema_service_checkPartialSchema;
 }
 
 export interface CheckPartialSchema {
@@ -60,6 +163,8 @@ export interface CheckPartialSchemaVariables {
   graphVariant: string;
   implementingServiceName: string;
   partialSchema: PartialSchemaInput;
+  gitContext?: GitContextInput | null;
+  historicParameters?: HistoricQueryParameters | null;
 }
 
 /* tslint:disable */

--- a/packages/apollo/README.md
+++ b/packages/apollo/README.md
@@ -21,7 +21,7 @@ $ npm install -g apollo
 $ apollo COMMAND
 running command...
 $ apollo (-v|--version|version)
-apollo/2.18.3 darwin-x64 node-v8.11.1
+apollo/2.18.4-alpha.0 darwin-x64 node-v8.11.1
 $ apollo --help [COMMAND]
 USAGE
   $ apollo COMMAND
@@ -164,7 +164,7 @@ OPTIONS
   --passthroughCustomScalars                 Use your own types for custom scalars
 
   --queries=queries                          Deprecated in favor of the includes flag
-  
+
   --suppressSwiftMultilineStringLiterals     Prevents operations from being rendered as multiline strings [Swift only]
 
   --tagName=tagName                          Name of the template literal tag used to identify template literals

--- a/packages/apollo/README.md
+++ b/packages/apollo/README.md
@@ -21,7 +21,7 @@ $ npm install -g apollo
 $ apollo COMMAND
 running command...
 $ apollo (-v|--version|version)
-apollo/2.18.4-alpha.0 darwin-x64 node-v8.11.1
+apollo/2.18.4-alpha.1 darwin-x64 node-v8.11.1
 $ apollo --help [COMMAND]
 USAGE
   $ apollo COMMAND

--- a/packages/apollo/package.json
+++ b/packages/apollo/package.json
@@ -1,7 +1,7 @@
 {
   "name": "apollo",
   "description": "Command line tool for Apollo GraphQL",
-  "version": "2.18.3",
+  "version": "2.18.4-alpha.0",
   "referenceID": "21ad0845-c235-422e-be7d-a998310df972",
   "author": "Apollo GraphQL <opensource@apollographql.com>",
   "license": "MIT",

--- a/packages/apollo/package.json
+++ b/packages/apollo/package.json
@@ -1,7 +1,7 @@
 {
   "name": "apollo",
   "description": "Command line tool for Apollo GraphQL",
-  "version": "2.18.4-alpha.0",
+  "version": "2.18.4-alpha.1",
   "referenceID": "21ad0845-c235-422e-be7d-a998310df972",
   "author": "Apollo GraphQL <opensource@apollographql.com>",
   "license": "MIT",

--- a/packages/apollo/src/commands/service/__tests__/__snapshots__/check.test.ts.snap
+++ b/packages/apollo/src/commands/service/__tests__/__snapshots__/check.test.ts.snap
@@ -186,7 +186,6 @@ exports[`service:check integration federated should report composition success c
 exports[`service:check integration federated should report composition success correctly compacts output in CI 1`] = `
 "Loading Apollo Project
 Found 0 graph composition errors for service accounts on graph engine
-Validated composed schema against tag master on graph engine
 Compared 1 schema change against 0 operations over the last 548 days
 Found 0 breaking changes and 1 compatible change
 ╔════════╤══════════════════╤═══════════════════════════════════════════════════════════════════════════════╗
@@ -206,10 +205,6 @@ Validate graph composition for service accounts on graph engine [started]
 → Attempting to compose graph with accounts service's partial schema
 Found 0 graph composition errors for service accounts on graph engine [title changed]
 Found 0 graph composition errors for service accounts on graph engine [completed]
-Validating composed schema against tag master on graph engine [started]
-→ Validating schema
-Validated composed schema against tag master on graph engine [title changed]
-Validated composed schema against tag master on graph engine [completed]
 Comparing schema changes [started]
 Compared 1 schema change against 0 operations over the last 548 days [title changed]
 Compared 1 schema change against 0 operations over the last 548 days [completed]

--- a/packages/apollo/src/commands/service/check.ts
+++ b/packages/apollo/src/commands/service/check.ts
@@ -403,6 +403,11 @@ export default class ServiceCheck extends ProjectCommand {
                         "there were no composition errors"
                     );
                   }
+
+                  // this is used for the printing
+                  taskOutput.checkSchemaResult = checkSchemaResult;
+
+                  // this is used for the next step in the `run` command (comparing schema changes)
                   ctx.checkSchemaResult = checkSchemaResult;
                 }
               }

--- a/packages/apollo/src/commands/service/check.ts
+++ b/packages/apollo/src/commands/service/check.ts
@@ -391,7 +391,8 @@ export default class ServiceCheck extends ProjectCommand {
                     });
 
                   taskOutput.compositionErrors = decodedErrors;
-                  taskOutput.graphCompositionID = graphCompositionID;
+                  taskOutput.graphCompositionID =
+                    compositionValidationResult.graphCompositionID;
 
                   this.error(
                     federatedServiceCompositionUnsuccessfulErrorMessage

--- a/packages/vscode-apollo/package.json
+++ b/packages/vscode-apollo/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-apollo",
   "displayName": "Apollo GraphQL",
   "description": "Rich editor support for GraphQL client and server development that seamlessly integrates with the Apollo platform",
-  "version": "1.10.4-alpha.0",
+  "version": "1.10.4-alpha.1",
   "referenceID": "87197759-7617-40d0-b32e-46d378e907c7",
   "author": "Apollo GraphQL <opensource@apollographql.com>",
   "license": "MIT",

--- a/packages/vscode-apollo/package.json
+++ b/packages/vscode-apollo/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-apollo",
   "displayName": "Apollo GraphQL",
   "description": "Rich editor support for GraphQL client and server development that seamlessly integrates with the Apollo platform",
-  "version": "1.10.3",
+  "version": "1.10.4-alpha.0",
   "referenceID": "87197759-7617-40d0-b32e-46d378e907c7",
   "author": "Apollo GraphQL <opensource@apollographql.com>",
   "license": "MIT",


### PR DESCRIPTION
Several months ago, we implemented a mutation called
`checkPartialSchema`, which was designed to encapsulate both checking
for ability to compose and validating schema changes against operations.
  This new mutation has several added benefits, like displaying a new
  webpage with better information for federation users, along with
  allowing users to see multiple status lines appear in their PRs when
  using the GitHub integration. This PR attempts to migrate to use the
  newer mutation, abandoning the old. There were some sad moments trying
  to fight against the automatic type generation, so please forgive me
  if anything is not quite right type-wise, and please take over this
    commit at will. I have yet to test it locally, but I figured that
    this could at the very least get the ball rolling, and I'm happy to
    push this to completion if there isn't enough capacity on the
    (single person) tooling team at the moment, though I think this
    change should be already mostly complete and relatively small.

<!--
  Thanks for filing a pull request on Apollo Tooling!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [ ] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [ ] Make sure all of the significant new logic is covered by tests
- [ ] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests and linter rules pass

\*Make sure changelog entries note which project(s) has been affected. See older entries for examples on what this looks like.
