### PR TITLE
Fix codegen --watch not seeing operation changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Upcoming
 
 - `apollo`
-  - <First `apollo` related entry goes here>
+  - Fix codegen --watch mode not writing changes for files [#1591](https://github.com/apollographql/apollo-tooling/pull/1591)
 - `apollo-codegen-flow`
   - <First `apollo-codegen-flow` related entry goes here>
 - `apollo-codegen-scala`

--- a/packages/apollo/src/commands/client/codegen.ts
+++ b/packages/apollo/src/commands/client/codegen.ts
@@ -240,6 +240,7 @@ export default class Generate extends ClientCommand {
         if (file.indexOf("__generated__") > -1) return;
         // don't trigger write events on single output file
         if (file.indexOf(output) > -1) return;
+        this.project.fileDidChange(URI.file(file).toString());
         console.log("\nChange detected, generating types...");
         write();
       });


### PR DESCRIPTION
resolves #1584 

#1559 introduced an issue where the documents from files were not being invalidated on change, so codegen in watch mode would not update types on save.

<!--
  Thanks for filing a pull request on Apollo Tooling!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [ ] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [ ] Make sure all of the significant new logic is covered by tests
- [ ] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests and linter rules pass

\*Make sure changelog entries note which project(s) has been affected. See older entries for examples on what this looks like.
