### PR TITLE
Unify and simplify jest config

### DIFF
--- a/jest.base.js
+++ b/jest.base.js
@@ -1,0 +1,11 @@
+module.exports = {
+  preset: "ts-jest",
+  testPathIgnorePatterns: ["node_modules", "lib", "__fixtures__", "__mocks__"],
+  testEnvironment: "node",
+  globals: {
+    "ts-jest": {
+      tsConfig: "<rootDir>/tsconfig.test.json",
+      diagnostics: false
+    }
+  }
+};

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  projects: ["<rootDir>/packages/!(vscode-apollo)"]
+};

--- a/package.json
+++ b/package.json
@@ -94,11 +94,6 @@
     "vscode": "1.1.36",
     "yarn": "1.19.1"
   },
-  "jest": {
-    "projects": [
-      "<rootDir>/packages/!(vscode-apollo)"
-    ]
-  },
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": [
       "prettier --write",

--- a/packages/apollo-codegen-core/jest.config.js
+++ b/packages/apollo-codegen-core/jest.config.js
@@ -1,0 +1,11 @@
+const baseConfig = require("../../jest.base");
+
+module.exports = {
+  ...baseConfig,
+  setupFiles: ["apollo-env"],
+  setupFilesAfterEnv: ["<rootDir>/test-utils/matchers.ts"],
+  testPathIgnorePatterns: [
+    ...baseConfig.testPathIgnorePatterns,
+    "<rootDir>/src/compiler/visitors/__tests__/test-utils/"
+  ]
+};

--- a/packages/apollo-codegen-core/package.json
+++ b/packages/apollo-codegen-core/package.json
@@ -25,37 +25,5 @@
     "ast-types": "^0.13.0",
     "common-tags": "^1.5.1",
     "recast": "^0.18.0"
-  },
-  "jest": {
-    "preset": "ts-jest",
-    "transformIgnorePatterns": [
-      "/node_modules/"
-    ],
-    "setupFiles": [
-      "apollo-env"
-    ],
-    "testEnvironment": "node",
-    "setupFilesAfterEnv": [
-      "<rootDir>/test-utils/matchers.ts"
-    ],
-    "testMatch": [
-      "**/__tests__/*.(js|ts)"
-    ],
-    "testPathIgnorePatterns": [
-      "<rootDir>/node_modules/",
-      "<rootDir>/lib/",
-      "<rootDir>/test/fixtures/",
-      "<rootDir>/test/test-utils"
-    ],
-    "moduleFileExtensions": [
-      "ts",
-      "js"
-    ],
-    "globals": {
-      "ts-jest": {
-        "tsConfig": "<rootDir>/tsconfig.test.json",
-        "diagnostics": false
-      }
-    }
   }
 }

--- a/packages/apollo-codegen-flow/jest.config.js
+++ b/packages/apollo-codegen-flow/jest.config.js
@@ -1,0 +1,3 @@
+const baseConfig = require("../../jest.base");
+
+module.exports = baseConfig;

--- a/packages/apollo-codegen-flow/package.json
+++ b/packages/apollo-codegen-flow/package.json
@@ -23,31 +23,5 @@
     "change-case": "^3.0.1",
     "common-tags": "^1.5.1",
     "inflected": "^2.0.3"
-  },
-  "jest": {
-    "preset": "ts-jest",
-    "transformIgnorePatterns": [
-      "/node_modules/"
-    ],
-    "testEnvironment": "node",
-    "testMatch": [
-      "**/__tests__/*.(js|ts)"
-    ],
-    "testPathIgnorePatterns": [
-      "<rootDir>/node_modules/",
-      "<rootDir>/lib/",
-      "<rootDir>/test/fixtures/",
-      "<rootDir>/test/test-utils"
-    ],
-    "moduleFileExtensions": [
-      "ts",
-      "js"
-    ],
-    "globals": {
-      "ts-jest": {
-        "tsConfig": "<rootDir>/tsconfig.test.json",
-        "diagnostics": false
-      }
-    }
   }
 }

--- a/packages/apollo-codegen-scala/jest.config.js
+++ b/packages/apollo-codegen-scala/jest.config.js
@@ -1,0 +1,3 @@
+const baseConfig = require("../../jest.base");
+
+module.exports = baseConfig;

