### PR TITLE
fix url missing from service:check output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - `apollo`
   - Fix codegen --watch mode not writing changes for files [#1591](https://github.com/apollographql/apollo-tooling/pull/1591)
+  - Fix `service:check` not outputing url
 - `apollo-codegen-flow`
   - <First `apollo-codegen-flow` related entry goes here>
 - `apollo-codegen-scala`

--- a/packages/apollo/src/commands/service/__tests__/__snapshots__/check.test.ts.snap
+++ b/packages/apollo/src/commands/service/__tests__/__snapshots__/check.test.ts.snap
@@ -40,7 +40,9 @@ exports[`service:check formatHumanReadable should have correct output with break
 ╟────────┼───────────────────────────┼─────────────────────────────────────────────────────────────────────────────────────────╢
 ║ PASS   │ FIELD_REMOVED             │ \`SchemaDiff.numberOfCheckedOperations\` was removed                                      ║
 ╚════════╧═══════════════════════════╧═════════════════════════════════════════════════════════════════════════════════════════╝
-"
+
+
+View full details at: https://engine-dev.apollographql.com/service/engine/checks?schemaTag=Detached%3A%20d664f715645c5f0bb5ad4f2260cd6cb8d19bbc68&schemaTagId=f9f68e7e-1b5f-4eab-a3da-1fd8cd681111&from=2019-03-26T22%3A25%3A12.887Z?graphCompositionId=fff"
 `;
 
 exports[`service:check formatHumanReadable should have correct output with only breaking changes 1`] = `
@@ -61,7 +63,9 @@ exports[`service:check formatHumanReadable should have correct output with only 
 ╟────────┼────────────────────┼─────────────────────────────────────────────────────────────────────────────────────────╢
 ║ FAIL   │ TYPE_REMOVED       │ \`NamedIntrospectionArg\` removed                                                         ║
 ╚════════╧════════════════════╧═════════════════════════════════════════════════════════════════════════════════════════╝
-"
+
+
+View full details at: https://engine-dev.apollographql.com/service/engine/checks?schemaTag=Detached%3A%20d664f715645c5f0bb5ad4f2260cd6cb8d19bbc68&schemaTagId=f9f68e7e-1b5f-4eab-a3da-1fd8cd681111&from=2019-03-26T22%3A25%3A12.887Z?graphCompositionId=fff"
 `;
 
 exports[`service:check formatHumanReadable should have correct output with only non-breaking changes 1`] = `
@@ -194,6 +198,8 @@ Found 0 breaking changes and 1 compatible change
 ║ PASS   │ ARG_CHANGED_TYPE │ \`Query.launches\` argument \`after\` has changed type from \`String\` to \`String!\` ║
 ╚════════╧══════════════════╧═══════════════════════════════════════════════════════════════════════════════╝
 
+
+View full details at: https://engine-staging.apollographql.com/service/justin-fullstack-tutorial/check/3acd7765-61b2-4f1a-9227-8b288e42bfdc
 "
 `;
 
@@ -217,6 +223,8 @@ Found 0 breaking changes and 1 compatible change [completed]
 ║ PASS   │ ARG_CHANGED_TYPE │ \`Query.launches\` argument \`after\` has changed type from \`String\` to \`String!\` ║
 ╚════════╧══════════════════╧═══════════════════════════════════════════════════════════════════════════════╝
 
+
+View full details at: https://engine-staging.apollographql.com/service/justin-fullstack-tutorial/check/3acd7765-61b2-4f1a-9227-8b288e42bfdc
 "
 `;
 
@@ -273,6 +281,8 @@ Found 1 breaking change and 0 compatible changes [failed]
 ║ FAIL   │ ARG_CHANGED_TYPE │ \`Query.launches\` argument \`after\` has changed type from \`String\` to \`String!\` ║
 ╚════════╧══════════════════╧═══════════════════════════════════════════════════════════════════════════════╝
 
+
+View full details at: https://engine-staging.apollographql.com/service/justin-fullstack-tutorial/check/3acd7765-61b2-4f1a-9227-8b288e42bfdc
 "
 `;
 
@@ -328,6 +338,8 @@ Found 0 breaking changes and 1 compatible change [completed]
 ║ PASS   │ ARG_CHANGED_TYPE │ \`Query.launches\` argument \`after\` has changed type from \`String\` to \`String!\` ║
 ╚════════╧══════════════════╧═══════════════════════════════════════════════════════════════════════════════╝
 
+
+View full details at: https://engine-staging.apollographql.com/service/justin-fullstack-tutorial/check/3acd7765-61b2-4f1a-9227-8b288e42bfdc
 "
 `;
 

--- a/packages/apollo/src/commands/service/check.ts
+++ b/packages/apollo/src/commands/service/check.ts
@@ -210,7 +210,7 @@ export function formatHumanReadable({
       change => change.severity !== ChangeSeverity.FAILURE
     );
 
-    return table([
+    result += table([
       ["Change", "Code", "Description"],
       ...[
         ...breakingChanges.map(formatChange).map(Object.values),


### PR DESCRIPTION
The early return of the new (and improved) table UI was preventing the addition of the url.