### PR TITLE
Fix debouncing issue in vscode autocomplete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,12 @@
 - `apollo-graphql`
   - <First `apollo-graphql` related entry goes here>
 - `apollo-language-server`
+  - Improve autocomplete performance by fixing `leading` option and debounce threshold [#1593](https://github.com/apollographql/apollo-tooling/pull/1593)
   - Load ENV variables from both `.env` and `.env.local` for Vue CLI compatibility [#1525](https://github.com/apollographql/apollo-tooling/pull/1525)
 - `apollo-tools`
   - <First `apollo-tools` related entry goes here>
 - `vscode-apollo`
+  - Fix `ctrl+space` autocomplete with language-server imrovements [#1593](https://github.com/apollographql/apollo-tooling/pull/1593)
   - Watch both `.env` and `.env.local` for changes [#1525](https://github.com/apollographql/apollo-tooling/pull/1525)
 
 ## `apollo@2.19.1`

--- a/packages/apollo-language-server/src/server.ts
+++ b/packages/apollo-language-server/src/server.ts
@@ -187,14 +187,12 @@ connection.onWorkspaceSymbol((params, token) =>
 );
 
 connection.onCompletion(
-  debounceHandler(
-    (params, token) =>
-      languageProvider.provideCompletionItems(
-        params.textDocument.uri,
-        params.position,
-        token
-      ),
-    false
+  debounceHandler((params, token) =>
+    languageProvider.provideCompletionItems(
+      params.textDocument.uri,
+      params.position,
+      token
+    )
   )
 );
 

--- a/packages/apollo-language-server/src/utilities/debouncer.ts
+++ b/packages/apollo-language-server/src/utilities/debouncer.ts
@@ -4,5 +4,5 @@ export function debounceHandler(
   handler: (...args: any[]) => any,
   leading: boolean = true
 ) {
-  return debounce(handler, 400, { leading });
+  return debounce(handler, 250, { leading });
 }


### PR DESCRIPTION
This is an incremental improvement to the autocomplete handling in the language server. this is _not_ a 100% fix for all of the issues in autocomplete but hopefully _is_ a complete fix for the ctrl+space recommendations in vscode.

Ctrl+space and autocomplete right now doesn't work properly. The recommended options are showing the fields for the parent type.

This is because of the `leading: false` option being passed to the debounce function. In addition, this PR reduces the debounce timeout to make other issues with autocomplete less obvious 

<!--
  Thanks for filing a pull request on Apollo Tooling!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [ ] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [ ] Make sure all of the significant new logic is covered by tests
- [ ] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests and linter rules pass

\*Make sure changelog entries note which project(s) has been affected. See older entries for examples on what this looks like.
