### PR TITLE
Support User Tokens

### DIFF
--- a/apollo.config.js
+++ b/apollo.config.js
@@ -5,6 +5,13 @@ module.exports = {
     includes: ["./packages/apollo-language-server/**/*.ts"],
     excludes: ["**/*.test.ts", "**/__tests__/*"]
   },
+  // service: {
+  //   name: "engine@master",
+  //   endpoint: {
+  //     url: "https://engine-staging-graphql.apollographql.com/api/graphql"
+  //   },
+  //   skipSSLValidation: true
+  // },
   engine: {
     frontend: "https://engine-staging.apollographql.com",
     endpoint: "https://engine-staging-graphql.apollographql.com/api/graphql"

--- a/apollo.config.js
+++ b/apollo.config.js
@@ -6,7 +6,7 @@ module.exports = {
     excludes: ["**/*.test.ts", "**/__tests__/*"]
   },
   // service: {
-  //   name: "engine@master",
+  //   name: "engine@staging",
   //   endpoint: {
   //     url: "https://engine-staging-graphql.apollographql.com/api/graphql"
   //   },

--- a/packages/apollo-codegen-core/src/loading.ts
+++ b/packages/apollo-codegen-core/src/loading.ts
@@ -82,7 +82,7 @@ function extractDocumentsWithAST(
   // isolate the template literals tagged with gql
   astTypes.visit(ast, {
     visitTaggedTemplateExpression(path: any) {
-      const tag = path.value.tag;
+      const tag = path.value.serviceGraphVariant;
       if (tag.name === tagName) {
         // This currently ignores the anti-pattern of including an interpolated
         // string as anything other than a fragment definition, for example a

--- a/packages/apollo-codegen-core/src/loading.ts
+++ b/packages/apollo-codegen-core/src/loading.ts
@@ -82,7 +82,7 @@ function extractDocumentsWithAST(
   // isolate the template literals tagged with gql
   astTypes.visit(ast, {
     visitTaggedTemplateExpression(path: any) {
-      const tag = path.value.serviceGraphVariant;
+      const tag = path.value.tag;
       if (tag.name === tagName) {
         // This currently ignores the anti-pattern of including an interpolated
         // string as anything other than a fragment definition, for example a

--- a/packages/apollo-language-server/src/config/__tests__/config.ts
+++ b/packages/apollo-language-server/src/config/__tests__/config.ts
@@ -58,18 +58,18 @@ describe("ApolloConfig", () => {
   describe("tag", () => {
     it("gets default tag when none is set", () => {
       const config = new ApolloConfig({ client: { service: "hai" } });
-      expect(config.tag).toEqual("current");
+      expect(config.serviceGraphVariant).toEqual("current");
     });
 
     it("gets tag from service specifier", () => {
       const config = new ApolloConfig({ client: { service: "hai@master" } });
-      expect(config.tag).toEqual("master");
+      expect(config.serviceGraphVariant).toEqual("master");
     });
 
     it("can set and override tags", () => {
       const config = new ApolloConfig({ client: { service: "hai@master" } });
-      config.tag = "new";
-      expect(config.tag).toEqual("new");
+      config.serviceGraphVariant = "new";
+      expect(config.serviceGraphVariant).toEqual("new");
     });
   });
 

--- a/packages/apollo-language-server/src/config/__tests__/config.ts
+++ b/packages/apollo-language-server/src/config/__tests__/config.ts
@@ -7,7 +7,7 @@ import {
 import URI from "vscode-uri";
 import { DeepPartial } from "apollo-env";
 
-function createConfig(raw: DeepPartial<ApolloConfigFormat>) {
+export function createConfig(raw: DeepPartial<ApolloConfigFormat>) {
   return loadConfigWithDefaults(
     {
       config: raw

--- a/packages/apollo-language-server/src/config/__tests__/loadConfig.ts
+++ b/packages/apollo-language-server/src/config/__tests__/loadConfig.ts
@@ -62,7 +62,7 @@ describe("loadConfig", () => {
   });
 
   describe("finding files", () => {
-    it("loads with client defaults from different dir", async () => {
+    it.only("loads with client defaults from different dir", async () => {
       writeFilesToDir(dir, {
         "my.config.js": `
           module.exports = {
@@ -77,7 +77,7 @@ describe("loadConfig", () => {
         configPath: dirPath,
         configFileName: "my.config.js"
       });
-      expect(config.rawConfig).toMatchInlineSnapshot(`
+      expect(config && config.rawConfig).toMatchInlineSnapshot(`
         Object {
           "client": Object {
             "addTypename": true,
@@ -89,13 +89,18 @@ describe("loadConfig", () => {
               "client",
               "rest",
             ],
+            "endpoint": Object {
+              "url": "http://localhost:4000/graphql",
+            },
             "excludes": Array [
               "**/node_modules",
               "**/__tests__",
             ],
+            "graphId": "hello",
             "includes": Array [
               "src/**/*.{ts,tsx,js,jsx,graphql,gql}",
             ],
+            "name": "hello@current",
             "service": "hello",
             "statsWindow": Object {
               "from": -86400,
@@ -104,8 +109,38 @@ describe("loadConfig", () => {
             "tagName": "gql",
           },
           "engine": Object {
+            "apiKey": undefined,
             "endpoint": "https://engine-graphql.apollographql.com/api/graphql",
             "frontend": "https://engine.apollographql.com",
+          },
+          "service": Object {
+            "addTypename": true,
+            "clientOnlyDirectives": Array [
+              "connection",
+              "type",
+            ],
+            "clientSchemaDirectives": Array [
+              "client",
+              "rest",
+            ],
+            "endpoint": Object {
+              "url": "http://localhost:4000/graphql",
+            },
+            "excludes": Array [
+              "**/node_modules",
+              "**/__tests__",
+            ],
+            "graphId": "hello",
+            "includes": Array [
+              "src/**/*.{ts,tsx,js,jsx,graphql,gql}",
+            ],
+            "name": "hello@current",
+            "service": "hello",
+            "statsWindow": Object {
+              "from": -86400,
+              "to": -0,
+            },
+            "tagName": "gql",
           },
         }
       `);

--- a/packages/apollo-language-server/src/config/__tests__/utils.ts
+++ b/packages/apollo-language-server/src/config/__tests__/utils.ts
@@ -1,8 +1,8 @@
 import {
   ApolloConfig,
   ApolloConfigFormat,
-  getServiceFromKey,
-  getGraphId,
+  getGraphIdFromKey,
+  getGraphInfo,
   isClientConfig,
   isLocalServiceConfig,
   isServiceConfig,
@@ -11,22 +11,22 @@ import {
 
 describe("getServiceFromKey", () => {
   it("returns undefined with no provided key", () => {
-    expect(getServiceFromKey()).toBeUndefined();
+    expect(getGraphIdFromKey()).toBeUndefined();
   });
 
   it("returns service name from service api key", () => {
     const key = "service:bob-123:489fhseo4";
-    expect(getServiceFromKey(key)).toEqual("bob-123");
+    expect(getGraphIdFromKey(key)).toEqual("bob-123");
   });
 
   it("returns nothing if key is not a service key", () => {
     const key = "not-a-service:bob-123:489fhseo4";
-    expect(getServiceFromKey(key)).toBeUndefined();
+    expect(getGraphIdFromKey(key)).toBeUndefined();
   });
 
   it("returns nothing if key is malformed", () => {
     const key = "service/bob-123:489fhseo4";
-    expect(getServiceFromKey(key)).toBeUndefined();
+    expect(getGraphIdFromKey(key)).toBeUndefined();
   });
 });
 
@@ -36,25 +36,25 @@ describe("getServiceName", () => {
       const rawConfig: ApolloConfigFormat = {
         client: { service: "my-service" }
       };
-      expect(getGraphId(rawConfig)).toEqual("my-service");
+      expect(getGraphInfo(rawConfig)).toEqual("my-service");
 
       const rawConfigWithTag: ApolloConfigFormat = {
         client: { service: "my-service@master" }
       };
-      expect(getGraphId(rawConfigWithTag)).toEqual("my-service");
+      expect(getGraphInfo(rawConfigWithTag)).toEqual("my-service");
     });
 
     it("finds service name when client.service is an object", () => {
       const rawConfig: ApolloConfigFormat = {
         client: { service: { name: "my-service" } }
       };
-      expect(getGraphId(rawConfig)).toEqual("my-service");
+      expect(getGraphInfo(rawConfig)).toEqual("my-service");
     });
   });
   describe("service config", () => {
     it("finds service name from raw service config", () => {
       const rawConfig: ApolloConfigFormat = { service: { name: "my-service" } };
-      expect(getGraphId(rawConfig)).toEqual("my-service");
+      expect(getGraphInfo(rawConfig)).toEqual("my-service");
     });
   });
 });

--- a/packages/apollo-language-server/src/config/__tests__/utils.ts
+++ b/packages/apollo-language-server/src/config/__tests__/utils.ts
@@ -8,6 +8,7 @@ import {
   isServiceConfig,
   parseServiceSpecifier
 } from "../";
+import { createConfig } from "./config";
 
 describe("getServiceFromKey", () => {
   it("returns undefined with no provided key", () => {
@@ -33,35 +34,39 @@ describe("getServiceFromKey", () => {
 describe("getServiceName", () => {
   describe("client config", () => {
     it("finds service name when client.service is a string", () => {
-      const rawConfig: ApolloConfigFormat = {
+      const rawConfig: ApolloConfigFormat = createConfig({
         client: { service: "my-service" }
-      };
-      expect(getGraphInfo(rawConfig)).toEqual("my-service");
+      });
+      expect(getGraphInfo(rawConfig).graphId).toEqual("my-service");
 
-      const rawConfigWithTag: ApolloConfigFormat = {
+      const rawConfigWithTag: ApolloConfigFormat = createConfig({
         client: { service: "my-service@master" }
-      };
-      expect(getGraphInfo(rawConfigWithTag)).toEqual("my-service");
+      });
+      expect(getGraphInfo(rawConfigWithTag).graphId).toEqual("my-service");
     });
 
     it("finds service name when client.service is an object", () => {
-      const rawConfig: ApolloConfigFormat = {
+      const rawConfig: ApolloConfigFormat = createConfig({
         client: { service: { name: "my-service" } }
-      };
-      expect(getGraphInfo(rawConfig)).toEqual("my-service");
+      });
+      expect(getGraphInfo(rawConfig).graphId).toEqual("my-service");
     });
   });
   describe("service config", () => {
     it("finds service name from raw service config", () => {
-      const rawConfig: ApolloConfigFormat = { service: { name: "my-service" } };
-      expect(getGraphInfo(rawConfig)).toEqual("my-service");
+      const rawConfig: ApolloConfigFormat = createConfig({
+        service: { name: "my-service" }
+      });
+      expect(getGraphInfo(rawConfig).graphId).toEqual("my-service");
     });
   });
 });
 
 describe("isClientConfig", () => {
   it("identifies client config properly", () => {
-    const config = new ApolloConfig({ client: { service: "hello" } });
+    const config = new ApolloConfig(
+      createConfig({ client: { service: "hello" } })
+    );
     expect(isClientConfig(config)).toBeTruthy();
   });
 });
@@ -75,7 +80,9 @@ describe("isLocalServiceConfig", () => {
 
 describe("isServiceConfig", () => {
   it("identifies service config properly", () => {
-    const config = new ApolloConfig({ service: "hello" });
+    const config = new ApolloConfig(
+      createConfig({ service: { name: "hello" } })
+    );
     expect(isServiceConfig(config)).toBeTruthy();
   });
 });

--- a/packages/apollo-language-server/src/config/__tests__/utils.ts
+++ b/packages/apollo-language-server/src/config/__tests__/utils.ts
@@ -2,7 +2,7 @@ import {
   ApolloConfig,
   ApolloConfigFormat,
   getServiceFromKey,
-  getServiceName,
+  getGraphId,
   isClientConfig,
   isLocalServiceConfig,
   isServiceConfig,
@@ -36,25 +36,25 @@ describe("getServiceName", () => {
       const rawConfig: ApolloConfigFormat = {
         client: { service: "my-service" }
       };
-      expect(getServiceName(rawConfig)).toEqual("my-service");
+      expect(getGraphId(rawConfig)).toEqual("my-service");
 
       const rawConfigWithTag: ApolloConfigFormat = {
         client: { service: "my-service@master" }
       };
-      expect(getServiceName(rawConfigWithTag)).toEqual("my-service");
+      expect(getGraphId(rawConfigWithTag)).toEqual("my-service");
     });
 
     it("finds service name when client.service is an object", () => {
       const rawConfig: ApolloConfigFormat = {
         client: { service: { name: "my-service" } }
       };
-      expect(getServiceName(rawConfig)).toEqual("my-service");
+      expect(getGraphId(rawConfig)).toEqual("my-service");
     });
   });
   describe("service config", () => {
     it("finds service name from raw service config", () => {
       const rawConfig: ApolloConfigFormat = { service: { name: "my-service" } };
-      expect(getServiceName(rawConfig)).toEqual("my-service");
+      expect(getGraphId(rawConfig)).toEqual("my-service");
     });
   });
 });

--- a/packages/apollo-language-server/src/config/config.ts
+++ b/packages/apollo-language-server/src/config/config.ts
@@ -3,7 +3,7 @@ import merge from "lodash.merge";
 import { ServiceID, ServiceSpecifier, ClientID } from "../engine";
 import URI from "vscode-uri";
 import { WithRequired } from "apollo-env";
-import { getServiceName, parseServiceSpecifier } from "./utils";
+import { getGraphId, parseServiceSpecifier } from "./utils";
 import { ValidationRule } from "graphql/validation/ValidationContext";
 
 export interface EngineStatsWindow {
@@ -132,7 +132,7 @@ export class ApolloConfig {
   public isClient: boolean;
   public isService: boolean;
   public engine: EngineConfig;
-  public name?: string;
+  public graphId?: string;
   public service?: ServiceConfigFormat;
   public client?: ClientConfigFormat;
   private _tag?: string;
@@ -141,7 +141,7 @@ export class ApolloConfig {
     this.isService = !!rawConfig.service;
     this.isClient = !!rawConfig.client;
     this.engine = rawConfig.engine!;
-    this.name = getServiceName(rawConfig);
+    this.graphId = getGraphId(rawConfig);
     this.client = rawConfig.client;
     this.service = rawConfig.service;
   }

--- a/packages/apollo-language-server/src/config/config.ts
+++ b/packages/apollo-language-server/src/config/config.ts
@@ -200,6 +200,7 @@ export class ApolloConfig {
   }
 
   // this type needs to be an "EveryKeyIsOptionalApolloConfig"
+  // TODO: delete this function and migrate caller to use merge directly
   public setDefaults({ client, engine, service }: any): void {
     const config = merge(this.rawConfig, { client, engine, service });
     this.rawConfig = config;
@@ -209,6 +210,7 @@ export class ApolloConfig {
   }
 }
 
+// TODO: these types can probably be cleaned up
 export class ClientProjectConfig extends ApolloConfig {
   public client!: ClientConfig;
 }

--- a/packages/apollo-language-server/src/config/config.ts
+++ b/packages/apollo-language-server/src/config/config.ts
@@ -146,7 +146,7 @@ export class ApolloConfig {
     this.isClient = !!rawConfig.client;
     this.engine = rawConfig.engine!;
     const graphInfo = getGraphInfo(rawConfig);
-    if (graphInfo) this.graphId = graphInfo.graphId;
+    if (graphInfo && graphInfo.graphId) this.graphId = graphInfo.graphId;
     this.client = rawConfig.client || DefaultClientConfig;
     this.service = rawConfig.service || DefaultServiceConfig;
   }

--- a/packages/apollo-language-server/src/config/config.ts
+++ b/packages/apollo-language-server/src/config/config.ts
@@ -173,8 +173,8 @@ export class ApolloConfig {
     if (this._serviceGraphVariant) return this._serviceGraphVariant;
     let tag: string = "current";
     if (this.service && typeof this.service.name === "string") {
-      const specifierTag = parseServiceSpecifier(this.client
-        .service as ServiceSpecifier)[1];
+      const specifierTag = parseServiceSpecifier(this.service
+        .name as ServiceSpecifier)[1];
       if (specifierTag) tag = specifierTag;
     }
     return tag;

--- a/packages/apollo-language-server/src/config/config.ts
+++ b/packages/apollo-language-server/src/config/config.ts
@@ -138,7 +138,10 @@ export class ApolloConfig {
   private _serviceGraphVariant?: string;
   private _clientGraphVariant?: string;
 
-  constructor(public rawConfig: ApolloConfigFormat, public configURI?: URI) {
+  constructor(
+    public rawConfig: Partial<ApolloConfigFormat>,
+    public configURI?: URI
+  ) {
     this.isService = !!rawConfig.service;
     this.isClient = !!rawConfig.client;
     this.engine = rawConfig.engine!;

--- a/packages/apollo-language-server/src/config/config.ts
+++ b/packages/apollo-language-server/src/config/config.ts
@@ -190,6 +190,7 @@ export class ApolloConfig {
   get clientGraphVariant(): string {
     if (this._clientGraphVariant) return this._clientGraphVariant;
     let tag: string = "current";
+    const foo = getGraphInfo(this);
     if (this.client && typeof this.client.service === "string") {
       const specifierTag = parseServiceSpecifier(this.client
         .service as ServiceSpecifier)[1];

--- a/packages/apollo-language-server/src/config/loadConfig.ts
+++ b/packages/apollo-language-server/src/config/loadConfig.ts
@@ -15,6 +15,7 @@ import {
 import { getGraphInfo, getGraphIdFromKey, GraphInfo } from "./utils";
 import URI from "vscode-uri";
 import { Debug } from "../utilities";
+import { load } from "nock";
 
 // config settings
 const MODULE_NAME = "apollo";
@@ -131,10 +132,15 @@ export async function loadConfig({
   const graphInfo = getGraphInfo(
     loadedConfig ? loadedConfig.config : undefined
   );
-  if (graphIdFromKey && graphInfo && graphInfo.graphId !== graphIdFromKey) {
+
+  if (
+    graphIdFromKey &&
+    graphInfo.graphId &&
+    graphInfo.graphId !== graphIdFromKey
+  ) {
     throw new Error(
-      "Graph specified in configuration does not match environment key. Please provide a matching " +
-        "graph-level API token or use a personal user token."
+      `Graph specified in configuration does not match environment key. Please provide a matching " +
+        "graph-level API token or use a personal user token.\n graphId: { key: ${graphIdFromKey}, config: ${graphInfo.graphId} }`
     );
   }
   const graphId: string | undefined = graphInfo.graphId || graphIdFromKey;

--- a/packages/apollo-language-server/src/config/loadConfig.ts
+++ b/packages/apollo-language-server/src/config/loadConfig.ts
@@ -70,9 +70,6 @@ export function loadConfigWithDefaults(
   configPath?: string,
   apiKey?: string
 ): ApolloConfig {
-  if (!graphInfo.graphId) {
-    console.warn("Graph is not specified from either Apollo config or env.");
-  }
   const graphId = graphInfo.graphId;
 
   const configWithDefaults = {

--- a/packages/apollo-language-server/src/config/loadConfig.ts
+++ b/packages/apollo-language-server/src/config/loadConfig.ts
@@ -187,6 +187,10 @@ export async function loadConfig({
     loadedConfig ? loadedConfig.config : undefined
   );
 
+  if (!graphInfo.graphId && graphIdFromKey) {
+    graphInfo.graphId = graphIdFromKey;
+  }
+
   if (
     graphIdFromKey &&
     graphInfo.graphId &&

--- a/packages/apollo-language-server/src/config/utils.ts
+++ b/packages/apollo-language-server/src/config/utils.ts
@@ -31,8 +31,14 @@ export function getServiceFromKey(key?: string) {
   return;
 }
 
-export function getServiceName(config: ApolloConfigFormat) {
-  if (config.service) return config.service.name;
+export function getGraphId(config: ApolloConfigFormat) {
+  if (config.service && config.service.name) {
+    if (config.service.name.indexOf("@") > 0) {
+      return parseServiceSpecifier(config.service.name)[0];
+    } else {
+      return config.service.name;
+    }
+  }
   if (config.client) {
     if (typeof config.client.service === "string") {
       return parseServiceSpecifier(config.client

--- a/packages/apollo-language-server/src/config/utils.ts
+++ b/packages/apollo-language-server/src/config/utils.ts
@@ -77,7 +77,7 @@ export function getGraphInfo(config?: ApolloConfigFormat): GraphInfo {
     return { clientGraphVariant, serviceGraphVariant };
   } else {
     return {
-      graphId: serviceGraphId,
+      graphId: serviceGraphId || clientGraphId,
       serviceGraphVariant,
       clientGraphVariant
     };

--- a/packages/apollo-language-server/src/config/utils.ts
+++ b/packages/apollo-language-server/src/config/utils.ts
@@ -46,17 +46,18 @@ export function getGraphInfo(
   config?: DeepPartial<ApolloConfigFormat>
 ): GraphInfo {
   let serviceGraphId: string | undefined, clientGraphId: string | undefined;
-  let serviceGraphVariant = "current";
-  let clientGraphVariant = "current";
+  const defaultGraphVariant = "current";
   if (!config) {
     return {
-      serviceGraphVariant,
-      clientGraphVariant
+      serviceGraphVariant: defaultGraphVariant,
+      clientGraphVariant: defaultGraphVariant
     };
   }
+  let serviceGraphVariant;
+  let clientGraphVariant;
   if (config.service && config.service.name) {
     if (config.service.name.indexOf("@") > 0) {
-      [serviceGraphId, serviceGraphVariant = "current"] = parseServiceSpecifier(
+      [serviceGraphId, serviceGraphVariant] = parseServiceSpecifier(
         config.service.name
       );
     } else {
@@ -65,13 +66,20 @@ export function getGraphInfo(
   }
   if (config.client) {
     if (typeof config.client.service === "string") {
-      [clientGraphId, clientGraphVariant = "current"] = parseServiceSpecifier(
+      [clientGraphId, clientGraphVariant] = parseServiceSpecifier(
         config.client.service
       );
     } else {
       clientGraphId = config.client.service && config.client.service.name;
     }
   }
+
+  // If variant is not set, fall back to other project or default
+  clientGraphVariant =
+    clientGraphVariant || serviceGraphVariant || defaultGraphVariant;
+  serviceGraphVariant =
+    serviceGraphVariant || clientGraphVariant || defaultGraphVariant;
+
   if (serviceGraphId && clientGraphId && serviceGraphId !== clientGraphId) {
     throw new Error(
       `Unsupported configuration: service and client configs must refer to the same graph.\nservice:${serviceGraphId}, client:${clientGraphId}`

--- a/packages/apollo-language-server/src/config/utils.ts
+++ b/packages/apollo-language-server/src/config/utils.ts
@@ -7,6 +7,7 @@ import {
   ServiceProjectConfig
 } from "./config";
 import { ServiceIDAndTag, ServiceSpecifier } from "../engine";
+import { DeepPartial } from "apollo-env";
 
 export function isClientConfig(
   config: ApolloConfig
@@ -41,7 +42,9 @@ export interface GraphInfo {
   clientGraphVariant: string;
 }
 
-export function getGraphInfo(config?: ApolloConfigFormat): GraphInfo {
+export function getGraphInfo(
+  config?: DeepPartial<ApolloConfigFormat>
+): GraphInfo {
   let serviceGraphId: string | undefined, clientGraphId: string | undefined;
   let serviceGraphVariant = "current";
   let clientGraphVariant = "current";

--- a/packages/apollo-language-server/src/engine/index.ts
+++ b/packages/apollo-language-server/src/engine/index.ts
@@ -1,5 +1,5 @@
 import { GraphQLDataSource } from "./GraphQLDataSource";
-import { DefaultEngineConfig, getServiceFromKey } from "../config";
+import { DefaultEngineConfig, getGraphIdFromKey } from "../config";
 import { CHECK_SCHEMA } from "./operations/checkSchema";
 import { UPLOAD_SCHEMA } from "./operations/uploadSchema";
 import { VALIDATE_OPERATIONS } from "./operations/validateOperations";
@@ -93,7 +93,7 @@ export class ApolloEngineClient extends GraphQLDataSource {
 
       if (data && !data.service) {
         throw new Error(
-          noServiceError(getServiceFromKey(this.engineKey), this.baseURL)
+          noServiceError(getGraphIdFromKey(this.engineKey), this.baseURL)
         );
       }
 
@@ -116,7 +116,7 @@ export class ApolloEngineClient extends GraphQLDataSource {
 
       if (data && !data.service) {
         throw new Error(
-          noServiceError(getServiceFromKey(this.engineKey), this.baseURL)
+          noServiceError(getGraphIdFromKey(this.engineKey), this.baseURL)
         );
       }
 
@@ -139,7 +139,7 @@ export class ApolloEngineClient extends GraphQLDataSource {
 
       if (data && !data.service) {
         throw new Error(
-          noServiceError(getServiceFromKey(this.engineKey), this.baseURL)
+          noServiceError(getGraphIdFromKey(this.engineKey), this.baseURL)
         );
       }
 
@@ -164,7 +164,7 @@ export class ApolloEngineClient extends GraphQLDataSource {
 
       if (data && !data.service) {
         throw new Error(
-          noServiceError(getServiceFromKey(this.engineKey), this.baseURL)
+          noServiceError(getGraphIdFromKey(this.engineKey), this.baseURL)
         );
       }
 
@@ -189,7 +189,7 @@ export class ApolloEngineClient extends GraphQLDataSource {
 
       if (data && !data.service) {
         throw new Error(
-          noServiceError(getServiceFromKey(this.engineKey), this.baseURL)
+          noServiceError(getGraphIdFromKey(this.engineKey), this.baseURL)
         );
       }
 
@@ -231,7 +231,7 @@ export class ApolloEngineClient extends GraphQLDataSource {
 
       if (data && !data.service) {
         throw new Error(
-          noServiceError(getServiceFromKey(this.engineKey), this.baseURL)
+          noServiceError(getGraphIdFromKey(this.engineKey), this.baseURL)
         );
       }
 
@@ -255,7 +255,7 @@ export class ApolloEngineClient extends GraphQLDataSource {
 
       if (data && !data.service) {
         throw new Error(
-          noServiceError(getServiceFromKey(this.engineKey), this.baseURL)
+          noServiceError(getGraphIdFromKey(this.engineKey), this.baseURL)
         );
       }
 

--- a/packages/apollo-language-server/src/errors/__tests__/NoMissingClientDirectives.test.ts
+++ b/packages/apollo-language-server/src/errors/__tests__/NoMissingClientDirectives.test.ts
@@ -181,7 +181,8 @@ describe("client state", () => {
     const project = new GraphQLClientProject({
       config,
       loadingHandler: new MockLoadingHandler(),
-      rootURI
+      rootURI,
+      loadSchemaOnStartup: true
     });
 
     const errors = Object.create(null);

--- a/packages/apollo-language-server/src/errors/__tests__/NoMissingClientDirectives.test.ts
+++ b/packages/apollo-language-server/src/errors/__tests__/NoMissingClientDirectives.test.ts
@@ -5,7 +5,7 @@ import { basename } from "path";
 
 import { vol } from "memfs";
 import { LoadingHandler } from "../../loadingHandler";
-import { ApolloConfig, ClientConfig } from "../../config";
+import { ApolloConfig, ClientProjectConfig } from "../../config";
 import URI from "vscode-uri";
 
 const serviceSchema = /* GraphQL */ `
@@ -141,7 +141,7 @@ const config = new ApolloConfig({
     validationRules: [NoMissingClientDirectives]
   },
   engine: {}
-}) as ClientConfig;
+}) as ClientProjectConfig;
 
 class MockLoadingHandler implements LoadingHandler {
   handle<T>(_message: string, value: Promise<T>): Promise<T> {

--- a/packages/apollo-language-server/src/graphqlTypes.ts
+++ b/packages/apollo-language-server/src/graphqlTypes.ts
@@ -271,6 +271,15 @@ export interface CheckSchema_service_checkSchema {
 
 export interface CheckSchema_service {
   __typename: "ServiceMutation";
+  /**
+   * Checks a proposed schema against the schema that has been published to
+   * a particular tag, using metrics that have been published to the base tag.
+   * Callers can set the historicParameters directly, which will be used if
+   * provided. If useMaximumRetention is provided, but historicParameters is not,
+   * then validation will use the maximum retention the graph has access to.
+   * If neither historicParameters nor useMaximumRetention is provided, the
+   * default time range of one week (7 days) will be used.
+   */
   checkSchema: CheckSchema_service_checkSchema;
 }
 
@@ -698,272 +707,268 @@ export interface ValidateOperationsVariables {
 // GraphQL query operation: GetSchemaByTag
 // ====================================================
 
-export interface GetSchemaByTag_service_User {
-  __typename: "User" | "InternalIdentity";
-}
-
-export interface GetSchemaByTag_service_Service_schema___schema_queryType {
+export interface GetSchemaByTag_service_schema___schema_queryType {
   __typename: "IntrospectionType";
   name: string | null;
 }
 
-export interface GetSchemaByTag_service_Service_schema___schema_mutationType {
+export interface GetSchemaByTag_service_schema___schema_mutationType {
   __typename: "IntrospectionType";
   name: string | null;
 }
 
-export interface GetSchemaByTag_service_Service_schema___schema_subscriptionType {
+export interface GetSchemaByTag_service_schema___schema_subscriptionType {
   __typename: "IntrospectionType";
   name: string | null;
 }
 
-export interface GetSchemaByTag_service_Service_schema___schema_types_fields_args_type_ofType_ofType_ofType_ofType_ofType_ofType_ofType {
+export interface GetSchemaByTag_service_schema___schema_types_fields_args_type_ofType_ofType_ofType_ofType_ofType_ofType_ofType {
   __typename: "IntrospectionType";
   kind: IntrospectionTypeKind | null;
   name: string | null;
 }
 
-export interface GetSchemaByTag_service_Service_schema___schema_types_fields_args_type_ofType_ofType_ofType_ofType_ofType_ofType {
+export interface GetSchemaByTag_service_schema___schema_types_fields_args_type_ofType_ofType_ofType_ofType_ofType_ofType {
   __typename: "IntrospectionType";
   kind: IntrospectionTypeKind | null;
   name: string | null;
-  ofType: GetSchemaByTag_service_Service_schema___schema_types_fields_args_type_ofType_ofType_ofType_ofType_ofType_ofType_ofType | null;
+  ofType: GetSchemaByTag_service_schema___schema_types_fields_args_type_ofType_ofType_ofType_ofType_ofType_ofType_ofType | null;
 }
 
-export interface GetSchemaByTag_service_Service_schema___schema_types_fields_args_type_ofType_ofType_ofType_ofType_ofType {
+export interface GetSchemaByTag_service_schema___schema_types_fields_args_type_ofType_ofType_ofType_ofType_ofType {
   __typename: "IntrospectionType";
   kind: IntrospectionTypeKind | null;
   name: string | null;
-  ofType: GetSchemaByTag_service_Service_schema___schema_types_fields_args_type_ofType_ofType_ofType_ofType_ofType_ofType | null;
+  ofType: GetSchemaByTag_service_schema___schema_types_fields_args_type_ofType_ofType_ofType_ofType_ofType_ofType | null;
 }
 
-export interface GetSchemaByTag_service_Service_schema___schema_types_fields_args_type_ofType_ofType_ofType_ofType {
+export interface GetSchemaByTag_service_schema___schema_types_fields_args_type_ofType_ofType_ofType_ofType {
   __typename: "IntrospectionType";
   kind: IntrospectionTypeKind | null;
   name: string | null;
-  ofType: GetSchemaByTag_service_Service_schema___schema_types_fields_args_type_ofType_ofType_ofType_ofType_ofType | null;
+  ofType: GetSchemaByTag_service_schema___schema_types_fields_args_type_ofType_ofType_ofType_ofType_ofType | null;
 }
 
-export interface GetSchemaByTag_service_Service_schema___schema_types_fields_args_type_ofType_ofType_ofType {
+export interface GetSchemaByTag_service_schema___schema_types_fields_args_type_ofType_ofType_ofType {
   __typename: "IntrospectionType";
   kind: IntrospectionTypeKind | null;
   name: string | null;
-  ofType: GetSchemaByTag_service_Service_schema___schema_types_fields_args_type_ofType_ofType_ofType_ofType | null;
+  ofType: GetSchemaByTag_service_schema___schema_types_fields_args_type_ofType_ofType_ofType_ofType | null;
 }
 
-export interface GetSchemaByTag_service_Service_schema___schema_types_fields_args_type_ofType_ofType {
+export interface GetSchemaByTag_service_schema___schema_types_fields_args_type_ofType_ofType {
   __typename: "IntrospectionType";
   kind: IntrospectionTypeKind | null;
   name: string | null;
-  ofType: GetSchemaByTag_service_Service_schema___schema_types_fields_args_type_ofType_ofType_ofType | null;
+  ofType: GetSchemaByTag_service_schema___schema_types_fields_args_type_ofType_ofType_ofType | null;
 }
 
-export interface GetSchemaByTag_service_Service_schema___schema_types_fields_args_type_ofType {
+export interface GetSchemaByTag_service_schema___schema_types_fields_args_type_ofType {
   __typename: "IntrospectionType";
   kind: IntrospectionTypeKind | null;
   name: string | null;
-  ofType: GetSchemaByTag_service_Service_schema___schema_types_fields_args_type_ofType_ofType | null;
+  ofType: GetSchemaByTag_service_schema___schema_types_fields_args_type_ofType_ofType | null;
 }
 
-export interface GetSchemaByTag_service_Service_schema___schema_types_fields_args_type {
+export interface GetSchemaByTag_service_schema___schema_types_fields_args_type {
   __typename: "IntrospectionType";
   kind: IntrospectionTypeKind | null;
   name: string | null;
-  ofType: GetSchemaByTag_service_Service_schema___schema_types_fields_args_type_ofType | null;
+  ofType: GetSchemaByTag_service_schema___schema_types_fields_args_type_ofType | null;
 }
 
-export interface GetSchemaByTag_service_Service_schema___schema_types_fields_args {
+export interface GetSchemaByTag_service_schema___schema_types_fields_args {
   __typename: "IntrospectionInputValue";
   name: string;
   description: string | null;
-  type: GetSchemaByTag_service_Service_schema___schema_types_fields_args_type;
+  type: GetSchemaByTag_service_schema___schema_types_fields_args_type;
   defaultValue: string | null;
 }
 
-export interface GetSchemaByTag_service_Service_schema___schema_types_fields_type_ofType_ofType_ofType_ofType_ofType_ofType_ofType {
+export interface GetSchemaByTag_service_schema___schema_types_fields_type_ofType_ofType_ofType_ofType_ofType_ofType_ofType {
   __typename: "IntrospectionType";
   kind: IntrospectionTypeKind | null;
   name: string | null;
 }
 
-export interface GetSchemaByTag_service_Service_schema___schema_types_fields_type_ofType_ofType_ofType_ofType_ofType_ofType {
+export interface GetSchemaByTag_service_schema___schema_types_fields_type_ofType_ofType_ofType_ofType_ofType_ofType {
   __typename: "IntrospectionType";
   kind: IntrospectionTypeKind | null;
   name: string | null;
-  ofType: GetSchemaByTag_service_Service_schema___schema_types_fields_type_ofType_ofType_ofType_ofType_ofType_ofType_ofType | null;
+  ofType: GetSchemaByTag_service_schema___schema_types_fields_type_ofType_ofType_ofType_ofType_ofType_ofType_ofType | null;
 }
 
-export interface GetSchemaByTag_service_Service_schema___schema_types_fields_type_ofType_ofType_ofType_ofType_ofType {
+export interface GetSchemaByTag_service_schema___schema_types_fields_type_ofType_ofType_ofType_ofType_ofType {
   __typename: "IntrospectionType";
   kind: IntrospectionTypeKind | null;
   name: string | null;
-  ofType: GetSchemaByTag_service_Service_schema___schema_types_fields_type_ofType_ofType_ofType_ofType_ofType_ofType | null;
+  ofType: GetSchemaByTag_service_schema___schema_types_fields_type_ofType_ofType_ofType_ofType_ofType_ofType | null;
 }
 
-export interface GetSchemaByTag_service_Service_schema___schema_types_fields_type_ofType_ofType_ofType_ofType {
+export interface GetSchemaByTag_service_schema___schema_types_fields_type_ofType_ofType_ofType_ofType {
   __typename: "IntrospectionType";
   kind: IntrospectionTypeKind | null;
   name: string | null;
-  ofType: GetSchemaByTag_service_Service_schema___schema_types_fields_type_ofType_ofType_ofType_ofType_ofType | null;
+  ofType: GetSchemaByTag_service_schema___schema_types_fields_type_ofType_ofType_ofType_ofType_ofType | null;
 }
 
-export interface GetSchemaByTag_service_Service_schema___schema_types_fields_type_ofType_ofType_ofType {
+export interface GetSchemaByTag_service_schema___schema_types_fields_type_ofType_ofType_ofType {
   __typename: "IntrospectionType";
   kind: IntrospectionTypeKind | null;
   name: string | null;
-  ofType: GetSchemaByTag_service_Service_schema___schema_types_fields_type_ofType_ofType_ofType_ofType | null;
+  ofType: GetSchemaByTag_service_schema___schema_types_fields_type_ofType_ofType_ofType_ofType | null;
 }
 
-export interface GetSchemaByTag_service_Service_schema___schema_types_fields_type_ofType_ofType {
+export interface GetSchemaByTag_service_schema___schema_types_fields_type_ofType_ofType {
   __typename: "IntrospectionType";
   kind: IntrospectionTypeKind | null;
   name: string | null;
-  ofType: GetSchemaByTag_service_Service_schema___schema_types_fields_type_ofType_ofType_ofType | null;
+  ofType: GetSchemaByTag_service_schema___schema_types_fields_type_ofType_ofType_ofType | null;
 }
 
-export interface GetSchemaByTag_service_Service_schema___schema_types_fields_type_ofType {
+export interface GetSchemaByTag_service_schema___schema_types_fields_type_ofType {
   __typename: "IntrospectionType";
   kind: IntrospectionTypeKind | null;
   name: string | null;
-  ofType: GetSchemaByTag_service_Service_schema___schema_types_fields_type_ofType_ofType | null;
+  ofType: GetSchemaByTag_service_schema___schema_types_fields_type_ofType_ofType | null;
 }
 
-export interface GetSchemaByTag_service_Service_schema___schema_types_fields_type {
+export interface GetSchemaByTag_service_schema___schema_types_fields_type {
   __typename: "IntrospectionType";
   kind: IntrospectionTypeKind | null;
   name: string | null;
-  ofType: GetSchemaByTag_service_Service_schema___schema_types_fields_type_ofType | null;
+  ofType: GetSchemaByTag_service_schema___schema_types_fields_type_ofType | null;
 }
 
-export interface GetSchemaByTag_service_Service_schema___schema_types_fields {
+export interface GetSchemaByTag_service_schema___schema_types_fields {
   __typename: "IntrospectionField";
   name: string;
   description: string | null;
-  args: GetSchemaByTag_service_Service_schema___schema_types_fields_args[];
-  type: GetSchemaByTag_service_Service_schema___schema_types_fields_type;
+  args: GetSchemaByTag_service_schema___schema_types_fields_args[];
+  type: GetSchemaByTag_service_schema___schema_types_fields_type;
   isDeprecated: boolean;
   deprecationReason: string | null;
 }
 
-export interface GetSchemaByTag_service_Service_schema___schema_types_inputFields_type_ofType_ofType_ofType_ofType_ofType_ofType_ofType {
+export interface GetSchemaByTag_service_schema___schema_types_inputFields_type_ofType_ofType_ofType_ofType_ofType_ofType_ofType {
   __typename: "IntrospectionType";
   kind: IntrospectionTypeKind | null;
   name: string | null;
 }
 
-export interface GetSchemaByTag_service_Service_schema___schema_types_inputFields_type_ofType_ofType_ofType_ofType_ofType_ofType {
+export interface GetSchemaByTag_service_schema___schema_types_inputFields_type_ofType_ofType_ofType_ofType_ofType_ofType {
   __typename: "IntrospectionType";
   kind: IntrospectionTypeKind | null;
   name: string | null;
-  ofType: GetSchemaByTag_service_Service_schema___schema_types_inputFields_type_ofType_ofType_ofType_ofType_ofType_ofType_ofType | null;
+  ofType: GetSchemaByTag_service_schema___schema_types_inputFields_type_ofType_ofType_ofType_ofType_ofType_ofType_ofType | null;
 }
 
-export interface GetSchemaByTag_service_Service_schema___schema_types_inputFields_type_ofType_ofType_ofType_ofType_ofType {
+export interface GetSchemaByTag_service_schema___schema_types_inputFields_type_ofType_ofType_ofType_ofType_ofType {
   __typename: "IntrospectionType";
   kind: IntrospectionTypeKind | null;
   name: string | null;
-  ofType: GetSchemaByTag_service_Service_schema___schema_types_inputFields_type_ofType_ofType_ofType_ofType_ofType_ofType | null;
+  ofType: GetSchemaByTag_service_schema___schema_types_inputFields_type_ofType_ofType_ofType_ofType_ofType_ofType | null;
 }
 
-export interface GetSchemaByTag_service_Service_schema___schema_types_inputFields_type_ofType_ofType_ofType_ofType {
+export interface GetSchemaByTag_service_schema___schema_types_inputFields_type_ofType_ofType_ofType_ofType {
   __typename: "IntrospectionType";
   kind: IntrospectionTypeKind | null;
   name: string | null;
-  ofType: GetSchemaByTag_service_Service_schema___schema_types_inputFields_type_ofType_ofType_ofType_ofType_ofType | null;
+  ofType: GetSchemaByTag_service_schema___schema_types_inputFields_type_ofType_ofType_ofType_ofType_ofType | null;
 }
 
-export interface GetSchemaByTag_service_Service_schema___schema_types_inputFields_type_ofType_ofType_ofType {
+export interface GetSchemaByTag_service_schema___schema_types_inputFields_type_ofType_ofType_ofType {
   __typename: "IntrospectionType";
   kind: IntrospectionTypeKind | null;
   name: string | null;
-  ofType: GetSchemaByTag_service_Service_schema___schema_types_inputFields_type_ofType_ofType_ofType_ofType | null;
+  ofType: GetSchemaByTag_service_schema___schema_types_inputFields_type_ofType_ofType_ofType_ofType | null;
 }
 
-export interface GetSchemaByTag_service_Service_schema___schema_types_inputFields_type_ofType_ofType {
+export interface GetSchemaByTag_service_schema___schema_types_inputFields_type_ofType_ofType {
   __typename: "IntrospectionType";
   kind: IntrospectionTypeKind | null;
   name: string | null;
-  ofType: GetSchemaByTag_service_Service_schema___schema_types_inputFields_type_ofType_ofType_ofType | null;
+  ofType: GetSchemaByTag_service_schema___schema_types_inputFields_type_ofType_ofType_ofType | null;
 }
 
-export interface GetSchemaByTag_service_Service_schema___schema_types_inputFields_type_ofType {
+export interface GetSchemaByTag_service_schema___schema_types_inputFields_type_ofType {
   __typename: "IntrospectionType";
   kind: IntrospectionTypeKind | null;
   name: string | null;
-  ofType: GetSchemaByTag_service_Service_schema___schema_types_inputFields_type_ofType_ofType | null;
+  ofType: GetSchemaByTag_service_schema___schema_types_inputFields_type_ofType_ofType | null;
 }
 
-export interface GetSchemaByTag_service_Service_schema___schema_types_inputFields_type {
+export interface GetSchemaByTag_service_schema___schema_types_inputFields_type {
   __typename: "IntrospectionType";
   kind: IntrospectionTypeKind | null;
   name: string | null;
-  ofType: GetSchemaByTag_service_Service_schema___schema_types_inputFields_type_ofType | null;
+  ofType: GetSchemaByTag_service_schema___schema_types_inputFields_type_ofType | null;
 }
 
-export interface GetSchemaByTag_service_Service_schema___schema_types_inputFields {
+export interface GetSchemaByTag_service_schema___schema_types_inputFields {
   __typename: "IntrospectionInputValue";
   name: string;
   description: string | null;
-  type: GetSchemaByTag_service_Service_schema___schema_types_inputFields_type;
+  type: GetSchemaByTag_service_schema___schema_types_inputFields_type;
   defaultValue: string | null;
 }
 
-export interface GetSchemaByTag_service_Service_schema___schema_types_interfaces_ofType_ofType_ofType_ofType_ofType_ofType_ofType {
+export interface GetSchemaByTag_service_schema___schema_types_interfaces_ofType_ofType_ofType_ofType_ofType_ofType_ofType {
   __typename: "IntrospectionType";
   kind: IntrospectionTypeKind | null;
   name: string | null;
 }
 
-export interface GetSchemaByTag_service_Service_schema___schema_types_interfaces_ofType_ofType_ofType_ofType_ofType_ofType {
+export interface GetSchemaByTag_service_schema___schema_types_interfaces_ofType_ofType_ofType_ofType_ofType_ofType {
   __typename: "IntrospectionType";
   kind: IntrospectionTypeKind | null;
   name: string | null;
-  ofType: GetSchemaByTag_service_Service_schema___schema_types_interfaces_ofType_ofType_ofType_ofType_ofType_ofType_ofType | null;
+  ofType: GetSchemaByTag_service_schema___schema_types_interfaces_ofType_ofType_ofType_ofType_ofType_ofType_ofType | null;
 }
 
-export interface GetSchemaByTag_service_Service_schema___schema_types_interfaces_ofType_ofType_ofType_ofType_ofType {
+export interface GetSchemaByTag_service_schema___schema_types_interfaces_ofType_ofType_ofType_ofType_ofType {
   __typename: "IntrospectionType";
   kind: IntrospectionTypeKind | null;
   name: string | null;
-  ofType: GetSchemaByTag_service_Service_schema___schema_types_interfaces_ofType_ofType_ofType_ofType_ofType_ofType | null;
+  ofType: GetSchemaByTag_service_schema___schema_types_interfaces_ofType_ofType_ofType_ofType_ofType_ofType | null;
 }
 
-export interface GetSchemaByTag_service_Service_schema___schema_types_interfaces_ofType_ofType_ofType_ofType {
+export interface GetSchemaByTag_service_schema___schema_types_interfaces_ofType_ofType_ofType_ofType {
   __typename: "IntrospectionType";
   kind: IntrospectionTypeKind | null;
   name: string | null;
-  ofType: GetSchemaByTag_service_Service_schema___schema_types_interfaces_ofType_ofType_ofType_ofType_ofType | null;
+  ofType: GetSchemaByTag_service_schema___schema_types_interfaces_ofType_ofType_ofType_ofType_ofType | null;
 }
 
-export interface GetSchemaByTag_service_Service_schema___schema_types_interfaces_ofType_ofType_ofType {
+export interface GetSchemaByTag_service_schema___schema_types_interfaces_ofType_ofType_ofType {
   __typename: "IntrospectionType";
   kind: IntrospectionTypeKind | null;
   name: string | null;
-  ofType: GetSchemaByTag_service_Service_schema___schema_types_interfaces_ofType_ofType_ofType_ofType | null;
+  ofType: GetSchemaByTag_service_schema___schema_types_interfaces_ofType_ofType_ofType_ofType | null;
 }
 
-export interface GetSchemaByTag_service_Service_schema___schema_types_interfaces_ofType_ofType {
+export interface GetSchemaByTag_service_schema___schema_types_interfaces_ofType_ofType {
   __typename: "IntrospectionType";
   kind: IntrospectionTypeKind | null;
   name: string | null;
-  ofType: GetSchemaByTag_service_Service_schema___schema_types_interfaces_ofType_ofType_ofType | null;
+  ofType: GetSchemaByTag_service_schema___schema_types_interfaces_ofType_ofType_ofType | null;
 }
 
-export interface GetSchemaByTag_service_Service_schema___schema_types_interfaces_ofType {
+export interface GetSchemaByTag_service_schema___schema_types_interfaces_ofType {
   __typename: "IntrospectionType";
   kind: IntrospectionTypeKind | null;
   name: string | null;
-  ofType: GetSchemaByTag_service_Service_schema___schema_types_interfaces_ofType_ofType | null;
+  ofType: GetSchemaByTag_service_schema___schema_types_interfaces_ofType_ofType | null;
 }
 
-export interface GetSchemaByTag_service_Service_schema___schema_types_interfaces {
+export interface GetSchemaByTag_service_schema___schema_types_interfaces {
   __typename: "IntrospectionType";
   kind: IntrospectionTypeKind | null;
   name: string | null;
-  ofType: GetSchemaByTag_service_Service_schema___schema_types_interfaces_ofType | null;
+  ofType: GetSchemaByTag_service_schema___schema_types_interfaces_ofType | null;
 }
 
-export interface GetSchemaByTag_service_Service_schema___schema_types_enumValues {
+export interface GetSchemaByTag_service_schema___schema_types_enumValues {
   __typename: "IntrospectionEnumValue";
   name: string;
   description: string | null;
@@ -971,168 +976,166 @@ export interface GetSchemaByTag_service_Service_schema___schema_types_enumValues
   depreactionReason: string | null;
 }
 
-export interface GetSchemaByTag_service_Service_schema___schema_types_possibleTypes_ofType_ofType_ofType_ofType_ofType_ofType_ofType {
+export interface GetSchemaByTag_service_schema___schema_types_possibleTypes_ofType_ofType_ofType_ofType_ofType_ofType_ofType {
   __typename: "IntrospectionType";
   kind: IntrospectionTypeKind | null;
   name: string | null;
 }
 
-export interface GetSchemaByTag_service_Service_schema___schema_types_possibleTypes_ofType_ofType_ofType_ofType_ofType_ofType {
+export interface GetSchemaByTag_service_schema___schema_types_possibleTypes_ofType_ofType_ofType_ofType_ofType_ofType {
   __typename: "IntrospectionType";
   kind: IntrospectionTypeKind | null;
   name: string | null;
-  ofType: GetSchemaByTag_service_Service_schema___schema_types_possibleTypes_ofType_ofType_ofType_ofType_ofType_ofType_ofType | null;
+  ofType: GetSchemaByTag_service_schema___schema_types_possibleTypes_ofType_ofType_ofType_ofType_ofType_ofType_ofType | null;
 }
 
-export interface GetSchemaByTag_service_Service_schema___schema_types_possibleTypes_ofType_ofType_ofType_ofType_ofType {
+export interface GetSchemaByTag_service_schema___schema_types_possibleTypes_ofType_ofType_ofType_ofType_ofType {
   __typename: "IntrospectionType";
   kind: IntrospectionTypeKind | null;
   name: string | null;
-  ofType: GetSchemaByTag_service_Service_schema___schema_types_possibleTypes_ofType_ofType_ofType_ofType_ofType_ofType | null;
+  ofType: GetSchemaByTag_service_schema___schema_types_possibleTypes_ofType_ofType_ofType_ofType_ofType_ofType | null;
 }
 
-export interface GetSchemaByTag_service_Service_schema___schema_types_possibleTypes_ofType_ofType_ofType_ofType {
+export interface GetSchemaByTag_service_schema___schema_types_possibleTypes_ofType_ofType_ofType_ofType {
   __typename: "IntrospectionType";
   kind: IntrospectionTypeKind | null;
   name: string | null;
-  ofType: GetSchemaByTag_service_Service_schema___schema_types_possibleTypes_ofType_ofType_ofType_ofType_ofType | null;
+  ofType: GetSchemaByTag_service_schema___schema_types_possibleTypes_ofType_ofType_ofType_ofType_ofType | null;
 }
 
-export interface GetSchemaByTag_service_Service_schema___schema_types_possibleTypes_ofType_ofType_ofType {
+export interface GetSchemaByTag_service_schema___schema_types_possibleTypes_ofType_ofType_ofType {
   __typename: "IntrospectionType";
   kind: IntrospectionTypeKind | null;
   name: string | null;
-  ofType: GetSchemaByTag_service_Service_schema___schema_types_possibleTypes_ofType_ofType_ofType_ofType | null;
+  ofType: GetSchemaByTag_service_schema___schema_types_possibleTypes_ofType_ofType_ofType_ofType | null;
 }
 
-export interface GetSchemaByTag_service_Service_schema___schema_types_possibleTypes_ofType_ofType {
+export interface GetSchemaByTag_service_schema___schema_types_possibleTypes_ofType_ofType {
   __typename: "IntrospectionType";
   kind: IntrospectionTypeKind | null;
   name: string | null;
-  ofType: GetSchemaByTag_service_Service_schema___schema_types_possibleTypes_ofType_ofType_ofType | null;
+  ofType: GetSchemaByTag_service_schema___schema_types_possibleTypes_ofType_ofType_ofType | null;
 }
 
-export interface GetSchemaByTag_service_Service_schema___schema_types_possibleTypes_ofType {
+export interface GetSchemaByTag_service_schema___schema_types_possibleTypes_ofType {
   __typename: "IntrospectionType";
   kind: IntrospectionTypeKind | null;
   name: string | null;
-  ofType: GetSchemaByTag_service_Service_schema___schema_types_possibleTypes_ofType_ofType | null;
+  ofType: GetSchemaByTag_service_schema___schema_types_possibleTypes_ofType_ofType | null;
 }
 
-export interface GetSchemaByTag_service_Service_schema___schema_types_possibleTypes {
+export interface GetSchemaByTag_service_schema___schema_types_possibleTypes {
   __typename: "IntrospectionType";
   kind: IntrospectionTypeKind | null;
   name: string | null;
-  ofType: GetSchemaByTag_service_Service_schema___schema_types_possibleTypes_ofType | null;
+  ofType: GetSchemaByTag_service_schema___schema_types_possibleTypes_ofType | null;
 }
 
-export interface GetSchemaByTag_service_Service_schema___schema_types {
+export interface GetSchemaByTag_service_schema___schema_types {
   __typename: "IntrospectionType";
   kind: IntrospectionTypeKind | null;
   name: string | null;
   description: string | null;
-  fields: GetSchemaByTag_service_Service_schema___schema_types_fields[] | null;
-  inputFields: GetSchemaByTag_service_Service_schema___schema_types_inputFields[] | null;
-  interfaces: GetSchemaByTag_service_Service_schema___schema_types_interfaces[] | null;
-  enumValues: GetSchemaByTag_service_Service_schema___schema_types_enumValues[] | null;
-  possibleTypes: GetSchemaByTag_service_Service_schema___schema_types_possibleTypes[] | null;
+  fields: GetSchemaByTag_service_schema___schema_types_fields[] | null;
+  inputFields: GetSchemaByTag_service_schema___schema_types_inputFields[] | null;
+  interfaces: GetSchemaByTag_service_schema___schema_types_interfaces[] | null;
+  enumValues: GetSchemaByTag_service_schema___schema_types_enumValues[] | null;
+  possibleTypes: GetSchemaByTag_service_schema___schema_types_possibleTypes[] | null;
 }
 
-export interface GetSchemaByTag_service_Service_schema___schema_directives_args_type_ofType_ofType_ofType_ofType_ofType_ofType_ofType {
+export interface GetSchemaByTag_service_schema___schema_directives_args_type_ofType_ofType_ofType_ofType_ofType_ofType_ofType {
   __typename: "IntrospectionType";
   kind: IntrospectionTypeKind | null;
   name: string | null;
 }
 
-export interface GetSchemaByTag_service_Service_schema___schema_directives_args_type_ofType_ofType_ofType_ofType_ofType_ofType {
+export interface GetSchemaByTag_service_schema___schema_directives_args_type_ofType_ofType_ofType_ofType_ofType_ofType {
   __typename: "IntrospectionType";
   kind: IntrospectionTypeKind | null;
   name: string | null;
-  ofType: GetSchemaByTag_service_Service_schema___schema_directives_args_type_ofType_ofType_ofType_ofType_ofType_ofType_ofType | null;
+  ofType: GetSchemaByTag_service_schema___schema_directives_args_type_ofType_ofType_ofType_ofType_ofType_ofType_ofType | null;
 }
 
-export interface GetSchemaByTag_service_Service_schema___schema_directives_args_type_ofType_ofType_ofType_ofType_ofType {
+export interface GetSchemaByTag_service_schema___schema_directives_args_type_ofType_ofType_ofType_ofType_ofType {
   __typename: "IntrospectionType";
   kind: IntrospectionTypeKind | null;
   name: string | null;
-  ofType: GetSchemaByTag_service_Service_schema___schema_directives_args_type_ofType_ofType_ofType_ofType_ofType_ofType | null;
+  ofType: GetSchemaByTag_service_schema___schema_directives_args_type_ofType_ofType_ofType_ofType_ofType_ofType | null;
 }
 
-export interface GetSchemaByTag_service_Service_schema___schema_directives_args_type_ofType_ofType_ofType_ofType {
+export interface GetSchemaByTag_service_schema___schema_directives_args_type_ofType_ofType_ofType_ofType {
   __typename: "IntrospectionType";
   kind: IntrospectionTypeKind | null;
   name: string | null;
-  ofType: GetSchemaByTag_service_Service_schema___schema_directives_args_type_ofType_ofType_ofType_ofType_ofType | null;
+  ofType: GetSchemaByTag_service_schema___schema_directives_args_type_ofType_ofType_ofType_ofType_ofType | null;
 }
 
-export interface GetSchemaByTag_service_Service_schema___schema_directives_args_type_ofType_ofType_ofType {
+export interface GetSchemaByTag_service_schema___schema_directives_args_type_ofType_ofType_ofType {
   __typename: "IntrospectionType";
   kind: IntrospectionTypeKind | null;
   name: string | null;
-  ofType: GetSchemaByTag_service_Service_schema___schema_directives_args_type_ofType_ofType_ofType_ofType | null;
+  ofType: GetSchemaByTag_service_schema___schema_directives_args_type_ofType_ofType_ofType_ofType | null;
 }
 
-export interface GetSchemaByTag_service_Service_schema___schema_directives_args_type_ofType_ofType {
+export interface GetSchemaByTag_service_schema___schema_directives_args_type_ofType_ofType {
   __typename: "IntrospectionType";
   kind: IntrospectionTypeKind | null;
   name: string | null;
-  ofType: GetSchemaByTag_service_Service_schema___schema_directives_args_type_ofType_ofType_ofType | null;
+  ofType: GetSchemaByTag_service_schema___schema_directives_args_type_ofType_ofType_ofType | null;
 }
 
-export interface GetSchemaByTag_service_Service_schema___schema_directives_args_type_ofType {
+export interface GetSchemaByTag_service_schema___schema_directives_args_type_ofType {
   __typename: "IntrospectionType";
   kind: IntrospectionTypeKind | null;
   name: string | null;
-  ofType: GetSchemaByTag_service_Service_schema___schema_directives_args_type_ofType_ofType | null;
+  ofType: GetSchemaByTag_service_schema___schema_directives_args_type_ofType_ofType | null;
 }
 
-export interface GetSchemaByTag_service_Service_schema___schema_directives_args_type {
+export interface GetSchemaByTag_service_schema___schema_directives_args_type {
   __typename: "IntrospectionType";
   kind: IntrospectionTypeKind | null;
   name: string | null;
-  ofType: GetSchemaByTag_service_Service_schema___schema_directives_args_type_ofType | null;
+  ofType: GetSchemaByTag_service_schema___schema_directives_args_type_ofType | null;
 }
 
-export interface GetSchemaByTag_service_Service_schema___schema_directives_args {
+export interface GetSchemaByTag_service_schema___schema_directives_args {
   __typename: "IntrospectionInputValue";
   name: string;
   description: string | null;
-  type: GetSchemaByTag_service_Service_schema___schema_directives_args_type;
+  type: GetSchemaByTag_service_schema___schema_directives_args_type;
   defaultValue: string | null;
 }
 
-export interface GetSchemaByTag_service_Service_schema___schema_directives {
+export interface GetSchemaByTag_service_schema___schema_directives {
   __typename: "IntrospectionDirective";
   name: string;
   description: string | null;
   locations: IntrospectionDirectiveLocation[];
-  args: GetSchemaByTag_service_Service_schema___schema_directives_args[];
+  args: GetSchemaByTag_service_schema___schema_directives_args[];
 }
 
-export interface GetSchemaByTag_service_Service_schema___schema {
+export interface GetSchemaByTag_service_schema___schema {
   __typename: "IntrospectionSchema";
-  queryType: GetSchemaByTag_service_Service_schema___schema_queryType;
-  mutationType: GetSchemaByTag_service_Service_schema___schema_mutationType | null;
-  subscriptionType: GetSchemaByTag_service_Service_schema___schema_subscriptionType | null;
-  types: GetSchemaByTag_service_Service_schema___schema_types[];
-  directives: GetSchemaByTag_service_Service_schema___schema_directives[];
+  queryType: GetSchemaByTag_service_schema___schema_queryType;
+  mutationType: GetSchemaByTag_service_schema___schema_mutationType | null;
+  subscriptionType: GetSchemaByTag_service_schema___schema_subscriptionType | null;
+  types: GetSchemaByTag_service_schema___schema_types[];
+  directives: GetSchemaByTag_service_schema___schema_directives[];
 }
 
-export interface GetSchemaByTag_service_Service_schema {
+export interface GetSchemaByTag_service_schema {
   __typename: "Schema";
   hash: string;
-  __schema: GetSchemaByTag_service_Service_schema___schema;
+  __schema: GetSchemaByTag_service_schema___schema;
 }
 
-export interface GetSchemaByTag_service_Service {
+export interface GetSchemaByTag_service {
   __typename: "Service";
   /**
    * Get a schema by hash OR current tag
    */
-  schema: GetSchemaByTag_service_Service_schema | null;
+  schema: GetSchemaByTag_service_schema | null;
 }
-
-export type GetSchemaByTag_service = GetSchemaByTag_service_User | GetSchemaByTag_service_Service;
 
 export interface GetSchemaByTag {
   service: GetSchemaByTag_service | null;
@@ -1140,6 +1143,7 @@ export interface GetSchemaByTag {
 
 export interface GetSchemaByTagVariables {
   tag: string;
+  id: string;
 }
 
 /* tslint:disable */

--- a/packages/apollo-language-server/src/project/base.ts
+++ b/packages/apollo-language-server/src/project/base.ts
@@ -69,7 +69,7 @@ export interface ProjectStats {
 }
 
 export abstract class GraphQLProject implements GraphQLSchemaProvider {
-  public schemaProvider: GraphQLSchemaProvider;
+  public serviceSchemaProvider: GraphQLSchemaProvider;
   protected _onDiagnostics?: NotificationHandler<PublishDiagnosticsParams>;
 
   private _isReady: boolean;
@@ -96,7 +96,10 @@ export abstract class GraphQLProject implements GraphQLSchemaProvider {
     this.config = config;
     this.fileSet = fileSet;
     this.loadingHandler = loadingHandler;
-    this.schemaProvider = schemaProviderFromConfig(config, clientIdentity);
+    this.serviceSchemaProvider = schemaProviderFromConfig(
+      config,
+      clientIdentity
+    );
     const { engine } = config;
     if (engine.apiKey) {
       this.engineClient = new ApolloEngineClient(
@@ -151,16 +154,16 @@ export abstract class GraphQLProject implements GraphQLSchemaProvider {
 
   public resolveSchema(config: SchemaResolveConfig): Promise<GraphQLSchema> {
     this.lastLoadDate = +new Date();
-    return this.schemaProvider.resolveSchema(config);
+    return this.serviceSchemaProvider.resolveSchema(config);
   }
 
   public resolveFederatedServiceSDL() {
-    return this.schemaProvider.resolveFederatedServiceSDL();
+    return this.serviceSchemaProvider.resolveFederatedServiceSDL();
   }
 
   public onSchemaChange(handler: NotificationHandler<GraphQLSchema>) {
     this.lastLoadDate = +new Date();
-    return this.schemaProvider.onSchemaChange(handler);
+    return this.serviceSchemaProvider.onSchemaChange(handler);
   }
 
   onDiagnostics(handler: NotificationHandler<PublishDiagnosticsParams>) {

--- a/packages/apollo-language-server/src/project/base.ts
+++ b/packages/apollo-language-server/src/project/base.ts
@@ -70,6 +70,7 @@ export interface ProjectStats {
 
 export abstract class GraphQLProject implements GraphQLSchemaProvider {
   public serviceSchemaProvider: GraphQLSchemaProvider;
+  public clientSchemaProvider: GraphQLSchemaProvider;
   protected _onDiagnostics?: NotificationHandler<PublishDiagnosticsParams>;
 
   private _isReady: boolean;
@@ -98,7 +99,13 @@ export abstract class GraphQLProject implements GraphQLSchemaProvider {
     this.loadingHandler = loadingHandler;
     this.serviceSchemaProvider = schemaProviderFromConfig(
       config,
-      clientIdentity
+      clientIdentity,
+      false
+    );
+    this.clientSchemaProvider = schemaProviderFromConfig(
+      config,
+      clientIdentity,
+      true
     );
     const { engine } = config;
     if (engine.apiKey) {
@@ -152,8 +159,14 @@ export abstract class GraphQLProject implements GraphQLSchemaProvider {
     return this.initialize();
   }
 
-  public resolveSchema(config: SchemaResolveConfig): Promise<GraphQLSchema> {
+  public resolveSchema(
+    config: SchemaResolveConfig,
+    forClientCommand?: boolean
+  ): Promise<GraphQLSchema> {
     this.lastLoadDate = +new Date();
+    if (forClientCommand) {
+      return this.clientSchemaProvider.resolveSchema(config);
+    }
     return this.serviceSchemaProvider.resolveSchema(config);
   }
 

--- a/packages/apollo-language-server/src/project/base.ts
+++ b/packages/apollo-language-server/src/project/base.ts
@@ -51,6 +51,7 @@ export interface GraphQLProjectConfig {
   config: ApolloConfig;
   fileSet: FileSet;
   loadingHandler: LoadingHandler;
+  loadSchemaOnStartup?: boolean;
 }
 
 export interface TypeStats {
@@ -75,6 +76,7 @@ export abstract class GraphQLProject implements GraphQLSchemaProvider {
 
   private _isReady: boolean;
   private readyPromise: Promise<void>;
+  protected loadSchemaOnStartup?: boolean;
   protected engineClient?: ApolloEngineClient;
 
   private needsValidation = false;
@@ -92,7 +94,8 @@ export abstract class GraphQLProject implements GraphQLSchemaProvider {
     config,
     fileSet,
     loadingHandler,
-    clientIdentity
+    clientIdentity,
+    loadSchemaOnStartup
   }: GraphQLProjectConfig) {
     this.config = config;
     this.fileSet = fileSet;
@@ -107,6 +110,7 @@ export abstract class GraphQLProject implements GraphQLSchemaProvider {
       clientIdentity,
       true
     );
+    this.loadSchemaOnStartup = loadSchemaOnStartup;
     const { engine } = config;
     if (engine.apiKey) {
       this.engineClient = new ApolloEngineClient(

--- a/packages/apollo-language-server/src/project/base.ts
+++ b/packages/apollo-language-server/src/project/base.ts
@@ -88,7 +88,7 @@ export abstract class GraphQLProject implements GraphQLSchemaProvider {
 
   protected lastLoadDate?: number;
 
-  constructor({
+  protected constructor({
     config,
     fileSet,
     loadingHandler,
@@ -117,7 +117,7 @@ export abstract class GraphQLProject implements GraphQLSchemaProvider {
     }
 
     this._isReady = false;
-    // FIXME: Instead of `Promise.all`, we should catch individual promise rejections
+    // TODO: Instead of `Promise.all`, we should catch individual promise rejections
     // so we can show multiple errors.
     this.readyPromise = Promise.all(this.initialize())
       .then(() => {
@@ -286,7 +286,7 @@ export abstract class GraphQLProject implements GraphQLSchemaProvider {
     this.needsValidation = false;
   }
 
-  abstract validate(): void;
+  abstract async validate(): Promise<void>;
 
   clearAllDiagnostics() {
     if (!this._onDiagnostics) return;

--- a/packages/apollo-language-server/src/project/client.ts
+++ b/packages/apollo-language-server/src/project/client.ts
@@ -114,7 +114,7 @@ export class GraphQLClientProject extends GraphQLProject {
 
     super({ config, fileSet, loadingHandler, clientIdentity });
     this.rootURI = rootURI;
-    this.serviceID = config.name;
+    this.serviceID = config.graphId;
 
     /**
      * This function is used in the Array.filter function below it to remove any .env files and config files.
@@ -149,7 +149,7 @@ export class GraphQLClientProject extends GraphQLProject {
   }
 
   get displayName(): string {
-    return this.config.name || "Unnamed Project";
+    return this.config.graphId || "Unnamed Project";
   }
 
   initialize() {

--- a/packages/apollo-language-server/src/project/client.ts
+++ b/packages/apollo-language-server/src/project/client.ts
@@ -201,7 +201,7 @@ export class GraphQLClientProject extends GraphQLProject {
       `Loading schema for ${this.displayName}`,
       (async () => {
         this.serviceSchema = augmentSchemaWithGeneratedSDLIfNeeded(
-          await this.schemaProvider.resolveSchema({
+          await this.serviceSchemaProvider.resolveSchema({
             tag: tag || this.config.tag,
             force: true
           })

--- a/packages/apollo-language-server/src/project/client.ts
+++ b/packages/apollo-language-server/src/project/client.ts
@@ -84,7 +84,7 @@ export interface GraphQLClientProjectConfig {
 export class GraphQLClientProject extends GraphQLProject {
   public rootURI: URI;
   public serviceID?: string;
-  public config: ClientConfig;
+  public config!: ClientConfig;
 
   private serviceSchema?: GraphQLSchema;
 

--- a/packages/apollo-language-server/src/project/client.ts
+++ b/packages/apollo-language-server/src/project/client.ts
@@ -84,7 +84,7 @@ export interface GraphQLClientProjectConfig {
 export class GraphQLClientProject extends GraphQLProject {
   public rootURI: URI;
   public serviceID?: string;
-  public config!: ClientConfig;
+  public config: ClientConfig;
 
   private serviceSchema?: GraphQLSchema;
 
@@ -201,7 +201,7 @@ export class GraphQLClientProject extends GraphQLProject {
       `Loading schema for ${this.displayName}`,
       (async () => {
         this.serviceSchema = augmentSchemaWithGeneratedSDLIfNeeded(
-          await this.serviceSchemaProvider.resolveSchema({
+          await this.clientSchemaProvider.resolveSchema({
             tag: tag || this.config.tag,
             force: true
           })

--- a/packages/apollo-language-server/src/project/client.ts
+++ b/packages/apollo-language-server/src/project/client.ts
@@ -18,8 +18,7 @@ import {
   FieldNode,
   ObjectTypeDefinitionNode,
   GraphQLObjectType,
-  DefinitionNode,
-  DirectiveDefinitionNode
+  DefinitionNode
 } from "graphql";
 import { ValidationRule } from "graphql/validation/ValidationContext";
 import Maybe from "graphql/tsutils/Maybe";

--- a/packages/apollo-language-server/src/project/clientAndService.ts
+++ b/packages/apollo-language-server/src/project/clientAndService.ts
@@ -1,0 +1,9 @@
+import { GraphQLProject } from "./base";
+import { FileSet } from "../fileSet";
+import { GraphQLServiceProject, GraphQLServiceProjectConfig } from "./service";
+import { GraphQLClientProject } from "./client";
+
+export interface GraphQLServiceAndClientProject {
+  serviceProject: GraphQLServiceProject;
+  clientProject: GraphQLClientProject;
+}

--- a/packages/apollo-language-server/src/project/service.ts
+++ b/packages/apollo-language-server/src/project/service.ts
@@ -50,6 +50,6 @@ export class GraphQLServiceProject extends GraphQLProject {
   }
 
   resolveFederationInfo() {
-    return this.schemaProvider.resolveFederatedServiceSDL();
+    return this.serviceSchemaProvider.resolveFederatedServiceSDL();
   }
 }

--- a/packages/apollo-language-server/src/project/service.ts
+++ b/packages/apollo-language-server/src/project/service.ts
@@ -36,7 +36,7 @@ export class GraphQLServiceProject extends GraphQLProject {
   }
 
   get displayName() {
-    return this.config.name || "Unnamed Project";
+    return this.config.graphId || "Unnamed Project";
   }
 
   initialize() {

--- a/packages/apollo-language-server/src/project/service.ts
+++ b/packages/apollo-language-server/src/project/service.ts
@@ -36,7 +36,7 @@ export class GraphQLServiceProject extends GraphQLProject {
   }
 
   get displayName() {
-    return this.config.graphId || "Unnamed Project";
+    return this.config.graphId + "@" + this.config.tag || "Unnamed Project";
   }
 
   initialize() {

--- a/packages/apollo-language-server/src/project/service.ts
+++ b/packages/apollo-language-server/src/project/service.ts
@@ -1,7 +1,7 @@
 import { GraphQLProject } from "./base";
 import { LoadingHandler } from "../loadingHandler";
 import { FileSet } from "../fileSet";
-import { ServiceConfig } from "../config";
+import { ServiceProjectConfig } from "../config";
 import { ClientIdentity } from "../engine";
 import URI from "vscode-uri";
 
@@ -13,10 +13,11 @@ export function isServiceProject(
 
 export interface GraphQLServiceProjectConfig {
   clientIdentity?: ClientIdentity;
-  config: ServiceConfig;
+  config: ServiceProjectConfig;
   rootURI: URI;
   loadingHandler: LoadingHandler;
 }
+
 export class GraphQLServiceProject extends GraphQLProject {
   constructor({
     clientIdentity,
@@ -36,14 +37,17 @@ export class GraphQLServiceProject extends GraphQLProject {
   }
 
   get displayName() {
-    return this.config.graphId + "@" + this.config.tag || "Unnamed Project";
+    return (
+      this.config.graphId + "@" + this.config.serviceGraphVariant ||
+      "Unnamed Project"
+    );
   }
 
   initialize() {
     return [];
   }
 
-  validate() {}
+  async validate() {}
 
   getProjectStats() {
     return { loaded: true, type: "service" };

--- a/packages/apollo-language-server/src/providers/schema/endpoint.ts
+++ b/packages/apollo-language-server/src/providers/schema/endpoint.ts
@@ -20,7 +20,7 @@ export class EndpointSchemaProvider implements GraphQLSchemaProvider {
   private schema?: GraphQLSchema;
   private federatedServiceSDL?: string;
 
-  constructor(private config: Exclude<RemoteServiceConfig, "name">) {}
+  constructor(private config: Omit<RemoteServiceConfig, "name">) {}
   async resolveSchema() {
     if (this.schema) return this.schema;
     const { skipSSLValidation, url, headers } = this.config;

--- a/packages/apollo-language-server/src/providers/schema/engine.ts
+++ b/packages/apollo-language-server/src/providers/schema/engine.ts
@@ -60,7 +60,6 @@ export class EngineSchemaProvider implements GraphQLSchemaProvider {
     }
 
     if (!(data && data.service && data.service.__typename === "Service")) {
-      console.log(JSON.stringify(data, null, 2));
       throw new Error(
         `Unable to get schema from Apollo Graph Manager for graph ${id}`
       );

--- a/packages/apollo-language-server/src/providers/schema/engine.ts
+++ b/packages/apollo-language-server/src/providers/schema/engine.ts
@@ -47,14 +47,6 @@ export class EngineSchemaProvider implements GraphQLSchemaProvider {
 
     const [id, tag = "current"] = parseServiceSpecifier(client.service);
 
-    // make sure the API key is valid for the service we're requesting a schema of.
-    const keyServiceName = getServiceFromKey(engine.apiKey);
-    if (id !== keyServiceName) {
-      throw new Error(
-        `API key service name (${keyServiceName}) does not match the service name in your config (${id}). Try changing the service name in your config to ${keyServiceName} or get a new key.`
-      );
-    }
-
     const { data, errors } = await this.client.execute<GetSchemaByTag>({
       query: SCHEMA_QUERY,
       variables: {
@@ -68,8 +60,9 @@ export class EngineSchemaProvider implements GraphQLSchemaProvider {
     }
 
     if (!(data && data.service && data.service.__typename === "Service")) {
+      console.log(JSON.stringify(data, null, 2));
       throw new Error(
-        `Unable to get schema from Apollo Engine for service ${id}`
+        `Unable to get schema from Apollo Graph Manager for graph ${id}`
       );
     }
 
@@ -95,8 +88,8 @@ export class EngineSchemaProvider implements GraphQLSchemaProvider {
 }
 
 export const SCHEMA_QUERY = gql`
-  query GetSchemaByTag($tag: String!) {
-    service: me {
+  query GetSchemaByTag($tag: String!, $id: ID!) {
+    service(id: $id) {
       ... on Service {
         __typename
         schema(tag: $tag) {

--- a/packages/apollo-language-server/src/providers/schema/engine.ts
+++ b/packages/apollo-language-server/src/providers/schema/engine.ts
@@ -61,7 +61,7 @@ export class EngineSchemaProvider implements GraphQLSchemaProvider {
 
     if (!(data && data.service && data.service.__typename === "Service")) {
       throw new Error(
-        `Unable to get schema from Apollo Graph Manager for graph ${id}`
+        `Unable to get schema from Apollo Engine for service ${id}`
       );
     }
 

--- a/packages/apollo-language-server/src/providers/schema/engine.ts
+++ b/packages/apollo-language-server/src/providers/schema/engine.ts
@@ -3,8 +3,8 @@ import { NotificationHandler } from "vscode-languageserver";
 import gql from "graphql-tag";
 import { GraphQLSchema, buildClientSchema } from "graphql";
 import { ApolloEngineClient, ClientIdentity } from "../../engine";
-import { ClientConfig, parseServiceSpecifier } from "../../config";
-import { getServiceFromKey } from "../../config/utils";
+import { ClientProjectConfig, parseServiceSpecifier } from "../../config";
+import { getGraphIdFromKey } from "../../config/utils";
 import {
   GraphQLSchemaProvider,
   SchemaChangeUnsubscribeHandler,
@@ -19,7 +19,7 @@ export class EngineSchemaProvider implements GraphQLSchemaProvider {
   private client?: ApolloEngineClient;
 
   constructor(
-    private config: ClientConfig,
+    private config: ClientProjectConfig,
     private clientIdentity?: ClientIdentity
   ) {}
 
@@ -54,6 +54,7 @@ export class EngineSchemaProvider implements GraphQLSchemaProvider {
         tag: override && override.tag ? override.tag : tag
       }
     });
+
     if (errors) {
       // XXX better error handling of GraphQL errors
       throw new Error(errors.map(({ message }: Error) => message).join("\n"));

--- a/packages/apollo-language-server/src/providers/schema/engine.ts
+++ b/packages/apollo-language-server/src/providers/schema/engine.ts
@@ -46,12 +46,13 @@ export class EngineSchemaProvider implements GraphQLSchemaProvider {
     }
 
     const [id, tag = "current"] = parseServiceSpecifier(client.service);
+    const variantToGet = override && override.tag ? override.tag : tag;
 
     const { data, errors } = await this.client.execute<GetSchemaByTag>({
       query: SCHEMA_QUERY,
       variables: {
         id,
-        tag: override && override.tag ? override.tag : tag
+        tag: variantToGet
       }
     });
 
@@ -62,7 +63,7 @@ export class EngineSchemaProvider implements GraphQLSchemaProvider {
 
     if (!(data && data.service && data.service.__typename === "Service")) {
       throw new Error(
-        `Unable to get schema from Apollo Engine for service ${id}`
+        `Unable to get schema from Apollo Graph Manager for graph ${id}@${variantToGet}`
       );
     }
 

--- a/packages/apollo-language-server/src/providers/schema/index.ts
+++ b/packages/apollo-language-server/src/providers/schema/index.ts
@@ -25,19 +25,17 @@ export function schemaProviderFromConfig(
   config: ApolloConfig,
   clientIdentity?: ClientIdentity // engine provider needs this
 ): GraphQLSchemaProvider {
-  if (isServiceConfig(config)) {
-    if (config.service.localSchemaFile) {
-      const isListOfSchemaFiles = Array.isArray(config.service.localSchemaFile);
-      return new FileSchemaProvider(
-        isListOfSchemaFiles
-          ? { paths: config.service.localSchemaFile as string[] }
-          : { path: config.service.localSchemaFile as string }
-      );
-    }
+  if (config.service && config.service.endpoint) {
+    return new EndpointSchemaProvider(config.service.endpoint);
+  }
 
-    if (config.service.endpoint) {
-      return new EndpointSchemaProvider(config.service.endpoint);
-    }
+  if (config.service && config.service.localSchemaFile) {
+    const isListOfSchemaFiles = Array.isArray(config.service.localSchemaFile);
+    return new FileSchemaProvider(
+      isListOfSchemaFiles
+        ? { paths: config.service.localSchemaFile as string[] }
+        : { path: config.service.localSchemaFile as string }
+    );
   }
 
   if (isClientConfig(config)) {

--- a/packages/apollo-language-server/src/providers/schema/index.ts
+++ b/packages/apollo-language-server/src/providers/schema/index.ts
@@ -23,13 +23,14 @@ export {
 
 export function schemaProviderFromConfig(
   config: ApolloConfig,
-  clientIdentity?: ClientIdentity // engine provider needs this
+  clientIdentity?: ClientIdentity, // engine provider needs this
+  forClientCommands?: boolean
 ): GraphQLSchemaProvider {
-  if (config.service && config.service.endpoint) {
+  if (!forClientCommands && config.service && config.service.endpoint) {
     return new EndpointSchemaProvider(config.service.endpoint);
   }
 
-  if (config.service && config.service.localSchemaFile) {
+  if (!forClientCommands && config.service && config.service.localSchemaFile) {
     const isListOfSchemaFiles = Array.isArray(config.service.localSchemaFile);
     return new FileSchemaProvider(
       isListOfSchemaFiles
@@ -62,6 +63,6 @@ export function schemaProviderFromConfig(
   }
 
   throw new Error(
-    "No schema provider was created, because the project type was unable to be resolved from your config. Please add either a client or service config. For more information, please refer to https://bit.ly/2ByILPj"
+    "No schema provider was created, because the project type was unable to be resolved from your config. Please add either a client or service config. Currently, running `client:` commands are not supported without a `client` key in your config. For more information, please refer to https://bit.ly/2ByILPj"
   );
 }

--- a/packages/apollo-language-server/src/workspace.ts
+++ b/packages/apollo-language-server/src/workspace.ts
@@ -11,7 +11,7 @@ import {
   loadConfig,
   ApolloConfig,
   isClientConfig,
-  ServiceConfig
+  ServiceProjectConfig
 } from "./config";
 import { LanguageServerLoadingHandler } from "./loadingHandler";
 import { ServiceID, SchemaTag, ClientIdentity } from "./engine";
@@ -70,7 +70,7 @@ export class GraphQLWorkspace {
           clientIdentity
         })
       : new GraphQLServiceProject({
-          config: config as ServiceConfig,
+          config: config as ServiceProjectConfig,
           loadingHandler: this.LanguageServerLoadingHandler,
           rootURI: URI.parse(folder.uri),
           clientIdentity

--- a/packages/apollo-language-server/src/workspace.ts
+++ b/packages/apollo-language-server/src/workspace.ts
@@ -62,6 +62,7 @@ export class GraphQLWorkspace {
     folder: WorkspaceFolder;
   }) {
     const { clientIdentity } = this.config;
+    // TODO: Support the idea that config is always client & service
     const project = isClientConfig(config)
       ? new GraphQLClientProject({
           config,

--- a/packages/apollo-language-server/src/workspace.ts
+++ b/packages/apollo-language-server/src/workspace.ts
@@ -1,20 +1,20 @@
 import {
-  WorkspaceFolder,
   NotificationHandler,
-  PublishDiagnosticsParams
+  PublishDiagnosticsParams,
+  WorkspaceFolder
 } from "vscode-languageserver";
 import { QuickPickItem } from "vscode";
-import { GraphQLProject, DocumentUri } from "./project/base";
+import { DocumentUri, GraphQLProject } from "./project/base";
 import { dirname } from "path";
 import fg from "glob";
 import {
-  loadConfig,
   ApolloConfig,
   isClientConfig,
+  loadConfig,
   ServiceProjectConfig
 } from "./config";
 import { LanguageServerLoadingHandler } from "./loadingHandler";
-import { ServiceID, SchemaTag, ClientIdentity } from "./engine";
+import { ClientIdentity, SchemaTag, ServiceID } from "./engine";
 import { GraphQLClientProject, isClientProject } from "./project/client";
 import { GraphQLServiceProject } from "./project/service";
 import URI from "vscode-uri";
@@ -67,7 +67,8 @@ export class GraphQLWorkspace {
           config,
           loadingHandler: this.LanguageServerLoadingHandler,
           rootURI: URI.parse(folder.uri),
-          clientIdentity
+          clientIdentity,
+          loadSchemaOnStartup: true
         })
       : new GraphQLServiceProject({
           config: config as ServiceProjectConfig,

--- a/packages/apollo/package.json
+++ b/packages/apollo/package.json
@@ -59,6 +59,7 @@
     "listr": "0.14.3",
     "lodash.identity": "3.0.0",
     "lodash.pickby": "4.6.0",
+    "lodash.merge": "4.6.1",
     "moment": "2.24.0",
     "strip-ansi": "5.2.0",
     "table": "5.4.6",

--- a/packages/apollo/src/Command.ts
+++ b/packages/apollo/src/Command.ts
@@ -147,7 +147,7 @@ export abstract class ProjectCommand extends Command {
     }
 
     config.tag = flags.tag || config.tag || "current";
-    //  flag overides
+    //  flag overrides
     config.setDefaults({
       engine: {
         apiKey: flags.key,

--- a/packages/apollo/src/Command.ts
+++ b/packages/apollo/src/Command.ts
@@ -158,6 +158,8 @@ export abstract class ProjectCommand extends Command {
 
     config.serviceGraphVariant =
       flags.tag || config.serviceGraphVariant || "current";
+    config.clientGraphVariant =
+      flags.tag || config.clientGraphVariant || "current";
     // Flags always override the config
     config.engine = merge(Object.create(null), config.engine, {
       apiKey: flags.key,
@@ -222,7 +224,8 @@ export abstract class ProjectCommand extends Command {
       config,
       loadingHandler,
       rootURI,
-      clientIdentity
+      clientIdentity,
+      loadSchemaOnStartup: false
     });
     this.serviceProject = new GraphQLServiceProject({
       config,

--- a/packages/apollo/src/Command.ts
+++ b/packages/apollo/src/Command.ts
@@ -214,15 +214,15 @@ export abstract class ProjectCommand extends Command {
       referenceID
     };
 
-    if (isServiceConfig(config)) {
-      this.project = new GraphQLServiceProject({
+    if (isClientConfig(config) && !isServiceConfig(config)) {
+      this.project = new GraphQLClientProject({
         config,
         loadingHandler,
         rootURI,
         clientIdentity
       });
-    } else if (isClientConfig(config)) {
-      this.project = new GraphQLClientProject({
+    } else if (isServiceConfig(config)) {
+      this.project = new GraphQLServiceProject({
         config,
         loadingHandler,
         rootURI,

--- a/packages/apollo/src/commands/client/check.ts
+++ b/packages/apollo/src/commands/client/check.ts
@@ -62,7 +62,7 @@ export default class ClientCheck extends ClientCommand {
             ctx.validationResults = await clientProject.engine.validateOperations(
               {
                 id: config.graphId,
-                tag: config.serviceGraphVariant,
+                tag: config.clientGraphVariant,
                 operations: ctx.operations.map(({ body, name }) => ({
                   body,
                   name

--- a/packages/apollo/src/commands/client/check.ts
+++ b/packages/apollo/src/commands/client/check.ts
@@ -36,15 +36,10 @@ export default class ClientCheck extends ClientCommand {
       operations: Operation[];
       validationResults: ValidationResult[];
     }>(
-      ({ project, config }) => [
+      ({ clientProject, config }) => [
         {
           title: "Checking client compatibility with service",
           task: async ctx => {
-            if (!isClientConfig(project.config)) {
-              throw new Error("not a client project!");
-            } else {
-              console.log("here is a log");
-            }
             if (!config.graphId) {
               throw new Error(
                 "No service found to link to Engine. Engine is required for this command."
@@ -53,7 +48,7 @@ export default class ClientCheck extends ClientCommand {
             ctx.gitContext = await gitInfo(this.log);
 
             ctx.operations = Object.entries(
-              this.project.mergedOperationsAndFragmentsForService
+              clientProject.mergedOperationsAndFragmentsForService
             ).map(([name, doc]) => ({
               body: print(doc),
               name,
@@ -64,15 +59,17 @@ export default class ClientCheck extends ClientCommand {
               locationOffset: doc.definitions[0].loc!.source.locationOffset
             }));
 
-            ctx.validationResults = await project.engine.validateOperations({
-              id: config.graphId,
-              tag: config.tag,
-              operations: ctx.operations.map(({ body, name }) => ({
-                body,
-                name
-              })),
-              gitContext: ctx.gitContext
-            });
+            ctx.validationResults = await clientProject.engine.validateOperations(
+              {
+                id: config.graphId,
+                tag: config.serviceGraphVariant,
+                operations: ctx.operations.map(({ body, name }) => ({
+                  body,
+                  name
+                })),
+                gitContext: ctx.gitContext
+              }
+            );
           }
         }
       ],

--- a/packages/apollo/src/commands/client/check.ts
+++ b/packages/apollo/src/commands/client/check.ts
@@ -40,7 +40,7 @@ export default class ClientCheck extends ClientCommand {
         {
           title: "Checking client compatibility with service",
           task: async ctx => {
-            if (!config.name) {
+            if (!config.graphId) {
               throw new Error(
                 "No service found to link to Engine. Engine is required for this command."
               );
@@ -60,7 +60,7 @@ export default class ClientCheck extends ClientCommand {
             }));
 
             ctx.validationResults = await project.engine.validateOperations({
-              id: config.name,
+              id: config.graphId,
               tag: config.tag,
               operations: ctx.operations.map(({ body, name }) => ({
                 body,

--- a/packages/apollo/src/commands/client/check.ts
+++ b/packages/apollo/src/commands/client/check.ts
@@ -5,7 +5,7 @@ import { ClientCommand } from "../../Command";
 import { CompactRenderer } from "../../utils";
 import URI from "vscode-uri";
 import { relative } from "path";
-import { graphqlTypes } from "apollo-language-server";
+import { graphqlTypes, isClientConfig } from "apollo-language-server";
 import chalk from "chalk";
 import envCi from "env-ci";
 
@@ -40,6 +40,11 @@ export default class ClientCheck extends ClientCommand {
         {
           title: "Checking client compatibility with service",
           task: async ctx => {
+            if (!isClientConfig(project.config)) {
+              throw new Error("not a client project!");
+            } else {
+              console.log("here is a log");
+            }
             if (!config.graphId) {
               throw new Error(
                 "No service found to link to Engine. Engine is required for this command."

--- a/packages/apollo/src/commands/client/codegen.ts
+++ b/packages/apollo/src/commands/client/codegen.ts
@@ -162,9 +162,7 @@ export default class Generate extends ClientCommand {
           );
         }
 
-        console.log("validating project");
         clientProject.validate();
-        console.log("validated");
 
         return [
           {

--- a/packages/apollo/src/commands/client/codegen.ts
+++ b/packages/apollo/src/commands/client/codegen.ts
@@ -125,10 +125,12 @@ export default class Generate extends ClientCommand {
       flags: { watch },
       args: { output }
     } = this.parse(Generate);
+    await this.clientProject.loadSchema();
 
     let write;
     const run = () =>
-      this.runTasks(({ flags, args, clientProject, config }) => {
+      this.runTasks(({ flags, args, config }) => {
+        const clientProject = this.clientProject;
         let inferredTarget: TargetType = "" as TargetType;
         if (
           ["json", "swift", "typescript", "flow", "scala"].includes(

--- a/packages/apollo/src/commands/client/download-schema.ts
+++ b/packages/apollo/src/commands/client/download-schema.ts
@@ -23,11 +23,13 @@ export default class SchemaDownload extends ClientCommand {
   async run() {
     let result;
     let gitContext;
-    await this.runTasks(({ args, project, flags }) => [
+    await this.runTasks(({ args, clientProject, flags, config }) => [
       {
         title: `Saving schema to ${args.output}`,
         task: async () => {
-          const schema = await project.resolveSchema({ tag: flags.tag });
+          const schema = await clientProject.resolveSchema({
+            tag: config.serviceGraphVariant
+          });
           writeFileSync(
             args.output,
             JSON.stringify(introspectionFromSchema(schema), null, 2)

--- a/packages/apollo/src/commands/client/extract.ts
+++ b/packages/apollo/src/commands/client/extract.ts
@@ -26,11 +26,11 @@ export default class ClientExtract extends ClientCommand {
       clientIdentity: ClientIdentity;
       operations: ManifestEntry[];
       filename: string;
-    }>(({ flags, project, config, args }) => [
+    }>(({ config, args }) => [
       {
         title: "Extracting operations from project",
         task: async ctx => {
-          ctx.operations = getOperationManifestFromProject(this.project);
+          ctx.operations = getOperationManifestFromProject(this.clientProject);
           ctx.clientIdentity = config.client;
         }
       },

--- a/packages/apollo/src/commands/client/push.ts
+++ b/packages/apollo/src/commands/client/push.ts
@@ -26,7 +26,7 @@ export default class ClientPush extends ClientCommand {
     const invalidOperationsErrorMessage = "encountered invalid operations";
     let result = "";
     try {
-      await this.runTasks(({ flags, project, config }) => {
+      await this.runTasks(({ flags, clientProject, config }) => {
         const clientBundleInfo = `${chalk.blue(
           (config.client && config.client.name) || flags
         )}${chalk.blue(
@@ -41,7 +41,7 @@ export default class ClientPush extends ClientCommand {
             title: `Extracting operation from client, ${clientBundleInfo}`,
             task: async (ctx, task) => {
               const operationManifest = getOperationManifestFromProject(
-                this.project
+                clientProject
               );
               ctx.operationManifest = operationManifest;
               task.title = `Extracted ${pluralize(
@@ -53,7 +53,7 @@ export default class ClientPush extends ClientCommand {
           {
             title: `Checked operations against ${chalk.blue(
               config.graphId || ""
-            )}@${chalk.blue(config.tag)}`,
+            )}@${chalk.blue(config.serviceGraphVariant)}`,
             task: async () => {}
           },
           {
@@ -66,11 +66,11 @@ export default class ClientPush extends ClientCommand {
               }
 
               const operationManifest = getOperationManifestFromProject(
-                this.project
+                this.clientProject
               );
 
               const signatureToOperation = generateSignatureToOperationMap(
-                this.project,
+                this.clientProject,
                 config
               );
 
@@ -88,7 +88,7 @@ export default class ClientPush extends ClientCommand {
                 id: config.graphId,
                 operations: operationManifest,
                 manifestVersion: 2,
-                graphVariant: config.tag
+                graphVariant: config.serviceGraphVariant
               };
               const { operations: _op, ...restVariables } = variables;
               this.debug("Variables sent to Apollo");
@@ -101,7 +101,7 @@ export default class ClientPush extends ClientCommand {
                 invalidOperations,
                 newOperations,
                 registrationSuccess
-              } = (response = await project.engine.registerOperations(
+              } = (response = await clientProject.engine.registerOperations(
                 variables
               ));
 

--- a/packages/apollo/src/commands/client/push.ts
+++ b/packages/apollo/src/commands/client/push.ts
@@ -52,14 +52,14 @@ export default class ClientPush extends ClientCommand {
           },
           {
             title: `Checked operations against ${chalk.blue(
-              config.name || ""
+              config.graphId || ""
             )}@${chalk.blue(config.tag)}`,
             task: async () => {}
           },
           {
             title: "Pushing operations to operation registry",
             task: async (_, task) => {
-              if (!config.name) {
+              if (!config.graphId) {
                 throw new Error(
                   "No service found to link to Engine. Engine is required for this command."
                 );
@@ -85,7 +85,7 @@ export default class ClientPush extends ClientCommand {
                   identifier: referenceID || name,
                   version
                 },
-                id: config.name,
+                id: config.graphId,
                 operations: operationManifest,
                 manifestVersion: 2,
                 graphVariant: config.tag

--- a/packages/apollo/src/commands/service/__tests__/__snapshots__/check.test.ts.snap
+++ b/packages/apollo/src/commands/service/__tests__/__snapshots__/check.test.ts.snap
@@ -132,32 +132,15 @@ Found 3 graph composition errors for service accounts on graph engine
 `;
 
 exports[`service:check integration federated should report composition errors correctly vanilla 1`] = `
-"
-  ✔ Loading Apollo Project
-  ⠙ Validate graph composition for service accounts on graph engine
-    → Attempting to compose graph with accounts service's partial schema
-    Comparing schema changes
-    Reporting result
-  ✔ Loading Apollo Project
-  ⠹ Validate graph composition for service accounts on graph engine
-    → Attempting to compose graph with accounts service's partial schema
-    Comparing schema changes
-    Reporting result
-  ✔ Loading Apollo Project
-  ⠸ Validate graph composition for service accounts on graph engine
-    → Attempting to compose graph with accounts service's partial schema
-    Comparing schema changes
-    Reporting result
-  ✔ Loading Apollo Project
-  ⠼ Validate graph composition for service accounts on graph engine
-    → Attempting to compose graph with accounts service's partial schema
-    Comparing schema changes
-    Reporting result
-  ✔ Loading Apollo Project
-  ✖ Found 3 graph composition errors for service accounts on graph engine
-    → Federated service composition was unsuccessful. Please see the reasons below.
-    Comparing schema changes
-    Reporting result
+"Loading Apollo Project [started]
+Loading Apollo Project [completed]
+Validate graph composition for service accounts on graph engine [started]
+→ Fetching local service's partial schema
+→ Attempting to compose graph with accounts service's partial schema
+Found 3 graph composition errors for service accounts on graph engine [title changed]
+Found 3 graph composition errors for service accounts on graph engine [failed]
+→ Federated service composition was unsuccessful. Please see the reasons below.
+
 ╔══════════╤═════════╤════════════════════════════════════════════════════╗
 ║ Service  │ Field   │ Message                                            ║
 ╟──────────┼─────────┼────────────────────────────────────────────────────╢
@@ -221,15 +204,19 @@ View full details at: https://engine-staging.apollographql.com/service/justin-fu
 `;
 
 exports[`service:check integration federated should report composition success correctly vanilla 1`] = `
-"  ✔ Loading Apollo Project
-  ⠙ Validate graph composition for service accounts on graph engine
-    → Attempting to compose graph with accounts service's partial schema
-    Comparing schema changes
-    Reporting result
-  ✔ Loading Apollo Project
-  ✔ Found 0 graph composition errors for service accounts on graph engine
-  ✔ Compared 1 schema change against 0 operations over the last 548 days
-  ✔ Found 0 breaking changes and 1 compatible change
+"Loading Apollo Project [started]
+Loading Apollo Project [completed]
+Validate graph composition for service accounts on graph engine [started]
+→ Fetching local service's partial schema
+→ Attempting to compose graph with accounts service's partial schema
+Found 0 graph composition errors for service accounts on graph engine [title changed]
+Found 0 graph composition errors for service accounts on graph engine [completed]
+Comparing schema changes [started]
+Compared 1 schema change against 0 operations over the last 548 days [title changed]
+Compared 1 schema change against 0 operations over the last 548 days [completed]
+Reporting result [started]
+Found 0 breaking changes and 1 compatible change [title changed]
+Found 0 breaking changes and 1 compatible change [completed]
 ╔════════╤══════════════════╤═══════════════════════════════════════════════════════════════════════════════╗
 ║ Change │ Code             │ Description                                                                   ║
 ╟────────┼──────────────────┼───────────────────────────────────────────────────────────────────────────────╢
@@ -274,16 +261,20 @@ exports[`service:check integration non-federated should report traffic errors co
 `;
 
 exports[`service:check integration non-federated should report traffic errors correctly vanilla 1`] = `
-"  ✔ Loading Apollo Project
-  ⠙ Validating schema against tag master on graph engine
-    → Validating schema
-    Comparing schema changes
-    Reporting result
-  ✔ Loading Apollo Project
-  ✔ Validated schema against tag master on graph engine
-  ✔ Compared 1 schema change against 0 operations over the last 548 days
-  ✖ Found 1 breaking change and 0 compatible changes
-    → breaking changes found
+"Loading Apollo Project [started]
+Loading Apollo Project [completed]
+Validating schema against tag master on graph engine [started]
+→ Resolving schema
+→ Validating schema
+Validated schema against tag master on graph engine [title changed]
+Validated schema against tag master on graph engine [completed]
+Comparing schema changes [started]
+Compared 1 schema change against 0 operations over the last 548 days [title changed]
+Compared 1 schema change against 0 operations over the last 548 days [completed]
+Reporting result [started]
+Found 1 breaking change and 0 compatible changes [title changed]
+Found 1 breaking change and 0 compatible changes [failed]
+→ breaking changes found
 ╔════════╤══════════════════╤═══════════════════════════════════════════════════════════════════════════════╗
 ║ Change │ Code             │ Description                                                                   ║
 ╟────────┼──────────────────┼───────────────────────────────────────────────────────────────────────────────╢
@@ -328,15 +319,19 @@ exports[`service:check integration non-federated should report traffic non-error
 `;
 
 exports[`service:check integration non-federated should report traffic non-errors correctly vanilla 1`] = `
-"  ✔ Loading Apollo Project
-  ⠙ Validating schema against tag master on graph engine
-    → Validating schema
-    Comparing schema changes
-    Reporting result
-  ✔ Loading Apollo Project
-  ✔ Validated schema against tag master on graph engine
-  ✔ Compared 1 schema change against 0 operations over the last 548 days
-  ✔ Found 0 breaking changes and 1 compatible change
+"Loading Apollo Project [started]
+Loading Apollo Project [completed]
+Validating schema against tag master on graph engine [started]
+→ Resolving schema
+→ Validating schema
+Validated schema against tag master on graph engine [title changed]
+Validated schema against tag master on graph engine [completed]
+Comparing schema changes [started]
+Compared 1 schema change against 0 operations over the last 548 days [title changed]
+Compared 1 schema change against 0 operations over the last 548 days [completed]
+Reporting result [started]
+Found 0 breaking changes and 1 compatible change [title changed]
+Found 0 breaking changes and 1 compatible change [completed]
 ╔════════╤══════════════════╤═══════════════════════════════════════════════════════════════════════════════╗
 ║ Change │ Code             │ Description                                                                   ║
 ╟────────┼──────────────────┼───────────────────────────────────────────────────────────────────────────────╢

--- a/packages/apollo/src/commands/service/__tests__/__snapshots__/check.test.ts.snap
+++ b/packages/apollo/src/commands/service/__tests__/__snapshots__/check.test.ts.snap
@@ -132,15 +132,32 @@ Found 3 graph composition errors for service accounts on graph engine
 `;
 
 exports[`service:check integration federated should report composition errors correctly vanilla 1`] = `
-"Loading Apollo Project [started]
-Loading Apollo Project [completed]
-Validate graph composition for service accounts on graph engine [started]
-→ Fetching local service's partial schema
-→ Attempting to compose graph with accounts service's partial schema
-Found 3 graph composition errors for service accounts on graph engine [title changed]
-Found 3 graph composition errors for service accounts on graph engine [failed]
-→ Federated service composition was unsuccessful. Please see the reasons below.
-
+"
+  ✔ Loading Apollo Project
+  ⠙ Validate graph composition for service accounts on graph engine
+    → Attempting to compose graph with accounts service's partial schema
+    Comparing schema changes
+    Reporting result
+  ✔ Loading Apollo Project
+  ⠹ Validate graph composition for service accounts on graph engine
+    → Attempting to compose graph with accounts service's partial schema
+    Comparing schema changes
+    Reporting result
+  ✔ Loading Apollo Project
+  ⠸ Validate graph composition for service accounts on graph engine
+    → Attempting to compose graph with accounts service's partial schema
+    Comparing schema changes
+    Reporting result
+  ✔ Loading Apollo Project
+  ⠼ Validate graph composition for service accounts on graph engine
+    → Attempting to compose graph with accounts service's partial schema
+    Comparing schema changes
+    Reporting result
+  ✔ Loading Apollo Project
+  ✖ Found 3 graph composition errors for service accounts on graph engine
+    → Federated service composition was unsuccessful. Please see the reasons below.
+    Comparing schema changes
+    Reporting result
 ╔══════════╤═════════╤════════════════════════════════════════════════════╗
 ║ Service  │ Field   │ Message                                            ║
 ╟──────────┼─────────┼────────────────────────────────────────────────────╢
@@ -204,19 +221,15 @@ View full details at: https://engine-staging.apollographql.com/service/justin-fu
 `;
 
 exports[`service:check integration federated should report composition success correctly vanilla 1`] = `
-"Loading Apollo Project [started]
-Loading Apollo Project [completed]
-Validate graph composition for service accounts on graph engine [started]
-→ Fetching local service's partial schema
-→ Attempting to compose graph with accounts service's partial schema
-Found 0 graph composition errors for service accounts on graph engine [title changed]
-Found 0 graph composition errors for service accounts on graph engine [completed]
-Comparing schema changes [started]
-Compared 1 schema change against 0 operations over the last 548 days [title changed]
-Compared 1 schema change against 0 operations over the last 548 days [completed]
-Reporting result [started]
-Found 0 breaking changes and 1 compatible change [title changed]
-Found 0 breaking changes and 1 compatible change [completed]
+"  ✔ Loading Apollo Project
+  ⠙ Validate graph composition for service accounts on graph engine
+    → Attempting to compose graph with accounts service's partial schema
+    Comparing schema changes
+    Reporting result
+  ✔ Loading Apollo Project
+  ✔ Found 0 graph composition errors for service accounts on graph engine
+  ✔ Compared 1 schema change against 0 operations over the last 548 days
+  ✔ Found 0 breaking changes and 1 compatible change
 ╔════════╤══════════════════╤═══════════════════════════════════════════════════════════════════════════════╗
 ║ Change │ Code             │ Description                                                                   ║
 ╟────────┼──────────────────┼───────────────────────────────────────────────────────────────────────────────╢
@@ -261,20 +274,16 @@ exports[`service:check integration non-federated should report traffic errors co
 `;
 
 exports[`service:check integration non-federated should report traffic errors correctly vanilla 1`] = `
-"Loading Apollo Project [started]
-Loading Apollo Project [completed]
-Validating schema against tag master on graph engine [started]
-→ Resolving schema
-→ Validating schema
-Validated schema against tag master on graph engine [title changed]
-Validated schema against tag master on graph engine [completed]
-Comparing schema changes [started]
-Compared 1 schema change against 0 operations over the last 548 days [title changed]
-Compared 1 schema change against 0 operations over the last 548 days [completed]
-Reporting result [started]
-Found 1 breaking change and 0 compatible changes [title changed]
-Found 1 breaking change and 0 compatible changes [failed]
-→ breaking changes found
+"  ✔ Loading Apollo Project
+  ⠙ Validating schema against tag master on graph engine
+    → Validating schema
+    Comparing schema changes
+    Reporting result
+  ✔ Loading Apollo Project
+  ✔ Validated schema against tag master on graph engine
+  ✔ Compared 1 schema change against 0 operations over the last 548 days
+  ✖ Found 1 breaking change and 0 compatible changes
+    → breaking changes found
 ╔════════╤══════════════════╤═══════════════════════════════════════════════════════════════════════════════╗
 ║ Change │ Code             │ Description                                                                   ║
 ╟────────┼──────────────────┼───────────────────────────────────────────────────────────────────────────────╢
@@ -319,19 +328,15 @@ exports[`service:check integration non-federated should report traffic non-error
 `;
 
 exports[`service:check integration non-federated should report traffic non-errors correctly vanilla 1`] = `
-"Loading Apollo Project [started]
-Loading Apollo Project [completed]
-Validating schema against tag master on graph engine [started]
-→ Resolving schema
-→ Validating schema
-Validated schema against tag master on graph engine [title changed]
-Validated schema against tag master on graph engine [completed]
-Comparing schema changes [started]
-Compared 1 schema change against 0 operations over the last 548 days [title changed]
-Compared 1 schema change against 0 operations over the last 548 days [completed]
-Reporting result [started]
-Found 0 breaking changes and 1 compatible change [title changed]
-Found 0 breaking changes and 1 compatible change [completed]
+"  ✔ Loading Apollo Project
+  ⠙ Validating schema against tag master on graph engine
+    → Validating schema
+    Comparing schema changes
+    Reporting result
+  ✔ Loading Apollo Project
+  ✔ Validated schema against tag master on graph engine
+  ✔ Compared 1 schema change against 0 operations over the last 548 days
+  ✔ Found 0 breaking changes and 1 compatible change
 ╔════════╤══════════════════╤═══════════════════════════════════════════════════════════════════════════════╗
 ║ Change │ Code             │ Description                                                                   ║
 ╟────────┼──────────────────┼───────────────────────────────────────────────────────────────────────────────╢

--- a/packages/apollo/src/commands/service/check.ts
+++ b/packages/apollo/src/commands/service/check.ts
@@ -468,8 +468,6 @@ export default class ServiceCheck extends ProjectCommand {
                 const checkSchemaResult = await project.engine.checkSchema(
                   variables
                 );
-
-                console.log(JSON.stringify(checkSchemaResult, null, 2));
                 // Attach to ctx as this will be used in later steps.
                 ctx.checkSchemaResult = checkSchemaResult;
                 // Save the output because we're going to use it even if we throw. `runTasks` won't return

--- a/packages/apollo/src/commands/service/check.ts
+++ b/packages/apollo/src/commands/service/check.ts
@@ -288,12 +288,6 @@ export default class ServiceCheck extends ProjectCommand {
     try {
       await this.runTasks<TasksOutput>(
         ({ config, flags, project }) => {
-          if (!isServiceProject(project)) {
-            throw new Error(
-              "This project needs to be configured as a service project but is configured as a client project. Please see bit.ly/2ByILPj for help regarding configuration."
-            );
-          }
-
           /**
            * Name of the graph being checked. `engine` is an example of a graph.
            *

--- a/packages/apollo/src/commands/service/check.ts
+++ b/packages/apollo/src/commands/service/check.ts
@@ -288,6 +288,12 @@ export default class ServiceCheck extends ProjectCommand {
     try {
       await this.runTasks<TasksOutput>(
         ({ config, flags, project }) => {
+          if (!isServiceProject(project)) {
+            throw new Error(
+              "This project needs to be configured as a service project but is configured as a client project. Please see bit.ly/2ByILPj for help regarding configuration."
+            );
+          }
+
           /**
            * Name of the graph being checked. `engine` is an example of a graph.
            *
@@ -304,7 +310,7 @@ export default class ServiceCheck extends ProjectCommand {
           const serviceName: string | undefined = flags.serviceName;
 
           if (!graphID) {
-            throw new Error("No graph found to link to Apollo Graph Manager");
+            throw new Error("No service found to link to Engine");
           }
 
           // Add some fields to output that are required for producing

--- a/packages/apollo/src/commands/service/check.ts
+++ b/packages/apollo/src/commands/service/check.ts
@@ -468,6 +468,8 @@ export default class ServiceCheck extends ProjectCommand {
                 const checkSchemaResult = await project.engine.checkSchema(
                   variables
                 );
+
+                console.log(JSON.stringify(checkSchemaResult, null, 2));
                 // Attach to ctx as this will be used in later steps.
                 ctx.checkSchemaResult = checkSchemaResult;
                 // Save the output because we're going to use it even if we throw. `runTasks` won't return

--- a/packages/apollo/src/commands/service/check.ts
+++ b/packages/apollo/src/commands/service/check.ts
@@ -283,22 +283,18 @@ export default class ServiceCheck extends ProjectCommand {
     const { isCi } = envCi();
 
     let schema: GraphQLSchema | undefined;
+    let graphID: string | undefined;
+    let graphVariant: string | undefined;
     try {
       await this.runTasks<TasksOutput>(
         ({ config, flags, project }) => {
-          if (!isServiceProject(project)) {
-            throw new Error(
-              "This project needs to be configured as a service project but is configured as a client project. Please see bit.ly/2ByILPj for help regarding configuration."
-            );
-          }
-
           /**
            * Name of the graph being checked. `engine` is an example of a graph.
            *
            * A graph can be either a monolithic schema or the result of composition a federated schema.
            */
-          const graphName = config.name;
-          const tag = flags.tag || config.tag || "current";
+          graphID = config.name;
+          graphVariant = flags.tag || config.tag || "current";
 
           /**
            * Name of the implementing service being checked.
@@ -307,8 +303,8 @@ export default class ServiceCheck extends ProjectCommand {
            */
           const serviceName: string | undefined = flags.serviceName;
 
-          if (!graphName) {
-            throw new Error("No service found to link to Engine");
+          if (!graphID) {
+            throw new Error("No graph found to link to Apollo Graph Manager");
           }
 
           // Add some fields to output that are required for producing
@@ -323,7 +319,7 @@ export default class ServiceCheck extends ProjectCommand {
               enabled: () => !!serviceName,
               title: `Validate graph composition for service ${chalk.blue(
                 serviceName || ""
-              )} on graph ${chalk.blue(graphName)}`,
+              )} on graph ${chalk.blue(graphID)}`,
               task: async (ctx: TasksOutput, task) => {
                 if (!serviceName) {
                   throw new Error(
@@ -352,8 +348,8 @@ export default class ServiceCheck extends ProjectCommand {
                   compositionValidationResult,
                   checkSchemaResult
                 } = await project.engine.checkPartialSchema({
-                  id: graphName,
-                  graphVariant: tag,
+                  id: graphID!,
+                  graphVariant: graphVariant!,
                   implementingServiceName: serviceName,
                   partialSchema: {
                     sdl
@@ -367,7 +363,7 @@ export default class ServiceCheck extends ProjectCommand {
                   compositionValidationResult.errors.length,
                   "graph composition error"
                 )} for service ${chalk.blue(serviceName)} on graph ${chalk.blue(
-                  graphName
+                  graphID!
                 )}`;
 
                 if (compositionValidationResult.errors.length > 0) {
@@ -417,9 +413,9 @@ export default class ServiceCheck extends ProjectCommand {
             {
               title: `Validating ${
                 serviceName ? "composed " : ""
-              }schema against tag ${chalk.blue(tag)} on graph ${chalk.blue(
-                graphName
-              )}`,
+              }schema against tag ${chalk.blue(
+                graphVariant!
+              )} on graph ${chalk.blue(graphID)}`,
               // We have already performed validation per operation above if the service is federated
               enabled: () => !serviceName,
               task: async (ctx: TasksOutput, task) => {
@@ -450,7 +446,7 @@ export default class ServiceCheck extends ProjectCommand {
                 task.output = "Validating schema";
 
                 const variables: CheckSchemaVariables = {
-                  id: graphName,
+                  id: graphID!,
                   tag: flags.tag,
                   gitContext: await gitInfo(this.log),
                   frontend: flags.frontend || config.engine.frontend,
@@ -603,20 +599,7 @@ export default class ServiceCheck extends ProjectCommand {
         )
       );
     } else if (shouldOutputMarkdown) {
-      // This _should_ always be here; but TypeScript tells us that's optional. If we check it here, then
-      // passing `config` to any other function will signify that `config.service` might now be null or
-      // undefined. Save it as a const to tell TypeScript `service` can't be changed.
-
-      const { service } = config;
-      if (!service) {
-        throw new Error(
-          "Service mising from config. This should have been validated elsewhere"
-        );
-      }
-
-      const graphName = config.service && config.service.name;
-
-      if (!graphName) {
+      if (!graphID) {
         throw new Error(
           "The graph name should have been defined in the Apollo config and validated when the config was loaded. Please file an issue if you're seeing this error."
         );
@@ -632,7 +615,7 @@ export default class ServiceCheck extends ProjectCommand {
         return this.log(
           formatCompositionErrorsMarkdown({
             compositionErrors,
-            graphName,
+            graphName: graphID,
             serviceName,
             tag: config.tag
           })
@@ -642,7 +625,7 @@ export default class ServiceCheck extends ProjectCommand {
       return this.log(
         formatMarkdown({
           checkSchemaResult,
-          graphName,
+          graphName: graphID,
           serviceName,
           tag: config.tag,
           graphCompositionID

--- a/packages/apollo/src/commands/service/check.ts
+++ b/packages/apollo/src/commands/service/check.ts
@@ -294,10 +294,7 @@ export default class ServiceCheck extends ProjectCommand {
            * A graph can be either a monolithic schema or the result of composition a federated schema.
            */
           graphID = config.graphId;
-          graphVariant =
-            flags.serviceGraphVariant ||
-            config.serviceGraphVariant ||
-            "current";
+          graphVariant = flags.tag || config.serviceGraphVariant || "current";
 
           /**
            * Name of the implementing service being checked.

--- a/packages/apollo/src/commands/service/check.ts
+++ b/packages/apollo/src/commands/service/check.ts
@@ -288,12 +288,22 @@ export default class ServiceCheck extends ProjectCommand {
     try {
       await this.runTasks<TasksOutput>(
         ({ config, flags, project }) => {
+          if (
+            !isServiceProject(project) &&
+            !(flags.endpoint || flags.localSchemaFile)
+          ) {
+            throw new Error(
+              "This project must be configured as a service project or define `endpoint` or `localSchemaFile` " +
+                "in order to run service:check"
+            );
+          }
+
           /**
            * Name of the graph being checked. `engine` is an example of a graph.
            *
            * A graph can be either a monolithic schema or the result of composition a federated schema.
            */
-          graphID = config.name;
+          graphID = config.graphId;
           graphVariant = flags.tag || config.tag || "current";
 
           /**
@@ -447,7 +457,7 @@ export default class ServiceCheck extends ProjectCommand {
 
                 const variables: CheckSchemaVariables = {
                   id: graphID!,
-                  tag: flags.tag,
+                  tag: graphVariant,
                   gitContext: await gitInfo(this.log),
                   frontend: flags.frontend || config.engine.frontend,
                   ...(historicParameters && { historicParameters }),

--- a/packages/apollo/src/commands/service/delete.ts
+++ b/packages/apollo/src/commands/service/delete.ts
@@ -31,7 +31,7 @@ export default class ServiceDelete extends ProjectCommand {
       {
         title: "Removing service from Engine",
         task: async () => {
-          if (!config.name) {
+          if (!config.graphId) {
             throw new Error("No service found to link to Engine");
           }
 
@@ -47,7 +47,7 @@ export default class ServiceDelete extends ProjectCommand {
             errors,
             updatedGateway
           } = await project.engine.removeServiceAndCompose({
-            id: config.name,
+            id: config.graphId,
             graphVariant,
             name: flags.serviceName
           });
@@ -55,7 +55,7 @@ export default class ServiceDelete extends ProjectCommand {
           result = {
             serviceName: flags.serviceName,
             graphVariant,
-            graphName: config.name,
+            graphName: config.graphId,
             errors,
             updatedGateway
           };

--- a/packages/apollo/src/commands/service/delete.ts
+++ b/packages/apollo/src/commands/service/delete.ts
@@ -27,7 +27,7 @@ export default class ServiceDelete extends ProjectCommand {
 
   async run() {
     let result;
-    await this.runTasks(({ flags, project, config }) => [
+    await this.runTasks(({ flags, serviceProject, config }) => [
       {
         title: "Removing service from Engine",
         task: async () => {
@@ -41,12 +41,15 @@ export default class ServiceDelete extends ProjectCommand {
             );
           }
 
-          const graphVariant = flags.tag || config.tag || "current";
+          const graphVariant =
+            flags.serviceGraphVariant ||
+            config.serviceGraphVariant ||
+            "current";
 
           const {
             errors,
             updatedGateway
-          } = await project.engine.removeServiceAndCompose({
+          } = await serviceProject.engine.removeServiceAndCompose({
             id: config.graphId,
             graphVariant,
             name: flags.serviceName

--- a/packages/apollo/src/commands/service/download.ts
+++ b/packages/apollo/src/commands/service/download.ts
@@ -33,12 +33,14 @@ export default class ServiceDownload extends ProjectCommand {
   async run() {
     let result;
     let gitContext;
-    await this.runTasks(({ args, project, flags }) => [
+    await this.runTasks(({ args, serviceProject, flags }) => [
       {
         title: `Saving schema to ${args.output}`,
         task: async () => {
           try {
-            const schema = await project.resolveSchema({ tag: flags.tag });
+            const schema = await serviceProject.resolveSchema({
+              tag: flags.serviceGraphVariant
+            });
             writeFileSync(
               args.output,
               JSON.stringify(introspectionFromSchema(schema), null, 2)

--- a/packages/apollo/src/commands/service/list.ts
+++ b/packages/apollo/src/commands/service/list.ts
@@ -100,7 +100,6 @@ export default class ServiceList extends ProjectCommand {
     // @ts-ignore we're going to populate `taskOutput` later
     const taskOutput: TasksOutput = {};
 
-    let schema: GraphQLSchema | undefined;
     let graphID: string | undefined;
     let graphVariant: string | undefined;
     try {

--- a/packages/apollo/src/commands/service/list.ts
+++ b/packages/apollo/src/commands/service/list.ts
@@ -110,7 +110,7 @@ export default class ServiceList extends ProjectCommand {
          *
          * A graph can be either a monolithic schema or the result of composition a federated schema.
          */
-        graphID = config.name;
+        graphID = config.graphId;
         graphVariant = flags.tag || config.tag || "current";
 
         if (!graphID) {
@@ -151,7 +151,7 @@ export default class ServiceList extends ProjectCommand {
     this.log(
       formatHumanReadable({
         implementingServices: taskOutput.implementingServices,
-        graphName: taskOutput.config.name,
+        graphName: taskOutput.config.graphId,
         frontendUrl:
           taskOutput.config.engine.frontend || DefaultEngineConfig.frontend
       })

--- a/packages/apollo/src/commands/service/list.ts
+++ b/packages/apollo/src/commands/service/list.ts
@@ -101,37 +101,33 @@ export default class ServiceList extends ProjectCommand {
     const taskOutput: TasksOutput = {};
 
     let schema: GraphQLSchema | undefined;
+    let graphID: string | undefined;
+    let graphVariant: string | undefined;
     try {
       await this.runTasks<TasksOutput>(({ config, flags, project }) => {
-        if (!isServiceProject(project)) {
-          throw new Error(
-            "This project needs to be configured as a service project but is configured as a client project. Please see bit.ly/2ByILPj for help regarding configuration."
-          );
-        }
-
         /**
          * Name of the graph being checked. `engine` is an example of a graph.
          *
          * A graph can be either a monolithic schema or the result of composition a federated schema.
          */
-        const graphName = config.name;
-        const variant = flags.tag || config.tag || "current";
+        graphID = config.name;
+        graphVariant = flags.tag || config.tag || "current";
 
-        if (!graphName) {
+        if (!graphID) {
           throw new Error("No service found to link to Engine");
         }
 
         return [
           {
             title: `Fetching list of services for graph ${chalk.blue(
-              graphName + "@" + variant
+              graphID + "@" + graphVariant
             )}`,
             task: async (ctx: TasksOutput, task) => {
               const {
                 implementingServices
               } = await project.engine.listServices({
-                id: graphName,
-                graphVariant: variant
+                id: graphID!,
+                graphVariant: graphVariant!
               });
               const newContext: typeof ctx = {
                 implementingServices,
@@ -151,17 +147,6 @@ export default class ServiceList extends ProjectCommand {
         return;
       }
       throw error;
-    }
-
-    // This _should_ always be here; but TypeScript tells us that's optional. If we check it here, then
-    // passing `config` to any other function will signify that `config.service` might now be null or
-    // undefined. Save it as a const to tell TypeScript `service` can't be changed.
-
-    const { service } = taskOutput.config;
-    if (!service || !taskOutput.config) {
-      throw new Error(
-        "Service mising from config. This should have been validated elsewhere"
-      );
     }
     this.log(
       formatHumanReadable({

--- a/packages/apollo/src/commands/service/list.ts
+++ b/packages/apollo/src/commands/service/list.ts
@@ -104,14 +104,15 @@ export default class ServiceList extends ProjectCommand {
     let graphID: string | undefined;
     let graphVariant: string | undefined;
     try {
-      await this.runTasks<TasksOutput>(({ config, flags, project }) => {
+      await this.runTasks<TasksOutput>(({ config, flags, serviceProject }) => {
         /**
          * Name of the graph being checked. `engine` is an example of a graph.
          *
          * A graph can be either a monolithic schema or the result of composition a federated schema.
          */
         graphID = config.graphId;
-        graphVariant = flags.tag || config.tag || "current";
+        graphVariant =
+          flags.serviceGraphVariant || config.serviceGraphVariant || "current";
 
         if (!graphID) {
           throw new Error("No service found to link to Engine");
@@ -125,7 +126,7 @@ export default class ServiceList extends ProjectCommand {
             task: async (ctx: TasksOutput, task) => {
               const {
                 implementingServices
-              } = await project.engine.listServices({
+              } = await serviceProject.engine.listServices({
                 id: graphID!,
                 graphVariant: graphVariant!
               });

--- a/packages/apollo/src/commands/service/push.ts
+++ b/packages/apollo/src/commands/service/push.ts
@@ -50,7 +50,7 @@ export default class ServicePush extends ProjectCommand {
       {
         title: "Uploading service to Engine",
         task: async () => {
-          if (!config.name) {
+          if (!config.graphId) {
             throw new Error("No service found to link to Engine");
           }
 
@@ -92,7 +92,7 @@ export default class ServicePush extends ProjectCommand {
               didUpdateGateway,
               serviceWasCreated
             } = await project.engine.uploadAndComposePartialSchema({
-              id: config.name,
+              id: config.graphId,
               graphVariant: config.tag,
               name: flags.serviceName,
               url: flags.serviceURL,
@@ -111,7 +111,7 @@ export default class ServicePush extends ProjectCommand {
               compositionErrors: errors,
               serviceWasCreated,
               didUpdateGateway,
-              graphId: config.name,
+              graphId: config.graphId,
               graphVariant: config.tag || "current"
             };
 
@@ -121,7 +121,7 @@ export default class ServicePush extends ProjectCommand {
           const schema = await project.resolveSchema({ tag: flags.tag });
 
           const variables: UploadSchemaVariables = {
-            id: config.name,
+            id: config.graphId,
             // @ts-ignore
             // XXX Looks like TS should be generating ReadonlyArrays instead
             schema: introspectionFromSchema(schema).__schema,
@@ -138,7 +138,7 @@ export default class ServicePush extends ProjectCommand {
           const response = await project.engine.uploadSchema(variables);
           if (response) {
             result = {
-              graphId: config.name,
+              graphId: config.graphId,
               graphVariant: response.tag ? response.tag.tag : "current",
               hash: response.tag ? response.tag.schema.hash : null,
               code: response.code

--- a/packages/apollo/src/utils/getOperationManifestFromProject.ts
+++ b/packages/apollo/src/utils/getOperationManifestFromProject.ts
@@ -15,24 +15,22 @@ export interface ManifestEntry {
 export function getOperationManifestFromProject(
   project: GraphQLClientProject
 ): ManifestEntry[] {
-  const manifest = Object.entries(
-    project.mergedOperationsAndFragmentsForService
-  ).map(([operationName, operationAST]) => {
-    const printed = defaultOperationRegistrySignature(
-      operationAST,
-      operationName
-    );
+  return Object.entries(project.mergedOperationsAndFragmentsForService).map(
+    ([operationName, operationAST]) => {
+      const printed = defaultOperationRegistrySignature(
+        operationAST,
+        operationName
+      );
 
-    return {
-      signature: operationHash(printed),
-      document: printed,
-      // TODO: unused. Remove or repurpose this field altogether with op. registry 2.0 work.
-      // For now, this field is non-nullable on the input type.
-      metadata: {
-        engineSignature: ""
-      }
-    };
-  });
-
-  return manifest;
+      return {
+        signature: operationHash(printed),
+        document: printed,
+        // TODO: unused. Remove or repurpose this field altogether with op. registry 2.0 work.
+        // For now, this field is non-nullable on the input type.
+        metadata: {
+          engineSignature: ""
+        }
+      };
+    }
+  );
 }


### PR DESCRIPTION
This PR supports setting `ENGINE_API_KEY` to the user's token! The reason why we need to support user tokens is so that we can eventually move to a world where the CLI doesn't need to depend on service tokens and so that we can instantiate the environment variables by running `apollo login` rather than manually copying and pasting keys into configuration files. 


TODO:

- [ ] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [x] Make sure all of the significant new logic is covered by tests
- [ ] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass

\*Make sure changelog entries note which project(s) has been affected. See older entries for examples on what this looks like.
