### PR TITLE
swift: Fix codegen with empty input objects / arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - `apollo-codegen-scala`
   - <First `apollo-codegen-scala` related entry goes here>
 - `apollo-codegen-swift`
-  - <First `apollo-codegen-swift` related entry goes here>
+  - Fix code generation for empty input objects / arrays [#1589](https://github.com/apollographql/apollo-tooling/pull/1589)
 - `apollo-codegen-typescript`
   - <First `apollo-codegen-typescript` related entry goes here>
 - `apollo-env`

--- a/packages/apollo-codegen-swift/src/codeGeneration.ts
+++ b/packages/apollo-codegen-swift/src/codeGeneration.ts
@@ -300,7 +300,7 @@ export class SwiftAPIGenerator extends SwiftGenerator<CompilerContext> {
                       swift`${SwiftSource.string(name)}: ${propertyName}`
                   ),
                   ", "
-                ) || ":",
+                ) || swift`:`,
                 swift`]`
               )
             );
@@ -649,7 +649,7 @@ export class SwiftAPIGenerator extends SwiftGenerator<CompilerContext> {
                 )
               ],
               ", "
-            ) || ":",
+            ) || swift`:`,
             swift`])`
           )
         );
@@ -691,7 +691,7 @@ export class SwiftAPIGenerator extends SwiftGenerator<CompilerContext> {
                   )
                 ],
                 ", "
-              ) || ":",
+              ) || swift`:`,
               swift`])`
             )
           );
