### PR TITLE
Fix client localSchemaFile for vscode stats command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
 - `apollo-tools`
   - <First `apollo-tools` related entry goes here>
 - `vscode-apollo`
-  - <First `vscode-apollo` related entry goes here>
+  - Fix client localSchemaFile for vscode stats command [#1634](https://github.com/apollographql/apollo-tooling/pull/1634)
 
 ## `apollo@2.21.1`
 

--- a/packages/apollo-language-server/src/project/client.ts
+++ b/packages/apollo-language-server/src/project/client.ts
@@ -178,7 +178,7 @@ export class GraphQLClientProject extends GraphQLProject {
         total: totalTypes
       },
       tag: this.config.tag,
-      loaded: Boolean(this.serviceID && (this.schema || this.serviceSchema)),
+      loaded: Boolean(this.schema || this.serviceSchema),
       lastFetch: this.lastLoadDate
     };
   }


### PR DESCRIPTION
Currently, if you click on the Apollo logo on the status bar, stats for the project you're working with are supposed to show, to confirm the config was setup properly and the extension has loaded.

If you're setting up a client project and using a `localSchemaFile` though, the stats will fail to load unless there is a service `name` also provided, which isn't required.

This removes the check in the stats loading function that forced a client to have a `client.service.name` even if not using graph manager to load the schema.

<!--
  Thanks for filing a pull request on Apollo Tooling!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [ ] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [ ] Make sure all of the significant new logic is covered by tests
- [ ] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests and linter rules pass

\*Make sure changelog entries note which project(s) has been affected. See older entries for examples on what this looks like.
