### PR TITLE
support frontend and historic parameters for service:check with federation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules
 lib
+.idea
 
 # TypeScript incremental compilation cache
 *.tsbuildinfo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Upcoming
 
 - `apollo`
-  - <First `apollo` related entry goes here>
+  - Support custom frontend and historic parameters for federated service:check
 - `apollo-codegen-flow`
   - <First `apollo-codegen-flow` related entry goes here>
 - `apollo-codegen-scala`

--- a/packages/apollo-language-server/src/engine/operations/checkPartialSchema.ts
+++ b/packages/apollo-language-server/src/engine/operations/checkPartialSchema.ts
@@ -8,6 +8,7 @@ export const CHECK_PARTIAL_SCHEMA = gql`
     $partialSchema: PartialSchemaInput!
     $gitContext: GitContextInput
     $historicParameters: HistoricQueryParameters
+    $frontend: String
   ) {
     service(id: $id) {
       checkPartialSchema(
@@ -16,6 +17,7 @@ export const CHECK_PARTIAL_SCHEMA = gql`
         partialSchema: $partialSchema
         gitContext: $gitContext
         historicParameters: $historicParameters
+        frontend: $frontend
       ) {
         compositionValidationResult {
           compositionValidationDetails {

--- a/packages/apollo-language-server/src/graphqlTypes.ts
+++ b/packages/apollo-language-server/src/graphqlTypes.ts
@@ -165,6 +165,7 @@ export interface CheckPartialSchemaVariables {
   partialSchema: PartialSchemaInput;
   gitContext?: GitContextInput | null;
   historicParameters?: HistoricQueryParameters | null;
+  frontend?: string | null;
 }
 
 /* tslint:disable */

--- a/packages/apollo/src/commands/service/check.ts
+++ b/packages/apollo/src/commands/service/check.ts
@@ -416,12 +416,12 @@ export default class ServiceCheck extends ProjectCommand {
 
                   // this is used for the printing
                   taskOutput.checkSchemaResult = checkSchemaResult;
-
+                  this.debug(`taskOutput:419 ${taskOutput.checkSchemaResult}`);
                   // this is used for the next step in the `run` command (comparing schema changes)
                   ctx.checkSchemaResult = checkSchemaResult;
 
                   this.debug(
-                    `ctx.checkSchemaResult:423 ${ctx.checkSchemaResult}`
+                    `ctx.checkSchemaResult:423 ${ctx.checkSchemaResult.targetUrl}`
                   );
                 }
               }
@@ -486,9 +486,15 @@ export default class ServiceCheck extends ProjectCommand {
                 );
                 // Attach to ctx as this will be used in later steps.
                 ctx.checkSchemaResult = checkSchemaResult;
+                this.debug(
+                  `checkSchemaResult:489 ${ctx.checkSchemaResult.targetUrl}`
+                );
                 // Save the output because we're going to use it even if we throw. `runTasks` won't return
                 // anything if we throw.
                 taskOutput.checkSchemaResult = checkSchemaResult;
+                this.debug(
+                  `taskOutput:493 ${taskOutput.checkSchemaResult.targetUrl}`
+                );
 
                 task.title = task.title.replace("Validating", "Validated");
               }
@@ -599,7 +605,7 @@ export default class ServiceCheck extends ProjectCommand {
         return this.log(JSON.stringify({ errors: compositionErrors }, null, 2));
       }
 
-      this.debug(` checkSchemaResult:600 ${checkSchemaResult.targetUrl}`);
+      this.debug(` checkSchemaResult:602 ${checkSchemaResult.targetUrl}`);
 
       return this.log(
         JSON.stringify(

--- a/packages/apollo/src/commands/service/check.ts
+++ b/packages/apollo/src/commands/service/check.ts
@@ -348,14 +348,6 @@ export default class ServiceCheck extends ProjectCommand {
                     flags.queryCountThresholdPercentage
                 });
 
-                this.debug({
-                  id: graphName,
-                  graphVariant: tag,
-                  implementingServiceName: serviceName,
-                  frontend: flags.frontend || config.engine.frontend,
-                  ...(historicParameters && { historicParameters })
-                });
-
                 const {
                   compositionValidationResult,
                   checkSchemaResult
@@ -416,13 +408,8 @@ export default class ServiceCheck extends ProjectCommand {
 
                   // this is used for the printing
                   taskOutput.checkSchemaResult = checkSchemaResult;
-                  this.debug(`taskOutput:419 ${taskOutput.checkSchemaResult}`);
                   // this is used for the next step in the `run` command (comparing schema changes)
                   ctx.checkSchemaResult = checkSchemaResult;
-
-                  this.debug(
-                    `ctx.checkSchemaResult:423 ${ctx.checkSchemaResult.targetUrl}`
-                  );
                 }
               }
             },
@@ -486,15 +473,9 @@ export default class ServiceCheck extends ProjectCommand {
                 );
                 // Attach to ctx as this will be used in later steps.
                 ctx.checkSchemaResult = checkSchemaResult;
-                this.debug(
-                  `checkSchemaResult:489 ${ctx.checkSchemaResult.targetUrl}`
-                );
                 // Save the output because we're going to use it even if we throw. `runTasks` won't return
                 // anything if we throw.
                 taskOutput.checkSchemaResult = checkSchemaResult;
-                this.debug(
-                  `taskOutput:493 ${taskOutput.checkSchemaResult.targetUrl}`
-                );
 
                 task.title = task.title.replace("Validating", "Validated");
               }
