### PR TITLE
Fix thrown errors breaking out of --watch mode

### DIFF
--- a/packages/apollo-language-server/src/errors/validation.ts
+++ b/packages/apollo-language-server/src/errors/validation.ts
@@ -28,6 +28,7 @@ import {
   ExecutionContext
 } from "graphql/execution/execute";
 import { hasClientDirective, simpleCollectFields } from "../utilities/graphql";
+import { Debug } from "../utilities";
 
 export interface CodeActionInfo {
   message: string;
@@ -72,7 +73,7 @@ export function validateQueryDocument(
       for (const error of validationErrors) {
         logError(error);
       }
-      throw new ToolError("Validation of GraphQL query document failed");
+      return Debug.error("Validation of GraphQL query document failed");
     }
   } catch (e) {
     console.error(e);

--- a/packages/apollo/src/Command.ts
+++ b/packages/apollo/src/Command.ts
@@ -108,10 +108,7 @@ export abstract class ProjectCommand extends Command {
     Debug.SetLoggers({
       info: this.log,
       warning: this.warn,
-      error: message => {
-        this.error(message);
-        this.exit(1);
-      }
+      error: console.error
     });
 
     const config = await this.createConfig(flags);

--- a/packages/apollo/src/commands/client/codegen.ts
+++ b/packages/apollo/src/commands/client/codegen.ts
@@ -5,9 +5,10 @@ import { Kind, DocumentNode } from "graphql";
 import tty from "tty";
 import { Gaze } from "gaze";
 import URI from "vscode-uri";
+import chalk from "chalk";
+import { Debug } from "apollo-language-server";
 
 import { TargetType, default as generate } from "../../generate";
-
 import { ClientCommand } from "../../Command";
 
 const waitForKey = async () => {
@@ -246,7 +247,12 @@ export default class Generate extends ClientCommand {
         if (file.indexOf(output) > -1) return;
         this.project.fileDidChange(URI.file(file).toString());
         console.log("\nChange detected, generating types...");
-        write();
+        try {
+          const fileCount = write();
+          console.log(`${chalk.green("✔")} Wrote ${fileCount} files`);
+        } catch (e) {
+          Debug.error("Error while generating types: " + e.message);
+        }
       });
       if (tty.isatty((process.stdin as any).fd)) {
         await waitForKey();


### PR DESCRIPTION
Currently, if you write an operation that throws an error in the validation step of codegen while in `--watch` mode, the watching will stop.

This PR changes a couple things to prevent that.

1. instead of `throw`ing an error in the validation step, we use the error logger from `apollo-language-server`.
2. Changes the error logger that the CLI sets from using `this.error` (which exits with a 1 code) to `console.error`.
3. Updates the watch mode function to catch thrown errors properly, as well as printing how many files are written.

TODO:

- [ ] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [ ] Make sure all of the significant new logic is covered by tests
- [ ] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests and linter rules pass

\*Make sure changelog entries note which project(s) has been affected. See older entries for examples on what this looks like.
