### PR TITLE
[Swift] Add documentation to input structs' init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - `apollo-codegen-scala`
   - <First `apollo-codegen-scala` related entry goes here>
 - `apollo-codegen-swift`
-  - <First `apollo-codegen-swift` related entry goes here>
+  - Add documentation to input structs' constructors [#1619](https://github.com/apollographql/apollo-tooling/pull/1619)
 - `apollo-codegen-typescript`
   - <First `apollo-codegen-typescript` related entry goes here>
 - `apollo-env`

--- a/packages/apollo-codegen-swift/src/__tests__/__snapshots__/codeGeneration.ts.snap
+++ b/packages/apollo-codegen-swift/src/__tests__/__snapshots__/codeGeneration.ts.snap
@@ -2011,6 +2011,10 @@ exports[`Swift code generation #typeDeclarationForGraphQLType() should generate 
 public struct ReviewInput: GraphQLMapConvertible {
   public var graphQLMap: GraphQLMap
 
+  /// - Parameters:
+  ///   - stars: 0-5 stars
+  ///   - commentary: Comment about the movie, optional
+  ///   - favoriteColor: Favorite color, optional
   public init(stars: Int, commentary: Swift.Optional<String?> = nil, favoriteColor: Swift.Optional<ColorInput?> = nil) {
     graphQLMap = [\\"stars\\": stars, \\"commentary\\": commentary, \\"favorite_color\\": favoriteColor]
   }

--- a/packages/apollo-codegen-swift/src/codeGeneration.ts
+++ b/packages/apollo-codegen-swift/src/codeGeneration.ts
@@ -1203,6 +1203,21 @@ export class SwiftAPIGenerator extends SwiftGenerator<CompilerContext> {
         this.printOnNewline(swift`public var graphQLMap: GraphQLMap`);
 
         this.printNewlineIfNeeded();
+
+        if (properties.length > 0) {
+          this.comment("- Parameters:");
+          properties.forEach(property => {
+            var propertyDescription = "";
+            if (property.description) {
+              propertyDescription = `: ${property.description}`;
+            }
+            this.comment(
+              `  - ${property.propertyName}${propertyDescription}`,
+              false
+            );
+          });
+        }
+
         this.printOnNewline(swift`public init`);
         this.print(swift`(`);
         this.print(

--- a/packages/apollo-codegen-swift/src/language.ts
+++ b/packages/apollo-codegen-swift/src/language.ts
@@ -388,10 +388,10 @@ export class SwiftGenerator<Context> extends CodeGenerator<
     }
   }
 
-  comment(comment?: string) {
+  comment(comment?: string, trim: Boolean = true) {
     comment &&
       comment.split("\n").forEach(line => {
-        this.printOnNewline(SwiftSource.raw`/// ${line.trim()}`);
+        this.printOnNewline(SwiftSource.raw`/// ${trim ? line.trim() : line}`);
       });
   }
 


### PR DESCRIPTION
Implement [feature request](https://github.com/apollographql/apollo-ios/issues/562) to add documentation to input structs' generated constructors.

Generates documentation of the form:
```
/// - Parameters:
///   - someUndocumentedField
///   - someDocumentedField: This field has a documentation comment. When it is really long,
/// it wraps like this.
```

The way the text wraps is admittedly not ideal, but I couldn't think of a good way to make it wrap like this:
```
///   - someDocumentedField: This field has a documentation comment. When it is really long,
///                          it would be nice if it wrapped like this.
```

TODO:

- [x] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass