### PR TITLE
Swift: Add CLI argument to set indent width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
   - Fix code generation for empty input objects / arrays [#1589](https://github.com/apollographql/apollo-tooling/pull/1589)
   - Add flag to omit deprecated enum cases [#1595](https://github.com/apollographql/apollo-tooling/pull/1595)
   - Fix code generation for input fields with the value `null` [#1596](https://github.com/apollographql/apollo-tooling/pull/1596)
+  - Add CLI argument to set indent width [#1606](https://github.com/apollographql/apollo-tooling/pull/1606)
 - `apollo-codegen-typescript`
   - <First `apollo-codegen-typescript` related entry goes here>
 - `apollo-env`

--- a/packages/apollo-codegen-core/src/compiler/index.ts
+++ b/packages/apollo-codegen-core/src/compiler/index.ts
@@ -48,6 +48,7 @@ export interface CompilerOptions {
   useReadOnlyTypes?: boolean;
   suppressSwiftMultilineStringLiterals?: boolean;
   omitDeprecatedEnumCases?: boolean;
+  indentWidth?: number;
 }
 
 export interface CompilerContext {

--- a/packages/apollo-codegen-swift/src/__tests__/__snapshots__/codeGeneration.ts.snap
+++ b/packages/apollo-codegen-swift/src/__tests__/__snapshots__/codeGeneration.ts.snap
@@ -1,5 +1,113 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Swift code generation #classDeclarationForOperation()  should generate a class declaration with an indent width of 4 spaces 1`] = `
+"public final class HeroQuery: GraphQLQuery {
+    /// The raw GraphQL definition of this operation.
+    public let operationDefinition =
+        \\"\\"\\"
+        query Hero {
+          hero {
+            ...HeroDetails
+          }
+        }
+        \\"\\"\\"
+
+    public let operationName = \\"Hero\\"
+
+    public let operationIdentifier: String? = \\"90d0d674eb6a7b33776f63200d6cec3d09f881247c360a2ac9a29037a02210c4\\"
+
+    public var queryDocument: String { return operationDefinition.appending(HeroDetails.fragmentDefinition) }
+
+    public init() {
+    }
+
+    public struct Data: GraphQLSelectionSet {
+        public static let possibleTypes = [\\"Query\\"]
+
+        public static let selections: [GraphQLSelection] = [
+            GraphQLField(\\"hero\\", type: .object(Hero.selections)),
+        ]
+
+        public private(set) var resultMap: ResultMap
+
+        public init(unsafeResultMap: ResultMap) {
+            self.resultMap = unsafeResultMap
+        }
+
+        public init(hero: Hero? = nil) {
+            self.init(unsafeResultMap: [\\"__typename\\": \\"Query\\", \\"hero\\": hero.flatMap { (value: Hero) -> ResultMap in value.resultMap }])
+        }
+
+        public var hero: Hero? {
+            get {
+                return (resultMap[\\"hero\\"] as? ResultMap).flatMap { Hero(unsafeResultMap: $0) }
+            }
+            set {
+                resultMap.updateValue(newValue?.resultMap, forKey: \\"hero\\")
+            }
+        }
+
+        public struct Hero: GraphQLSelectionSet {
+            public static let possibleTypes = [\\"Human\\", \\"Droid\\"]
+
+            public static let selections: [GraphQLSelection] = [
+                GraphQLField(\\"name\\", type: .nonNull(.scalar(String.self))),
+            ]
+
+            public private(set) var resultMap: ResultMap
+
+            public init(unsafeResultMap: ResultMap) {
+                self.resultMap = unsafeResultMap
+            }
+
+            public static func makeHuman(name: String) -> Hero {
+                return Hero(unsafeResultMap: [\\"__typename\\": \\"Human\\", \\"name\\": name])
+            }
+
+            public static func makeDroid(name: String) -> Hero {
+                return Hero(unsafeResultMap: [\\"__typename\\": \\"Droid\\", \\"name\\": name])
+            }
+
+            /// The name of the character
+            public var name: String {
+                get {
+                    return resultMap[\\"name\\"]! as! String
+                }
+                set {
+                    resultMap.updateValue(newValue, forKey: \\"name\\")
+                }
+            }
+
+            public var fragments: Fragments {
+                get {
+                    return Fragments(unsafeResultMap: resultMap)
+                }
+                set {
+                    resultMap += newValue.resultMap
+                }
+            }
+
+            public struct Fragments {
+                public private(set) var resultMap: ResultMap
+
+                public init(unsafeResultMap: ResultMap) {
+                    self.resultMap = unsafeResultMap
+                }
+
+                public var heroDetails: HeroDetails {
+                    get {
+                        return HeroDetails(unsafeResultMap: resultMap)
+                    }
+                    set {
+                        resultMap += newValue.resultMap
+                    }
+                }
+            }
+        }
+    }
+}"
+`;
+
 exports[`Swift code generation #classDeclarationForOperation() should correctly escape a mutli-line string literal 1`] = `
 "public final class CreateReviewMutation: GraphQLMutation {
   /// The raw GraphQL definition of this operation.

--- a/packages/apollo-codegen-swift/src/__tests__/codeGeneration.ts
+++ b/packages/apollo-codegen-swift/src/__tests__/codeGeneration.ts
@@ -26,10 +26,6 @@ import { SwiftAPIGenerator } from "../codeGeneration";
 describe("Swift code generation", () => {
   let generator: SwiftAPIGenerator;
 
-  beforeEach(() => {
-    generator = new SwiftAPIGenerator({});
-  });
-
   function compile(
     source: string,
     options: CompilerOptions = {
@@ -37,6 +33,13 @@ describe("Swift code generation", () => {
       omitDeprecatedEnumCases: false
     }
   ): CompilerContext {
+    generator = new SwiftAPIGenerator({
+      fragments: {},
+      operations: {},
+      schema: schema,
+      typesUsed: [],
+      options: options
+    });
     const document = parse(source);
     const context = compileToIR(schema, document, options);
     generator.context = context;
@@ -195,6 +198,30 @@ describe("Swift code generation", () => {
           generateOperationIds: true,
           mergeInFieldsFromFragmentSpreads: true,
           omitDeprecatedEnumCases: false
+        }
+      );
+
+      generator.classDeclarationForOperation(operations["Hero"], false, false);
+
+      expect(generator.output).toMatchSnapshot();
+    });
+
+    it(` should generate a class declaration with an indent width of 4 spaces`, () => {
+      const { operations } = compile(
+        `
+        query Hero {
+          hero {
+            ...HeroDetails
+          }
+        }
+        fragment HeroDetails on Character {
+          name
+        }
+        `,
+        {
+          generateOperationIds: true,
+          mergeInFieldsFromFragmentSpreads: true,
+          indentWidth: 4
         }
       );
 

--- a/packages/apollo-codegen-swift/src/codeGeneration.ts
+++ b/packages/apollo-codegen-swift/src/codeGeneration.ts
@@ -41,6 +41,7 @@ import { generateOperationId } from "apollo-codegen-core/lib/compiler/visitors/g
 import { collectAndMergeFields } from "apollo-codegen-core/lib/compiler/visitors/collectAndMergeFields";
 
 import "apollo-codegen-core/lib/utilities/array";
+import { GeneratedFile } from "apollo-codegen-core/lib/utilities/CodeGenerator";
 
 const { join, wrap } = SwiftSource;
 
@@ -156,6 +157,29 @@ export class SwiftAPIGenerator extends SwiftGenerator<CompilerContext> {
     super(context);
 
     this.helpers = new Helpers(context.options);
+
+    let indentWidth = context.options.indentWidth;
+    if (indentWidth) {
+      this.currentFile.indentWidth = indentWidth;
+    }
+  }
+
+  withinFile(fileName: string, closure: Function) {
+    let file = this.generatedFiles[fileName];
+    if (!file) {
+      file = new GeneratedFile();
+
+      let indentWidth = this.context.options.indentWidth;
+      if (indentWidth) {
+        file.indentWidth = indentWidth;
+      }
+
+      this.generatedFiles[fileName] = file;
+    }
+    const oldCurrentFile = this.currentFile;
+    this.currentFile = file;
+    closure();
+    this.currentFile = oldCurrentFile;
   }
 
   fileHeader() {

--- a/packages/apollo/README.md
+++ b/packages/apollo/README.md
@@ -139,6 +139,9 @@ OPTIONS
   --includes=includes                        Glob of files to search for GraphQL operations. This should be used to find
                                              queries *and* any client schema extensions
 
+  --indentWidth=indentWidth                  Number of spaces to indent by at each indent level. Default=2 [currently
+                                             Swift-only]
+
   --key=key                                  The API key for the Apollo Engine service
 
   --localSchemaFile=localSchemaFile          Path to one or more local GraphQL schema file(s), as introspection result

--- a/packages/apollo/src/commands/client/codegen.ts
+++ b/packages/apollo/src/commands/client/codegen.ts
@@ -61,6 +61,10 @@ export default class Generate extends ClientCommand {
     }),
 
     // swift
+    indentWidth: flags.integer({
+      description: "Number of spaces to indent by at each indent level",
+      default: 2
+    }),
     namespace: flags.string({
       description: "The namespace to emit generated code into."
     }),
@@ -222,7 +226,8 @@ export default class Generate extends ClientCommand {
                     tsFileExtension: flags.tsFileExtension,
                     suppressSwiftMultilineStringLiterals:
                       flags.suppressSwiftMultilineStringLiterals,
-                    omitDeprecatedEnumCases: flags.omitDeprecatedEnumCases
+                    omitDeprecatedEnumCases: flags.omitDeprecatedEnumCases,
+                    indentWidth: flags.indentWidth
                   }
                 );
               };


### PR DESCRIPTION
Enable the ability to set a custom indentation width
(e.g., 4 spaces instead of the default 2) on generated code, so
users can configure the generated code to match the rest of their
project's indentation.

TODO:

- [x] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests and linter rules pass