@@ -1227,7 +1227,7 @@ export class SwiftAPIGenerator extends SwiftGenerator<CompilerContext> {
                     )}`
                 ),
                 ", "
-              ) || ":",
+              ) || swift`:`,
               swift`]`
             )
           );

--- a/packages/apollo-codegen-swift/src/helpers.ts
+++ b/packages/apollo-codegen-swift/src/helpers.ts
@@ -260,23 +260,27 @@ export class Helpers {
           value.variableName
         )})`;
       } else if (Array.isArray(value)) {
-        return SwiftSource.wrap(
-          swift`[`,
-          SwiftSource.join(value.map(expressionFromValue), ", "),
-          swift`]`
+        return (
+          SwiftSource.wrap(
+            swift`[`,
+            SwiftSource.join(value.map(expressionFromValue), ", "),
+            swift`]`
+          ) || swift`[]`
         );
       } else if (typeof value === "object") {
-        return SwiftSource.wrap(
-          swift`[`,
-          SwiftSource.join(
-            Object.entries(value).map(([key, value]) => {
-              return swift`${SwiftSource.string(key)}: ${expressionFromValue(
-                value
-              )}`;
-            }),
-            ", "
-          ) || ":",
-          swift`]`
+        return (
+          SwiftSource.wrap(
+            swift`[`,
+            SwiftSource.join(
+              Object.entries(value).map(([key, value]) => {
+                return swift`${SwiftSource.string(key)}: ${expressionFromValue(
+                  value
+                )}`;
+              }),
+              ", "
+            ),
+            swift`]`
+          ) || swift`[:]`
         );
       } else if (typeof value === "string") {
         return SwiftSource.string(value);
@@ -285,17 +289,19 @@ export class Helpers {
       }
     }
 
-    return SwiftSource.wrap(
-      swift`[`,
-      SwiftSource.join(
-        args.map(arg => {
-          return swift`${SwiftSource.string(arg.name)}: ${expressionFromValue(
-            arg.value
-          )}`;
-        }),
-        ", "
-      ) || ":",
-      swift`]`
+    return (
+      SwiftSource.wrap(
+        swift`[`,
+        SwiftSource.join(
+          args.map(arg => {
+            return swift`${SwiftSource.string(arg.name)}: ${expressionFromValue(
+              arg.value
+            )}`;
+          }),
+          ", "
+        ),
+        swift`]`
+      ) || swift`[:]`
     );
   }
 

--- a/packages/apollo-codegen-swift/src/language.ts
+++ b/packages/apollo-codegen-swift/src/language.ts
@@ -276,30 +276,29 @@ export class SwiftSource {
   }
 
   /**
-   * If maybeSource is not null or empty, then wrap with start and end, otherwise return an empty
-   * string.
+   * If maybeSource is not undefined or empty, then wrap with start and end, otherwise return
+   * undefined.
    *
-   * This is just a wrapper for `wrap()` from apollo-codegen-core/lib/utilities/printing.
+   * This is largely just a wrapper for `wrap()` from apollo-codegen-core/lib/utilities/printing.
    */
   static wrap(
     start: SwiftSource,
     maybeSource?: SwiftSource,
     end?: SwiftSource
-  ): SwiftSource {
-    return new SwiftSource(
-      _wrap(
-        start.source,
-        maybeSource !== undefined ? maybeSource.source : undefined,
-        end !== undefined ? end.source : undefined
-      )
+  ): SwiftSource | undefined {
+    const result = _wrap(
+      start.source,
+      maybeSource !== undefined ? maybeSource.source : undefined,
+      end !== undefined ? end.source : undefined
     );
+    return result ? new SwiftSource(result) : undefined;
   }
 
   /**
-   * Given maybeArray, return an empty string if it is null or empty, otherwise return all items
+   * Given maybeArray, return undefined if it is undefined or empty, otherwise return all items
    * together separated by separator if provided.
    *
-   * This is just a wrapper for `join()` from apollo-codegen-core/lib/utilities/printing.
+   * This is largely just a wrapper for `join()` from apollo-codegen-core/lib/utilities/printing.
    *
    * @param separator The separator to put between elements. This is typed as `string` with the
    * expectation that it's generally something like `', '` but if it contains identifiers it should
@@ -308,8 +307,9 @@ export class SwiftSource {
   static join(
     maybeArray?: (SwiftSource | undefined)[],
     separator?: string
-  ): SwiftSource {
-    return new SwiftSource(_join(maybeArray, separator));
+  ): SwiftSource | undefined {
+    const result = _join(maybeArray, separator);
+    return result ? new SwiftSource(result) : undefined;
   }
 }
 
@@ -452,9 +452,10 @@ export class SwiftGenerator<Context> extends CodeGenerator<
   ) {
     this.printNewlineIfNeeded();
     this.printOnNewline(
-      wrap(swift``, new SwiftSource(_join(modifiers, " ")), swift` `).concat(
-        swift`class ${className}`
-      )
+      (
+        wrap(swift``, new SwiftSource(_join(modifiers, " ")), swift` `) ||
+        swift``
+      ).concat(swift`class ${className}`)
     );
     this.print(
       wrap(


### PR DESCRIPTION
The codegen was omitting the `[:]` and `[]` tokens entirely.

Fixes apollographql/apollo-ios#838

The root cause of missing `[:]` was there was some code relying on the truthy value of strings, but the conversion to `SwiftSource` caused even empty sources to become truthy. I'm actually surprised TypeScript happily accepts `someObject || someStr` and evaluates it as the object type with no warnings (I mean, it will always be the object type, but the `|| someStr` is now dead code).

Empty arrays I'm pretty sure were always broken even before `SwiftSource` due to the counterintuitive behavior of `wrap` (namely, `wrap("[", "", "]") == ""` instead of returning `"[]"`). I didn't want to deviate too much from the underlying `wrap` behavior (since the behavior is relied-upon in places) so I just made it return `undefined` instead of an empty source object, which forced us to handle that at the call sites.

TODO:

- [x] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [X] Make sure all of the significant new logic is covered by tests
- [X] Rebase your changes on master so that they can be merged easily
- [X] Make sure all tests and linter rules pass

\*Make sure changelog entries note which project(s) has been affected. See older entries for examples on what this looks like.
