### PR TITLE
Adjust misnamed `fileExtension` to `tsFileExtension` in help.

### DIFF
--- a/packages/apollo/src/commands/client/codegen.ts
+++ b/packages/apollo/src/commands/client/codegen.ts
@@ -103,7 +103,7 @@ export default class Generate extends ClientCommand {
     // typescript
     globalTypesFile: flags.string({
       description:
-        'By default, TypeScript will put a file named "globalTypes.ts" inside the "output" directory. Set "globalTypesFile" to specify a different path. Alternatively, set "fileExtension" to modify the extension of the file, for example "d.ts" will output "globalTypes.d.ts"'
+        'By default, TypeScript will put a file named "globalTypes.ts" inside the "output" directory. Set "globalTypesFile" to specify a different path. Alternatively, set "tsFileExtension" to modify the extension of the file, for example "d.ts" will output "globalTypes.d.ts"'
     }),
     tsFileExtension: flags.string({
       description:


### PR DESCRIPTION
The name used in this parameter's help appears to be the previous version of the flag which is listed directly below this in the source (`tsFileExtension`).