--- a/packages/apollo-codegen-scala/package.json
+++ b/packages/apollo-codegen-scala/package.json
@@ -21,31 +21,5 @@
     "change-case": "^3.0.1",
     "common-tags": "^1.5.1",
     "inflected": "^2.0.3"
-  },
-  "jest": {
-    "preset": "ts-jest",
-    "transformIgnorePatterns": [
-      "/node_modules/"
-    ],
-    "testEnvironment": "node",
-    "testMatch": [
-      "**/__tests__/*.(js|ts)"
-    ],
-    "testPathIgnorePatterns": [
-      "<rootDir>/node_modules/",
-      "<rootDir>/lib/",
-      "<rootDir>/test/fixtures/",
-      "<rootDir>/test/test-utils"
-    ],
-    "moduleFileExtensions": [
-      "ts",
-      "js"
-    ],
-    "globals": {
-      "ts-jest": {
-        "tsConfig": "<rootDir>/tsconfig.test.json",
-        "diagnostics": false
-      }
-    }
   }
 }

--- a/packages/apollo-codegen-swift/jest.config.js
+++ b/packages/apollo-codegen-swift/jest.config.js
@@ -1,0 +1,3 @@
+const baseConfig = require("../../jest.base");
+
+module.exports = baseConfig;

--- a/packages/apollo-codegen-swift/package.json
+++ b/packages/apollo-codegen-swift/package.json
@@ -21,31 +21,5 @@
     "change-case": "^3.0.1",
     "common-tags": "^1.5.1",
     "inflected": "^2.0.3"
-  },
-  "jest": {
-    "preset": "ts-jest",
-    "transformIgnorePatterns": [
-      "/node_modules/"
-    ],
-    "testEnvironment": "node",
-    "testMatch": [
-      "**/__tests__/*.(js|ts)"
-    ],
-    "testPathIgnorePatterns": [
-      "<rootDir>/node_modules/",
-      "<rootDir>/lib/",
-      "<rootDir>/test/fixtures/",
-      "<rootDir>/test/test-utils"
-    ],
-    "moduleFileExtensions": [
-      "ts",
-      "js"
-    ],
-    "globals": {
-      "ts-jest": {
-        "tsConfig": "<rootDir>/tsconfig.test.json",
-        "diagnostics": false
-      }
-    }
   }
 }

--- a/packages/apollo-codegen-typescript/jest.config.js
+++ b/packages/apollo-codegen-typescript/jest.config.js
@@ -1,0 +1,3 @@
+const baseConfig = require("../../jest.base");
+
+module.exports = baseConfig;

--- a/packages/apollo-codegen-typescript/package.json
+++ b/packages/apollo-codegen-typescript/package.json
@@ -23,31 +23,5 @@
     "change-case": "^3.0.1",
     "common-tags": "^1.5.1",
     "inflected": "^2.0.3"
-  },
-  "jest": {
-    "preset": "ts-jest",
-    "transformIgnorePatterns": [
-      "/node_modules/"
-    ],
-    "testEnvironment": "node",
-    "testMatch": [
-      "**/__tests__/*.(js|ts)"
-    ],
-    "testPathIgnorePatterns": [
-      "<rootDir>/node_modules/",
-      "<rootDir>/lib/",
-      "<rootDir>/test/fixtures/",
-      "<rootDir>/test/test-utils"
-    ],
-    "moduleFileExtensions": [
-      "ts",
-      "js"
-    ],
-    "globals": {
-      "ts-jest": {
-        "tsConfig": "<rootDir>/tsconfig.test.json",
-        "diagnostics": false
-      }
-    }
   }
 }

--- a/packages/apollo-graphql/jest.config.js
+++ b/packages/apollo-graphql/jest.config.js
@@ -1,0 +1,9 @@
+const baseConfig = require("../../jest.base");
+
+module.exports = {
+  ...baseConfig,
+  testPathIgnorePatterns: [
+    ...baseConfig.testPathIgnorePatterns,
+    "snapshotSerializers"
+  ]
+};

--- a/packages/apollo-graphql/package.json
+++ b/packages/apollo-graphql/package.json
@@ -16,31 +16,5 @@
   },
   "peerDependencies": {
     "graphql": "^14.2.1"
-  },
-  "jest": {
-    "preset": "ts-jest",
-    "transformIgnorePatterns": [
-      "/node_modules/"
-    ],
-    "testEnvironment": "node",
-    "testMatch": [
-      "**/__tests__/*.(js|ts)"
-    ],
-    "testPathIgnorePatterns": [
-      "<rootDir>/node_modules/",
-      "<rootDir>/lib/",
-      "<rootDir>/test/fixtures/",
-      "<rootDir>/test/test-utils"
-    ],
-    "moduleFileExtensions": [
-      "ts",
-      "js"
-    ],
-    "globals": {
-      "ts-jest": {
-        "tsConfig": "<rootDir>/tsconfig.test.json",
-        "diagnostics": false
-      }
-    }
   }
 }

--- a/packages/apollo-graphql/src/schema/__tests__/snapshotSerializers/astSerializer.ts
+++ b/packages/apollo-graphql/src/schema/__tests__/snapshotSerializers/astSerializer.ts
@@ -1,19 +1,12 @@
 import { ASTNode, print } from "graphql";
-import { Plugin, Config, Refs, Printer } from "pretty-format";
+import { Plugin, Config } from "pretty-format";
 
 export = (({
   test(value: any) {
     return value && typeof value.kind === "string";
   },
 
-  serialize(
-    value: ASTNode,
-    config: Config,
-    indentation: string,
-    depth: number,
-    refs: Refs,
-    printer: Printer
-  ): string {
+  serialize(value: ASTNode, _config: Config, indentation: string): string {
     return (
       indentation +
       print(value)

--- a/packages/apollo-graphql/src/schema/__tests__/snapshotSerializers/graphQLTypeSerializer.ts
+++ b/packages/apollo-graphql/src/schema/__tests__/snapshotSerializers/graphQLTypeSerializer.ts
@@ -1,19 +1,12 @@
 import { isNamedType, GraphQLNamedType, printType } from "graphql";
-import { Plugin, Config, Refs, Printer } from "pretty-format";
+import { Plugin } from "pretty-format";
 
 export = (({
   test(value: any) {
     return value && isNamedType(value);
   },
 
-  serialize(
-    value: GraphQLNamedType,
-    config: Config,
-    indentation: string,
-    depth: number,
-    refs: Refs,
-    printer: Printer
-  ): string {
+  serialize(value: GraphQLNamedType): string {
     return printType(value);
   }
 } as Plugin) as unknown) as jest.SnapshotSerializerPlugin;

--- a/packages/apollo-graphql/src/schema/__tests__/snapshotSerializers/selectionSetSerializer.ts
+++ b/packages/apollo-graphql/src/schema/__tests__/snapshotSerializers/selectionSetSerializer.ts
@@ -1,5 +1,5 @@
 import { print, SelectionNode, isSelectionNode } from "graphql";
-import { Plugin, Config, Refs, Printer } from "pretty-format";
+import { Plugin } from "pretty-format";
 
 export = (({
   test(value: any) {
@@ -8,14 +8,7 @@ export = (({
     );
   },
 
-  serialize(
-    value: SelectionNode[],
-    config: Config,
-    indentation: string,
-    depth: number,
-    refs: Refs,
-    printer: Printer
-  ): string {
+  serialize(value: SelectionNode[]): string {
     return String(print(value)).replace(",", "\n");
   }
 } as Plugin) as unknown) as jest.SnapshotSerializerPlugin;

--- a/packages/apollo-language-server/jest.config.js
+++ b/packages/apollo-language-server/jest.config.js
@@ -1,0 +1,6 @@
+const baseConfig = require("../../jest.base");
+
+module.exports = {
+  ...baseConfig,
+  setupFiles: ["apollo-env"]
+};

--- a/packages/apollo-language-server/package.json
+++ b/packages/apollo-language-server/package.json
@@ -42,34 +42,5 @@
     "moment": "^2.24.0",
     "vscode-languageserver": "^5.1.0",
     "vscode-uri": "1.0.6"
-  },
-  "jest": {
-    "preset": "ts-jest",
-    "transformIgnorePatterns": [
-      "/node_modules/"
-    ],
-    "setupFiles": [
-      "apollo-env"
-    ],
-    "testEnvironment": "node",
-    "testMatch": [
-      "**/__tests__/*.(js|ts)"
-    ],
-    "testPathIgnorePatterns": [
-      "<rootDir>/node_modules/",
-      "<rootDir>/lib/",
-      "<rootDir>/test/fixtures/",
-      "<rootDir>/test/test-utils"
-    ],
-    "moduleFileExtensions": [
-      "ts",
-      "js"
-    ],
-    "globals": {
-      "ts-jest": {
-        "tsConfig": "<rootDir>/tsconfig.test.json",
-        "diagnostics": false
-      }
-    }
   }
 }

--- a/packages/apollo-tools/jest.config.js
+++ b/packages/apollo-tools/jest.config.js
@@ -2,9 +2,5 @@ const baseConfig = require("../../jest.base");
 
 module.exports = {
   ...baseConfig,
-  setupFiles: ["apollo-env"],
-  testPathIgnorePatterns: [
-    ...baseConfig.testPathIgnorePatterns,
-    "snapshotSerializers"
-  ]
+  setupFiles: ["apollo-env"]
 };

--- a/packages/apollo-tools/jest.config.js
+++ b/packages/apollo-tools/jest.config.js
@@ -1,0 +1,10 @@
+const baseConfig = require("../../jest.base");
+
+module.exports = {
+  ...baseConfig,
+  setupFiles: ["apollo-env"],
+  testPathIgnorePatterns: [
+    ...baseConfig.testPathIgnorePatterns,
+    "snapshotSerializers"
+  ]
+};

--- a/packages/apollo-tools/package.json
+++ b/packages/apollo-tools/package.json
@@ -17,35 +17,5 @@
   },
   "dependencies": {
     "apollo-env": "file:../apollo-env"
-  },
-  "jest": {
-    "preset": "ts-jest",
-    "testEnvironment": "node",
-    "testMatch": null,
-    "testRegex": "/__tests__/.*\\.test\\.(js|ts)$",
-    "testPathIgnorePatterns": [
-      "<rootDir>/node_modules/",
-      "<rootDir>/lib/"
-    ],
-    "moduleFileExtensions": [
-      "ts",
-      "js"
-    ],
-    "transformIgnorePatterns": [
-      "/node_modules/"
-    ],
-    "setupFiles": [
-      "apollo-env"
-    ],
-    "snapshotSerializers": [
-      "<rootDir>/src/__tests__/snapshotSerializers/astSerializer.ts",
-      "<rootDir>/src/__tests__/snapshotSerializers/graphQLTypeSerializer.ts"
-    ],
-    "globals": {
-      "ts-jest": {
-        "tsConfig": "<rootDir>/tsconfig.test.json",
-        "diagnostics": true
-      }
-    }
   }
 }

--- a/packages/apollo-tools/src/__tests__/buildServiceDefinition.test.ts
+++ b/packages/apollo-tools/src/__tests__/buildServiceDefinition.test.ts
@@ -1,6 +1,10 @@
 import gql from "graphql-tag";
 import { buildServiceDefinition } from "../buildServiceDefinition";
 import { GraphQLObjectType } from "graphql";
+import { astSerializer, graphQLTypeSerializer } from "./snapshotSerializers";
+
+expect.addSnapshotSerializer(astSerializer);
+expect.addSnapshotSerializer(graphQLTypeSerializer);
 
 describe("buildServiceDefinition", () => {
   describe(`type definitions`, () => {

--- a/packages/apollo-tools/src/__tests__/snapshotSerializers/astSerializer.ts
+++ b/packages/apollo-tools/src/__tests__/snapshotSerializers/astSerializer.ts
@@ -1,7 +1,7 @@
 import { ASTNode, print } from "graphql";
-import { Plugin, Config, Refs, Printer } from "pretty-format";
+import { Plugin, Config, Refs } from "pretty-format";
 
-export = {
+export default {
   test(value: any) {
     return value && typeof value.kind === "string";
   },
@@ -12,7 +12,7 @@ export = {
     indentation: string,
     depth: number,
     refs: Refs,
-    printer: Printer
+    printer: any
   ): string {
     return (
       indentation +

--- a/packages/apollo-tools/src/__tests__/snapshotSerializers/graphQLTypeSerializer.ts
+++ b/packages/apollo-tools/src/__tests__/snapshotSerializers/graphQLTypeSerializer.ts
@@ -1,7 +1,7 @@
 import { isNamedType, GraphQLNamedType, printType } from "graphql";
-import { Plugin, Config, Refs, Printer } from "pretty-format";
+import { Plugin, Config, Refs } from "pretty-format";
 
-export = {
+export default {
   test(value: any) {
     return value && isNamedType(value);
   },
@@ -12,7 +12,7 @@ export = {
     indentation: string,
     depth: number,
     refs: Refs,
-    printer: Printer
+    printer: any
   ): string {
     return printType(value);
   }

--- a/packages/apollo-tools/src/__tests__/snapshotSerializers/index.ts
+++ b/packages/apollo-tools/src/__tests__/snapshotSerializers/index.ts
@@ -1,0 +1,13 @@
+export { default as astSerializer } from "./astSerializer";
+export { default as graphQLTypeSerializer } from "./graphQLTypeSerializer";
+
+declare global {
+  namespace jest {
+    interface Expect {
+      /**
+       * Adds a module to format application-specific data structures for serialization.
+       */
+      addSnapshotSerializer(serializer: import("pretty-format").Plugin): void;
+    }
+  }
+}

--- a/packages/apollo-tools/tsconfig.json
+++ b/packages/apollo-tools/tsconfig.json
@@ -2,8 +2,7 @@
   "extends": "../../tsconfig.base",
   "compilerOptions": {
     "rootDir": "./src",
-    "outDir": "./lib",
-    "esModuleInterop": true
+    "outDir": "./lib"
   },
   "include": ["./src/**/*"],
   "exclude": ["**/__tests__/*", "**/__mocks__/*"],

--- a/packages/apollo-tools/tsconfig.json
+++ b/packages/apollo-tools/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.base",
   "compilerOptions": {
     "rootDir": "./src",
-    "outDir": "./lib"
+    "outDir": "./lib",
+    "esModuleInterop": true
   },
   "include": ["./src/**/*"],
   "exclude": ["**/__tests__/*", "**/__mocks__/*"],

--- a/packages/apollo/jest.config.js
+++ b/packages/apollo/jest.config.js
@@ -1,0 +1,6 @@
+const baseConfig = require("../../jest.base");
+
+module.exports = {
+  ...baseConfig,
+  setupFiles: ["apollo-env"]
+};

--- a/packages/apollo/package.json
+++ b/packages/apollo/package.json
@@ -78,35 +78,5 @@
       "@oclif/plugin-warn-if-update-available"
     ],
     "repositoryPrefix": "<%- repo %>/blob/master/packages/apollo/<%- commandPath %>"
-  },
-  "jest": {
-    "preset": "ts-jest",
-    "transformIgnorePatterns": [
-      "/node_modules/"
-    ],
-    "setupFiles": [
-      "apollo-env"
-    ],
-    "testMatch": null,
-    "testRegex": "(/__tests__/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$",
-    "testPathIgnorePatterns": [
-      "node_modules",
-      "lib"
-    ],
-    "moduleFileExtensions": [
-      "ts",
-      "tsx",
-      "js",
-      "jsx",
-      "json",
-      "node"
-    ],
-    "testEnvironment": "node",
-    "globals": {
-      "ts-jest": {
-        "tsConfig": "<rootDir>/tsconfig.test.json",
-        "diagnostics": false
-      }
-    }
   }
 }


### PR DESCRIPTION
Semi-dependent upon #1611, though this could be split out to be its own set of changes independent of said PR.

This PR introduces a base Jest config from which all projects extend. It also simplifies the current config, as many options that were specified within each package were actually just the defaults that Jest provides.

This approach is a boon for maintainability of the configuration of this repo, and aligns with the approach that [`apollo-server`](https://github.com/apollographql/apollo-server/blob/master/jest.config.base.js) has taken.

<!--
  Thanks for filing a pull request on Apollo Tooling!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [ ] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [ ] Make sure all of the significant new logic is covered by tests
- [ ] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests and linter rules pass

\*Make sure changelog entries note which project(s) has been affected. See older entries for examples on what this looks like.
