### PR TITLE
Add variant to service list output

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,25 @@
         "lodash.xorby": "^4.7.0"
       },
       "dependencies": {
+        "apollo-env": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/apollo-env/-/apollo-env-0.5.1.tgz",
+          "integrity": "sha512-fndST2xojgSdH02k5hxk1cbqA9Ti8RX4YzzBoAB4oIe1Puhq7+YlhXGXfXB5Y4XN0al8dLg+5nAkyjNAR2qZTw==",
+          "requires": {
+            "core-js": "^3.0.1",
+            "node-fetch": "^2.2.0",
+            "sha.js": "^2.4.11"
+          }
+        },
+        "apollo-graphql": {
+          "version": "0.3.4",
+          "resolved": "https://registry.npmjs.org/apollo-graphql/-/apollo-graphql-0.3.4.tgz",
+          "integrity": "sha512-w+Az1qxePH4oQ8jvbhQBl5iEVvqcqynmU++x/M7MM5xqN1C7m1kyIzpN17gybXlTJXY4Oxej2WNURC2/hwpfYw==",
+          "requires": {
+            "apollo-env": "^0.5.1",
+            "lodash.sortby": "^4.7.0"
+          }
+        },
         "apollo-server-env": {
           "version": "2.4.3",
           "resolved": "https://registry.npmjs.org/apollo-server-env/-/apollo-server-env-2.4.3.tgz",

--- a/packages/apollo/src/commands/service/__tests__/__snapshots__/list.test.ts.snap
+++ b/packages/apollo/src/commands/service/__tests__/__snapshots__/list.test.ts.snap
@@ -13,8 +13,8 @@ There are no services on this federated graph
 exports[`service:list integration should list services correctly for a federated service vanilla 1`] = `
 "Loading Apollo Project [started]
 Loading Apollo Project [completed]
-Fetching list of services for graph engine [started]
-Fetching list of services for graph engine [completed]
+Fetching list of services for graph engine@master [started]
+Fetching list of services for graph engine@master [completed]
 ╔═══════════╤═══════════════════════════════╤═══════════════════════════╗
 ║ Name      │ URL                           │ Last Updated              ║
 ╟───────────┼───────────────────────────────┼───────────────────────────╢

--- a/packages/apollo/src/commands/service/__tests__/__snapshots__/list.test.ts.snap
+++ b/packages/apollo/src/commands/service/__tests__/__snapshots__/list.test.ts.snap
@@ -3,8 +3,8 @@
 exports[`service:list integration should display non federated message for a non federated service vanilla 1`] = `
 "Loading Apollo Project [started]
 Loading Apollo Project [completed]
-Fetching list of services for graph engine [started]
-Fetching list of services for graph engine [completed]
+Fetching list of services for graph engine@master [started]
+Fetching list of services for graph engine@master [completed]
 
 There are no services on this federated graph
 "

--- a/packages/apollo/src/commands/service/list.ts
+++ b/packages/apollo/src/commands/service/list.ts
@@ -124,7 +124,7 @@ export default class ServiceList extends ProjectCommand {
         return [
           {
             title: `Fetching list of services for graph ${chalk.blue(
-              graphName
+              graphName + "@" + variant
             )}`,
             task: async (ctx: TasksOutput, task) => {
               const {


### PR DESCRIPTION
We always fetch list of services with a variant, so include it in the
CLI output

<!--
  Thanks for filing a pull request on Apollo Tooling!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [ ] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [ ] Make sure all of the significant new logic is covered by tests
- [ ] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests and linter rules pass

\*Make sure changelog entries note which project(s) has been affected. See older entries for examples on what this looks like.
