### PR TITLE
Add missing `graphql` peer dependency

### DIFF
--- a/packages/apollo-tools/package.json
+++ b/packages/apollo-tools/package.json
@@ -18,6 +18,9 @@
   "dependencies": {
     "apollo-env": "file:../apollo-env"
   },
+  "peerDependencies": {
+    "graphql": "^14.2.1"
+  },
   "jest": {
     "preset": "ts-jest",
     "testEnvironment": "node",


### PR DESCRIPTION
`graphql` is currently imported, but not mentioned as a package dependency. When installing via pnpm, `graphql` cannot be resolved without this addition. Even with npm/yarn, the missing peer dependency may prove to be problematic for consumers (lack of version constraint).

<!--
  Thanks for filing a pull request on Apollo Tooling!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [ ] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [ ] Make sure all of the significant new logic is covered by tests
- [ ] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass

\*Make sure changelog entries note which project(s) has been affected. See older entries for examples on what this looks like.
