### PR TITLE
Fixes #1617: Federation Enum not parsing value 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 - `apollo-env`
   - <First `apollo-env` related entry goes here>
 - `apollo-graphql`
-  - <First `apollo-graphql` related entry goes here>
+  - [#1618] Fixes an issue when enums with a value of 0 fail to resolve when using a Federated Schema (https://github.com/apollographql/apollo-tooling/pull/1618)
 - `apollo-language-server`
   - <First `apollo-language-server` related entry goes here>
 - `apollo-tools`

--- a/packages/apollo-graphql/src/schema/__tests__/buildSchemaFromSDL.test.ts
+++ b/packages/apollo-graphql/src/schema/__tests__/buildSchemaFromSDL.test.ts
@@ -503,5 +503,49 @@ type MutationRoot {
       expect(colorEnum.getValue("RED")!.value).toBe("#f00");
       expect(mockResolver).toBeCalledWith(undefined, { borderColor: "#f00" });
     });
+
+    it(`should add resolvers to enum types with 0 value`, () => {
+      const typeDefs = gql`
+        enum CustomerType {
+          EXISTING
+          NEW
+        }
+
+        type Query {
+          existingCustomer: CustomerType
+          newCustomer: CustomerType
+        }
+      `;
+
+      const resolvers = {
+        CustomerType: {
+          EXISTING: 0,
+          NEW: 1
+        },
+        Query: {
+          existingCustomer: () => 0,
+          newCustomer: () => 1
+        }
+      };
+
+      const schema = buildSchemaFromSDL([{ typeDefs, resolvers }]);
+      const customerTypeEnum = schema.getType("CustomerType") as GraphQLEnumType;
+
+      let result = execute(
+        schema,
+        gql`
+          query {
+            existingCustomer
+            newCustomer
+          }
+        `
+      );
+
+      expect((result as ExecutionResult).data!.existingCustomer).toBe("EXISTING");
+      expect(customerTypeEnum.getValue("EXISTING")!.value).toBe(0);
+
+      expect((result as ExecutionResult).data!.newCustomer).toBe("NEW");
+      expect(customerTypeEnum.getValue("NEW")!.value).toBe(1);
+    });
   });
 });

--- a/packages/apollo-graphql/src/schema/__tests__/buildSchemaFromSDL.test.ts
+++ b/packages/apollo-graphql/src/schema/__tests__/buildSchemaFromSDL.test.ts
@@ -529,7 +529,9 @@ type MutationRoot {
       };
 
       const schema = buildSchemaFromSDL([{ typeDefs, resolvers }]);
-      const customerTypeEnum = schema.getType("CustomerType") as GraphQLEnumType;
+      const customerTypeEnum = schema.getType(
+        "CustomerType"
+      ) as GraphQLEnumType;
 
       let result = execute(
         schema,
@@ -541,9 +543,10 @@ type MutationRoot {
         `
       );
 
-      expect((result as ExecutionResult).data!.existingCustomer).toBe("EXISTING");
+      expect((result as ExecutionResult).data!.existingCustomer).toBe(
+        "EXISTING"
+      );
       expect(customerTypeEnum.getValue("EXISTING")!.value).toBe(0);
-
       expect((result as ExecutionResult).data!.newCustomer).toBe("NEW");
       expect(customerTypeEnum.getValue("NEW")!.value).toBe(1);
     });

--- a/packages/apollo-graphql/src/schema/buildSchemaFromSDL.ts
+++ b/packages/apollo-graphql/src/schema/buildSchemaFromSDL.ts
@@ -237,7 +237,10 @@ export function addResolversToSchema(
       const values = type.getValues();
       const newValues: { [key: string]: GraphQLEnumValue } = {};
       values.forEach(value => {
-        const newValue = (fieldConfigs as any)[value.name] || value.name;
+        let newValue = (fieldConfigs as any)[value.name];
+        if (newValue == undefined) {
+          newValue = value.name;
+        }
         newValues[value.name] = {
           value: newValue,
           deprecationReason: value.deprecationReason,

--- a/packages/apollo-graphql/src/schema/buildSchemaFromSDL.ts
+++ b/packages/apollo-graphql/src/schema/buildSchemaFromSDL.ts
@@ -238,7 +238,7 @@ export function addResolversToSchema(
       const newValues: { [key: string]: GraphQLEnumValue } = {};
       values.forEach(value => {
         let newValue = (fieldConfigs as any)[value.name];
-        if (newValue == undefined) {
+        if (newValue === undefined) {
           newValue = value.name;
         }
         newValues[value.name] = {


### PR DESCRIPTION
Fixes https://github.com/apollographql/apollo-tooling/issues/1617

Updated buildSchemaFromSDL to handle enums with a value of 0. Previously, when an enum had a value of 0, the name would be used as the enum value.

Added a unit test to ensure 0 is parsed correctly.

TODO:

- [X] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [X] Make sure all of the significant new logic is covered by tests
- [X] Rebase your changes on master so that they can be merged easily
- [X] Make sure all tests and linter rules pass

