### PR TITLE
Use reference-equality when filtering rules in `buildSchemaFromSDL`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 - `apollo-env`
   - <First `apollo-env` related entry goes here>
 - `apollo-graphql`
-  - <First `apollo-graphql` related entry goes here>
+  - Use reference-equality, rather than `Function.prototype.name` string comparison, when omitting validation rules within `buildSchemaFromSDL`. [#1551](https://github.com/apollographql/apollo-tooling/pull/1551)
 - `apollo-language-server`
   - <First `apollo-language-server` related entry goes here>
 - `apollo-tools`

--- a/packages/apollo-graphql/src/schema/buildSchemaFromSDL.ts
+++ b/packages/apollo-graphql/src/schema/buildSchemaFromSDL.ts
@@ -25,6 +25,13 @@ import { isDocumentNode, isNode } from "../utilities/graphql";
 import { GraphQLResolverMap } from "./resolverMap";
 import { GraphQLSchemaValidationError } from "./GraphQLSchemaValidationError";
 import { specifiedSDLRules } from "graphql/validation/specifiedRules";
+import {
+  KnownTypeNamesRule,
+  UniqueDirectivesPerLocationRule
+} from "graphql/validation";
+// Currently, this PossibleTypeExtensions rule is experimental and thus not
+// exposed directly from the rules module above. This may change in the future!
+import { PossibleTypeExtensions } from "graphql/validation/rules/PossibleTypeExtensions";
 import { mapValues, isNotNullOrUndefined } from "apollo-env";
 
 export interface GraphQLSchemaModule {
@@ -33,13 +40,13 @@ export interface GraphQLSchemaModule {
 }
 
 const skippedSDLRules = [
-  "PossibleTypeExtensions",
-  "KnownTypeNames",
-  "UniqueDirectivesPerLocation"
+  PossibleTypeExtensions,
+  KnownTypeNamesRule,
+  UniqueDirectivesPerLocationRule
 ];
 
 const sdlRules = specifiedSDLRules.filter(
-  rule => !skippedSDLRules.includes(rule.name)
+  rule => !skippedSDLRules.includes(rule)
 );
 
 export function modulesFromSDL(


### PR DESCRIPTION
Similar in spirit to https://github.com/apollographql/apollo-server/pull/3338.

The technique previously used for removing rules from the standard `specifiedRules` was leveraging a check on `Function.prototype.name`, rather than doing direct object equality.  While that does generally work, thanks to the more recent standardization of `Function.prototype.name`, it still breaks down under some of the more aggressive minification techniques since a function's name is not guaranteed to remain the same.

Fixes: https://github.com/apollographql/apollo-server/issues/3335