@@ -605,8 +586,6 @@ export default class ServiceCheck extends ProjectCommand {
         return this.log(JSON.stringify({ errors: compositionErrors }, null, 2));
       }
 
-      this.debug(` checkSchemaResult:602 ${checkSchemaResult.targetUrl}`);
-
       return this.log(
         JSON.stringify(
           {
@@ -659,7 +638,6 @@ export default class ServiceCheck extends ProjectCommand {
         );
       }
 
-      this.debug(`formatMarkdown:654 ${checkSchemaResult.targetUrl}`);
       return this.log(
         formatMarkdown({
           checkSchemaResult,

--- a/packages/apollo/src/commands/service/check.ts
+++ b/packages/apollo/src/commands/service/check.ts
@@ -419,6 +419,10 @@ export default class ServiceCheck extends ProjectCommand {
 
                   // this is used for the next step in the `run` command (comparing schema changes)
                   ctx.checkSchemaResult = checkSchemaResult;
+
+                  this.debug(
+                    `ctx.checkSchemaResult:423 ${ctx.checkSchemaResult}`
+                  );
                 }
               }
             },
@@ -595,6 +599,8 @@ export default class ServiceCheck extends ProjectCommand {
         return this.log(JSON.stringify({ errors: compositionErrors }, null, 2));
       }
 
+      this.debug(` checkSchemaResult:600 ${checkSchemaResult.targetUrl}`);
+
       return this.log(
         JSON.stringify(
           {
@@ -647,6 +653,7 @@ export default class ServiceCheck extends ProjectCommand {
         );
       }
 
+      this.debug(`formatMarkdown:654 ${checkSchemaResult.targetUrl}`);
       return this.log(
         formatMarkdown({
           checkSchemaResult,

--- a/packages/apollo/src/commands/service/check.ts
+++ b/packages/apollo/src/commands/service/check.ts
@@ -358,6 +358,8 @@ export default class ServiceCheck extends ProjectCommand {
                   partialSchema: {
                     sdl
                   },
+                  frontend: flags.frontend || config.engine.frontend,
+                  ...(historicParameters && { historicParameters }),
                   gitContext: await gitInfo(this.log)
                 });
 

--- a/packages/apollo/src/commands/service/check.ts
+++ b/packages/apollo/src/commands/service/check.ts
@@ -348,6 +348,14 @@ export default class ServiceCheck extends ProjectCommand {
                     flags.queryCountThresholdPercentage
                 });
 
+                this.debug({
+                  id: graphName,
+                  graphVariant: tag,
+                  implementingServiceName: serviceName,
+                  frontend: flags.frontend || config.engine.frontend,
+                  ...(historicParameters && { historicParameters })
+                });
+
                 const {
                   compositionValidationResult,
                   checkSchemaResult

--- a/packages/apollo/src/commands/service/check.ts
+++ b/packages/apollo/src/commands/service/check.ts
@@ -408,6 +408,7 @@ export default class ServiceCheck extends ProjectCommand {
 
                   // this is used for the printing
                   taskOutput.checkSchemaResult = checkSchemaResult;
+
                   // this is used for the next step in the `run` command (comparing schema changes)
                   ctx.checkSchemaResult = checkSchemaResult;
                 }


### PR DESCRIPTION
This passes the already in memory frontend and historic parameters to the federated service check