### PR TITLE
[Swift Codegen] Adding some explicit type annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - `apollo-codegen-scala`
   - <First `apollo-codegen-scala` related entry goes here>
 - `apollo-codegen-swift`
-  - <First `apollo-codegen-swift` related entry goes here>
+  - Add additional type annotations to improve compile times.  [1638](https://github.com/apollographql/apollo-tooling/pull/1638)
 - `apollo-codegen-typescript`
   - <First `apollo-codegen-typescript` related entry goes here>
 - `apollo-env`

--- a/packages/apollo-codegen-swift/src/__tests__/__snapshots__/codeGeneration.ts.snap
+++ b/packages/apollo-codegen-swift/src/__tests__/__snapshots__/codeGeneration.ts.snap
@@ -916,7 +916,7 @@ exports[`Swift code generation #initializerDeclarationForProperties() should gen
 exports[`Swift code generation #structDeclarationForFragment() should generate a struct declaration for a fragment that includes a fragment spread 1`] = `
 "public struct HeroDetails: GraphQLFragment {
   /// The raw GraphQL definition of this fragment.
-  public static let fragmentDefinition =
+  public static let fragmentDefinition: String =
     \\"\\"\\"
     fragment HeroDetails on Character {
       name
@@ -996,7 +996,7 @@ exports[`Swift code generation #structDeclarationForFragment() should generate a
 exports[`Swift code generation #structDeclarationForFragment() should generate a struct declaration for a fragment with a concrete type condition 1`] = `
 "public struct DroidDetails: GraphQLFragment {
   /// The raw GraphQL definition of this fragment.
-  public static let fragmentDefinition =
+  public static let fragmentDefinition: String =
     \\"\\"\\"
     fragment DroidDetails on Droid {
       name
@@ -1046,7 +1046,7 @@ exports[`Swift code generation #structDeclarationForFragment() should generate a
 exports[`Swift code generation #structDeclarationForFragment() should generate a struct declaration for a fragment with a subselection 1`] = `
 "public struct HeroDetails: GraphQLFragment {
   /// The raw GraphQL definition of this fragment.
-  public static let fragmentDefinition =
+  public static let fragmentDefinition: String =
     \\"\\"\\"
     fragment HeroDetails on Character {
       name
@@ -1134,7 +1134,7 @@ exports[`Swift code generation #structDeclarationForFragment() should generate a
 exports[`Swift code generation #structDeclarationForFragment() should generate a struct declaration for a fragment with an abstract type condition 1`] = `
 "public struct HeroDetails: GraphQLFragment {
   /// The raw GraphQL definition of this fragment.
-  public static let fragmentDefinition =
+  public static let fragmentDefinition: String =
     \\"\\"\\"
     fragment HeroDetails on Character {
       name

--- a/packages/apollo-codegen-swift/src/__tests__/__snapshots__/codeGeneration.ts.snap
+++ b/packages/apollo-codegen-swift/src/__tests__/__snapshots__/codeGeneration.ts.snap
@@ -3,7 +3,7 @@
 exports[`Swift code generation #classDeclarationForOperation() should correctly escape a mutli-line string literal 1`] = `
 "public final class CreateReviewMutation: GraphQLMutation {
   /// The raw GraphQL definition of this operation.
-  public let operationDefinition =
+  public let operationDefinition: String =
     #\\"\\"\\"
     mutation CreateReview($episode: Episode) {
       createReview(episode: $episode, review: {stars: 5, commentary: \\"\\"\\"
@@ -17,7 +17,7 @@ exports[`Swift code generation #classDeclarationForOperation() should correctly 
     }
     \\"\\"\\"#
 
-  public let operationName = \\"CreateReview\\"
+  public let operationName: String = \\"CreateReview\\"
 
   public var episode: Episode?
 
@@ -30,7 +30,7 @@ exports[`Swift code generation #classDeclarationForOperation() should correctly 
   }
 
   public struct Data: GraphQLSelectionSet {
-    public static let possibleTypes = [\\"Mutation\\"]
+    public static let possibleTypes: [String] = [\\"Mutation\\"]
 
     public static let selections: [GraphQLSelection] = [
       GraphQLField(\\"createReview\\", arguments: [\\"episode\\": GraphQLVariable(\\"episode\\"), \\"review\\": [\\"stars\\": 5, \\"commentary\\": \\"Wow!\\\\n I thought\\\\n  This movie ROCKED!\\"]], type: .object(CreateReview.selections)),
@@ -56,7 +56,7 @@ exports[`Swift code generation #classDeclarationForOperation() should correctly 
     }
 
     public struct CreateReview: GraphQLSelectionSet {
-      public static let possibleTypes = [\\"Review\\"]
+      public static let possibleTypes: [String] = [\\"Review\\"]
 
       public static let selections: [GraphQLSelection] = [
         GraphQLField(\\"stars\\", type: .nonNull(.scalar(Int.self))),
@@ -100,7 +100,7 @@ exports[`Swift code generation #classDeclarationForOperation() should correctly 
 exports[`Swift code generation #classDeclarationForOperation() should correctly escape a mutli-line string literal with backslashes 1`] = `
 "public final class CreateReviewMutation: GraphQLMutation {
   /// The raw GraphQL definition of this operation.
-  public let operationDefinition =
+  public let operationDefinition: String =
     #\\"\\"\\"
     mutation CreateReview($episode: Episode) {
       createReview(episode: $episode, review: {stars: 5, commentary: \\"\\"\\"
@@ -114,7 +114,7 @@ exports[`Swift code generation #classDeclarationForOperation() should correctly 
     }
     \\"\\"\\"#
 
-  public let operationName = \\"CreateReview\\"
+  public let operationName: String = \\"CreateReview\\"
 
   public var episode: Episode?
 
@@ -127,7 +127,7 @@ exports[`Swift code generation #classDeclarationForOperation() should correctly 
   }
 
   public struct Data: GraphQLSelectionSet {
-    public static let possibleTypes = [\\"Mutation\\"]
+    public static let possibleTypes: [String] = [\\"Mutation\\"]
 
     public static let selections: [GraphQLSelection] = [
       GraphQLField(\\"createReview\\", arguments: [\\"episode\\": GraphQLVariable(\\"episode\\"), \\"review\\": [\\"stars\\": 5, \\"commentary\\": \\"Wow!\\\\n I thought\\\\n  This movie \\\\\\\\ ROCKED!\\"]], type: .object(CreateReview.selections)),
@@ -153,7 +153,7 @@ exports[`Swift code generation #classDeclarationForOperation() should correctly 
     }
 
     public struct CreateReview: GraphQLSelectionSet {
-      public static let possibleTypes = [\\"Review\\"]
+      public static let possibleTypes: [String] = [\\"Review\\"]
 
       public static let selections: [GraphQLSelection] = [
         GraphQLField(\\"stars\\", type: .nonNull(.scalar(Int.self))),
@@ -197,7 +197,7 @@ exports[`Swift code generation #classDeclarationForOperation() should correctly 
 exports[`Swift code generation #classDeclarationForOperation() should generate a class declaration for a mutation with variables 1`] = `
 "public final class CreateReviewMutation: GraphQLMutation {
   /// The raw GraphQL definition of this operation.
-  public let operationDefinition =
+  public let operationDefinition: String =
     \\"\\"\\"
     mutation CreateReview($episode: Episode) {
       createReview(episode: $episode, review: {stars: 5, commentary: \\"Wow!\\"}) {
@@ -207,7 +207,7 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
     }
     \\"\\"\\"
 
-  public let operationName = \\"CreateReview\\"
+  public let operationName: String = \\"CreateReview\\"
 
   public var episode: Episode?
 
@@ -220,7 +220,7 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
   }
 
   public struct Data: GraphQLSelectionSet {
-    public static let possibleTypes = [\\"Mutation\\"]
+    public static let possibleTypes: [String] = [\\"Mutation\\"]
 
     public static let selections: [GraphQLSelection] = [
       GraphQLField(\\"createReview\\", arguments: [\\"episode\\": GraphQLVariable(\\"episode\\"), \\"review\\": [\\"stars\\": 5, \\"commentary\\": \\"Wow!\\"]], type: .object(CreateReview.selections)),
@@ -246,7 +246,7 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
     }
 
     public struct CreateReview: GraphQLSelectionSet {
-      public static let possibleTypes = [\\"Review\\"]
+      public static let possibleTypes: [String] = [\\"Review\\"]
 
       public static let selections: [GraphQLSelection] = [
         GraphQLField(\\"stars\\", type: .nonNull(.scalar(Int.self))),
@@ -290,7 +290,7 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
 exports[`Swift code generation #classDeclarationForOperation() should generate a class declaration for a query with a fragment spread nested in an inline fragment 1`] = `
 "public final class HeroQuery: GraphQLQuery {
   /// The raw GraphQL definition of this operation.
-  public let operationDefinition =
+  public let operationDefinition: String =
     \\"\\"\\"
     query Hero {
       hero {
@@ -301,7 +301,7 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
     }
     \\"\\"\\"
 
-  public let operationName = \\"Hero\\"
+  public let operationName: String = \\"Hero\\"
 
   public var queryDocument: String { return operationDefinition.appending(HeroDetails.fragmentDefinition) }
 
@@ -309,7 +309,7 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
   }
 
   public struct Data: GraphQLSelectionSet {
-    public static let possibleTypes = [\\"Query\\"]
+    public static let possibleTypes: [String] = [\\"Query\\"]
 
     public static let selections: [GraphQLSelection] = [
       GraphQLField(\\"hero\\", type: .object(Hero.selections)),
@@ -335,7 +335,7 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
     }
 
     public struct Hero: GraphQLSelectionSet {
-      public static let possibleTypes = [\\"Human\\", \\"Droid\\"]
+      public static let possibleTypes: [String] = [\\"Human\\", \\"Droid\\"]
 
       public static let selections: [GraphQLSelection] = [
         GraphQLTypeCase(
@@ -371,7 +371,7 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
       }
 
       public struct AsDroid: GraphQLSelectionSet {
-        public static let possibleTypes = [\\"Droid\\"]
+        public static let possibleTypes: [String] = [\\"Droid\\"]
 
         public static let selections: [GraphQLSelection] = [
           GraphQLField(\\"name\\", type: .nonNull(.scalar(String.self))),
@@ -431,7 +431,7 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
 exports[`Swift code generation #classDeclarationForOperation() should generate a class declaration for a query with conditional fragment spreads 1`] = `
 "public final class HeroQuery: GraphQLQuery {
   /// The raw GraphQL definition of this operation.
-  public let operationDefinition =
+  public let operationDefinition: String =
     \\"\\"\\"
     query Hero {
       hero {
@@ -440,7 +440,7 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
     }
     \\"\\"\\"
 
-  public let operationName = \\"Hero\\"
+  public let operationName: String = \\"Hero\\"
 
   public var queryDocument: String { return operationDefinition.appending(DroidDetails.fragmentDefinition) }
 
@@ -448,7 +448,7 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
   }
 
   public struct Data: GraphQLSelectionSet {
-    public static let possibleTypes = [\\"Query\\"]
+    public static let possibleTypes: [String] = [\\"Query\\"]
 
     public static let selections: [GraphQLSelection] = [
       GraphQLField(\\"hero\\", type: .object(Hero.selections)),
@@ -474,7 +474,7 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
     }
 
     public struct Hero: GraphQLSelectionSet {
-      public static let possibleTypes = [\\"Human\\", \\"Droid\\"]
+      public static let possibleTypes: [String] = [\\"Human\\", \\"Droid\\"]
 
       public static let selections: [GraphQLSelection] = [
         GraphQLTypeCase(
@@ -538,7 +538,7 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
       }
 
       public struct AsDroid: GraphQLSelectionSet {
-        public static let possibleTypes = [\\"Droid\\"]
+        public static let possibleTypes: [String] = [\\"Droid\\"]
 
         public static let selections: [GraphQLSelection] = [
           GraphQLField(\\"primaryFunction\\", type: .scalar(String.self)),
@@ -598,7 +598,7 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
 exports[`Swift code generation #classDeclarationForOperation() should generate a class declaration for a query with fragment spreads 1`] = `
 "public final class HeroQuery: GraphQLQuery {
   /// The raw GraphQL definition of this operation.
-  public let operationDefinition =
+  public let operationDefinition: String =
     \\"\\"\\"
     query Hero {
       hero {
@@ -607,7 +607,7 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
     }
     \\"\\"\\"
 
-  public let operationName = \\"Hero\\"
+  public let operationName: String = \\"Hero\\"
 
   public var queryDocument: String { return operationDefinition.appending(HeroDetails.fragmentDefinition) }
 
@@ -615,7 +615,7 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
   }
 
   public struct Data: GraphQLSelectionSet {
-    public static let possibleTypes = [\\"Query\\"]
+    public static let possibleTypes: [String] = [\\"Query\\"]
 
     public static let selections: [GraphQLSelection] = [
       GraphQLField(\\"hero\\", type: .object(Hero.selections)),
@@ -641,7 +641,7 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
     }
 
     public struct Hero: GraphQLSelectionSet {
-      public static let possibleTypes = [\\"Human\\", \\"Droid\\"]
+      public static let possibleTypes: [String] = [\\"Human\\", \\"Droid\\"]
 
       public static let selections: [GraphQLSelection] = [
         GraphQLField(\\"name\\", type: .nonNull(.scalar(String.self))),
@@ -704,7 +704,7 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
 exports[`Swift code generation #classDeclarationForOperation() should generate a class declaration for a query with variables 1`] = `
 "public final class HeroNameQuery: GraphQLQuery {
   /// The raw GraphQL definition of this operation.
-  public let operationDefinition =
+  public let operationDefinition: String =
     \\"\\"\\"
     query HeroName($episode: Episode) {
       hero(episode: $episode) {
@@ -713,7 +713,7 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
     }
     \\"\\"\\"
 
-  public let operationName = \\"HeroName\\"
+  public let operationName: String = \\"HeroName\\"
 
   public var episode: Episode?
 
@@ -726,7 +726,7 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
   }
 
   public struct Data: GraphQLSelectionSet {
-    public static let possibleTypes = [\\"Query\\"]
+    public static let possibleTypes: [String] = [\\"Query\\"]
 
     public static let selections: [GraphQLSelection] = [
       GraphQLField(\\"hero\\", arguments: [\\"episode\\": GraphQLVariable(\\"episode\\")], type: .object(Hero.selections)),
@@ -752,7 +752,7 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
     }
 
     public struct Hero: GraphQLSelectionSet {
-      public static let possibleTypes = [\\"Human\\", \\"Droid\\"]
+      public static let possibleTypes: [String] = [\\"Human\\", \\"Droid\\"]
 
       public static let selections: [GraphQLSelection] = [
         GraphQLField(\\"name\\", type: .nonNull(.scalar(String.self))),
@@ -789,7 +789,7 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
 exports[`Swift code generation #classDeclarationForOperation() should generate a class declaration with an operationIdentifier property when generateOperationIds is specified 1`] = `
 "public final class HeroQuery: GraphQLQuery {
   /// The raw GraphQL definition of this operation.
-  public let operationDefinition =
+  public let operationDefinition: String =
     \\"\\"\\"
     query Hero {
       hero {
@@ -798,7 +798,7 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
     }
     \\"\\"\\"
 
-  public let operationName = \\"Hero\\"
+  public let operationName: String = \\"Hero\\"
 
   public let operationIdentifier: String? = \\"90d0d674eb6a7b33776f63200d6cec3d09f881247c360a2ac9a29037a02210c4\\"
 
@@ -808,7 +808,7 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
   }
 
   public struct Data: GraphQLSelectionSet {
-    public static let possibleTypes = [\\"Query\\"]
+    public static let possibleTypes: [String] = [\\"Query\\"]
 
     public static let selections: [GraphQLSelection] = [
       GraphQLField(\\"hero\\", type: .object(Hero.selections)),
@@ -834,7 +834,7 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
     }
 
     public struct Hero: GraphQLSelectionSet {
-      public static let possibleTypes = [\\"Human\\", \\"Droid\\"]
+      public static let possibleTypes: [String] = [\\"Human\\", \\"Droid\\"]
 
       public static let selections: [GraphQLSelection] = [
         GraphQLField(\\"name\\", type: .nonNull(.scalar(String.self))),
@@ -924,7 +924,7 @@ exports[`Swift code generation #structDeclarationForFragment() should generate a
     }
     \\"\\"\\"
 
-  public static let possibleTypes = [\\"Human\\", \\"Droid\\"]
+  public static let possibleTypes: [String] = [\\"Human\\", \\"Droid\\"]
 
   public static let selections: [GraphQLSelection] = [
     GraphQLField(\\"name\\", type: .nonNull(.scalar(String.self))),
@@ -1004,7 +1004,7 @@ exports[`Swift code generation #structDeclarationForFragment() should generate a
     }
     \\"\\"\\"
 
-  public static let possibleTypes = [\\"Droid\\"]
+  public static let possibleTypes: [String] = [\\"Droid\\"]
 
   public static let selections: [GraphQLSelection] = [
     GraphQLField(\\"name\\", type: .nonNull(.scalar(String.self))),
@@ -1056,7 +1056,7 @@ exports[`Swift code generation #structDeclarationForFragment() should generate a
     }
     \\"\\"\\"
 
-  public static let possibleTypes = [\\"Human\\", \\"Droid\\"]
+  public static let possibleTypes: [String] = [\\"Human\\", \\"Droid\\"]
 
   public static let selections: [GraphQLSelection] = [
     GraphQLField(\\"name\\", type: .nonNull(.scalar(String.self))),
@@ -1098,7 +1098,7 @@ exports[`Swift code generation #structDeclarationForFragment() should generate a
   }
 
   public struct Friend: GraphQLSelectionSet {
-    public static let possibleTypes = [\\"Human\\", \\"Droid\\"]
+    public static let possibleTypes: [String] = [\\"Human\\", \\"Droid\\"]
 
     public static let selections: [GraphQLSelection] = [
       GraphQLField(\\"name\\", type: .nonNull(.scalar(String.self))),
@@ -1142,7 +1142,7 @@ exports[`Swift code generation #structDeclarationForFragment() should generate a
     }
     \\"\\"\\"
 
-  public static let possibleTypes = [\\"Human\\", \\"Droid\\"]
+  public static let possibleTypes: [String] = [\\"Human\\", \\"Droid\\"]
 
   public static let selections: [GraphQLSelection] = [
     GraphQLField(\\"name\\", type: .nonNull(.scalar(String.self))),
@@ -1187,7 +1187,7 @@ exports[`Swift code generation #structDeclarationForFragment() should generate a
 
 exports[`Swift code generation #structDeclarationForSelectionSet() should escape init specially in a struct declaration initializer for a selection set 1`] = `
 "public struct Human: GraphQLSelectionSet {
-  public static let possibleTypes = [\\"Human\\"]
+  public static let possibleTypes: [String] = [\\"Human\\"]
 
   public static let selections: [GraphQLSelection] = [
     GraphQLField(\\"friends\\", alias: \\"self\\", type: .list(.object(\`Self\`.selections))),
@@ -1214,7 +1214,7 @@ exports[`Swift code generation #structDeclarationForSelectionSet() should escape
   }
 
   public struct \`Self\`: GraphQLSelectionSet {
-    public static let possibleTypes = [\\"Human\\", \\"Droid\\"]
+    public static let possibleTypes: [String] = [\\"Human\\", \\"Droid\\"]
 
     public static let selections: [GraphQLSelection] = [
       GraphQLField(\\"id\\", type: .nonNull(.scalar(GraphQLID.self))),
@@ -1247,7 +1247,7 @@ exports[`Swift code generation #structDeclarationForSelectionSet() should escape
 }
 
 public struct Human: GraphQLSelectionSet {
-  public static let possibleTypes = [\\"Human\\"]
+  public static let possibleTypes: [String] = [\\"Human\\"]
 
   public static let selections: [GraphQLSelection] = [
     GraphQLField(\\"friends\\", alias: \\"self\\", type: .list(.object(\`Self\`.selections))),
@@ -1285,7 +1285,7 @@ public struct Human: GraphQLSelectionSet {
   }
 
   public struct \`Self\`: GraphQLSelectionSet {
-    public static let possibleTypes = [\\"Human\\", \\"Droid\\"]
+    public static let possibleTypes: [String] = [\\"Human\\", \\"Droid\\"]
 
     public static let selections: [GraphQLSelection] = [
       GraphQLField(\\"id\\", type: .nonNull(.scalar(GraphQLID.self))),
@@ -1320,7 +1320,7 @@ public struct Human: GraphQLSelectionSet {
 
 exports[`Swift code generation #structDeclarationForSelectionSet() should escape reserved keywords in a struct declaration for a selection set 1`] = `
 "public struct Hero: GraphQLSelectionSet {
-  public static let possibleTypes = [\\"Human\\", \\"Droid\\"]
+  public static let possibleTypes: [String] = [\\"Human\\", \\"Droid\\"]
 
   public static let selections: [GraphQLSelection] = [
     GraphQLField(\\"name\\", alias: \\"private\\", type: .nonNull(.scalar(String.self))),
@@ -1362,7 +1362,7 @@ exports[`Swift code generation #structDeclarationForSelectionSet() should escape
   }
 
   public struct \`Self\`: GraphQLSelectionSet {
-    public static let possibleTypes = [\\"Human\\", \\"Droid\\"]
+    public static let possibleTypes: [String] = [\\"Human\\", \\"Droid\\"]
 
     public static let selections: [GraphQLSelection] = [
       GraphQLField(\\"id\\", type: .nonNull(.scalar(GraphQLID.self))),
@@ -1397,7 +1397,7 @@ exports[`Swift code generation #structDeclarationForSelectionSet() should escape
 
 exports[`Swift code generation #structDeclarationForSelectionSet() should generate a nested struct declaration for a selection set with subselections 1`] = `
 "public struct Hero: GraphQLSelectionSet {
-  public static let possibleTypes = [\\"Human\\", \\"Droid\\"]
+  public static let possibleTypes: [String] = [\\"Human\\", \\"Droid\\"]
 
   public static let selections: [GraphQLSelection] = [
     GraphQLField(\\"friends\\", type: .list(.object(Friend.selections))),
@@ -1428,7 +1428,7 @@ exports[`Swift code generation #structDeclarationForSelectionSet() should genera
   }
 
   public struct Friend: GraphQLSelectionSet {
-    public static let possibleTypes = [\\"Human\\", \\"Droid\\"]
+    public static let possibleTypes: [String] = [\\"Human\\", \\"Droid\\"]
 
     public static let selections: [GraphQLSelection] = [
       GraphQLField(\\"name\\", type: .nonNull(.scalar(String.self))),
@@ -1463,7 +1463,7 @@ exports[`Swift code generation #structDeclarationForSelectionSet() should genera
 
 exports[`Swift code generation #structDeclarationForSelectionSet() should generate a struct declaration for a fragment spread nested in an inline fragment 1`] = `
 "public struct Hero: GraphQLSelectionSet {
-  public static let possibleTypes = [\\"Human\\", \\"Droid\\"]
+  public static let possibleTypes: [String] = [\\"Human\\", \\"Droid\\"]
 
   public static let selections: [GraphQLSelection] = [
     GraphQLTypeCase(
@@ -1510,7 +1510,7 @@ exports[`Swift code generation #structDeclarationForSelectionSet() should genera
   }
 
   public struct AsDroid: GraphQLSelectionSet {
-    public static let possibleTypes = [\\"Droid\\"]
+    public static let possibleTypes: [String] = [\\"Droid\\"]
 
     public static let selections: [GraphQLSelection] = [
       GraphQLField(\\"name\\", type: .nonNull(.scalar(String.self))),
@@ -1568,7 +1568,7 @@ exports[`Swift code generation #structDeclarationForSelectionSet() should genera
 
 exports[`Swift code generation #structDeclarationForSelectionSet() should generate a struct declaration for a selection set 1`] = `
 "public struct Hero: GraphQLSelectionSet {
-  public static let possibleTypes = [\\"Human\\", \\"Droid\\"]
+  public static let possibleTypes: [String] = [\\"Human\\", \\"Droid\\"]
 
   public static let selections: [GraphQLSelection] = [
     GraphQLField(\\"name\\", type: .nonNull(.scalar(String.self))),
@@ -1602,7 +1602,7 @@ exports[`Swift code generation #structDeclarationForSelectionSet() should genera
 
 exports[`Swift code generation #structDeclarationForSelectionSet() should generate a struct declaration for a selection set with a conditional field 1`] = `
 "public struct Hero: GraphQLSelectionSet {
-  public static let possibleTypes = [\\"Human\\", \\"Droid\\"]
+  public static let possibleTypes: [String] = [\\"Human\\", \\"Droid\\"]
 
   public static let selections: [GraphQLSelection] = [
     GraphQLBooleanCondition(variableName: \\"includeName\\", inverted: false, selections: [
@@ -1638,7 +1638,7 @@ exports[`Swift code generation #structDeclarationForSelectionSet() should genera
 
 exports[`Swift code generation #structDeclarationForSelectionSet() should generate a struct declaration for a selection set with a fragment spread that matches the parent type 1`] = `
 "public struct Hero: GraphQLSelectionSet {
-  public static let possibleTypes = [\\"Human\\", \\"Droid\\"]
+  public static let possibleTypes: [String] = [\\"Human\\", \\"Droid\\"]
 
   public static let selections: [GraphQLSelection] = [
     GraphQLField(\\"name\\", type: .nonNull(.scalar(String.self))),
@@ -1699,7 +1699,7 @@ exports[`Swift code generation #structDeclarationForSelectionSet() should genera
 
 exports[`Swift code generation #structDeclarationForSelectionSet() should generate a struct declaration for a selection set with a fragment spread with a more specific type condition 1`] = `
 "public struct Hero: GraphQLSelectionSet {
-  public static let possibleTypes = [\\"Human\\", \\"Droid\\"]
+  public static let possibleTypes: [String] = [\\"Human\\", \\"Droid\\"]
 
   public static let selections: [GraphQLSelection] = [
     GraphQLTypeCase(
@@ -1774,7 +1774,7 @@ exports[`Swift code generation #structDeclarationForSelectionSet() should genera
   }
 
   public struct AsDroid: GraphQLSelectionSet {
-    public static let possibleTypes = [\\"Droid\\"]
+    public static let possibleTypes: [String] = [\\"Droid\\"]
 
     public static let selections: [GraphQLSelection] = [
       GraphQLField(\\"name\\", type: .nonNull(.scalar(String.self))),
@@ -1832,7 +1832,7 @@ exports[`Swift code generation #structDeclarationForSelectionSet() should genera
 
 exports[`Swift code generation #structDeclarationForSelectionSet() should generate a struct declaration for a selection set with an inline fragment 1`] = `
 "public struct Hero: GraphQLSelectionSet {
-  public static let possibleTypes = [\\"Human\\", \\"Droid\\"]
+  public static let possibleTypes: [String] = [\\"Human\\", \\"Droid\\"]
 
   public static let selections: [GraphQLSelection] = [
     GraphQLTypeCase(
@@ -1879,7 +1879,7 @@ exports[`Swift code generation #structDeclarationForSelectionSet() should genera
   }
 
   public struct AsDroid: GraphQLSelectionSet {
-    public static let possibleTypes = [\\"Droid\\"]
+    public static let possibleTypes: [String] = [\\"Droid\\"]
 
     public static let selections: [GraphQLSelection] = [
       GraphQLField(\\"name\\", type: .nonNull(.scalar(String.self))),
@@ -1921,7 +1921,7 @@ exports[`Swift code generation #structDeclarationForSelectionSet() should genera
 
 exports[`Swift code generation #structDeclarationForSelectionSet() should preserve leading and trailing underscores on fields 1`] = `
 "public struct Hero: GraphQLSelectionSet {
-  public static let possibleTypes = [\\"Human\\", \\"Droid\\"]
+  public static let possibleTypes: [String] = [\\"Human\\", \\"Droid\\"]
 
   public static let selections: [GraphQLSelection] = [
     GraphQLField(\\"name\\", alias: \\"_name\\", type: .nonNull(.scalar(String.self))),

--- a/packages/apollo-codegen-swift/src/codeGeneration.ts
+++ b/packages/apollo-codegen-swift/src/codeGeneration.ts
@@ -346,7 +346,9 @@ export class SwiftAPIGenerator extends SwiftGenerator<CompilerContext> {
       () => {
         if (source) {
           this.comment("The raw GraphQL definition of this fragment.");
-          this.printOnNewline(swift`public static let fragmentDefinition =`);
+          this.printOnNewline(
+            swift`public static let fragmentDefinition: String =`
+          );
           this.withIndent(() => {
             this.multilineString(source, suppressMultilineStringLiterals);
           });

--- a/packages/apollo-codegen-swift/src/codeGeneration.ts
+++ b/packages/apollo-codegen-swift/src/codeGeneration.ts
@@ -233,7 +233,9 @@ export class SwiftAPIGenerator extends SwiftGenerator<CompilerContext> {
 
         this.printNewlineIfNeeded();
         this.printOnNewline(
-          swift`public let operationName: String = ${SwiftSource.string(operationName)}`
+          swift`public let operationName: String = ${SwiftSource.string(
+            operationName
+          )}`
         );
 
         const fragmentsReferenced = collectFragmentsReferenced(
@@ -451,7 +453,9 @@ export class SwiftAPIGenerator extends SwiftGenerator<CompilerContext> {
         }
 
         this.printNewlineIfNeeded();
-        this.printOnNewline(swift`public static let possibleTypes: [String] = [`);
+        this.printOnNewline(
+          swift`public static let possibleTypes: [String] = [`
+        );
         this.print(
           join(
             variant.possibleTypes.map(

--- a/packages/apollo-codegen-swift/src/codeGeneration.ts
+++ b/packages/apollo-codegen-swift/src/codeGeneration.ts
@@ -225,7 +225,7 @@ export class SwiftAPIGenerator extends SwiftGenerator<CompilerContext> {
       () => {
         if (source) {
           this.comment("The raw GraphQL definition of this operation.");
-          this.printOnNewline(swift`public let operationDefinition =`);
+          this.printOnNewline(swift`public let operationDefinition: String =`);
           this.withIndent(() => {
             this.multilineString(source, suppressMultilineStringLiterals);
           });
@@ -233,7 +233,7 @@ export class SwiftAPIGenerator extends SwiftGenerator<CompilerContext> {
 
         this.printNewlineIfNeeded();
         this.printOnNewline(
-          swift`public let operationName = ${SwiftSource.string(operationName)}`
+          swift`public let operationName: String = ${SwiftSource.string(operationName)}`
         );
 
         const fragmentsReferenced = collectFragmentsReferenced(
@@ -451,7 +451,7 @@ export class SwiftAPIGenerator extends SwiftGenerator<CompilerContext> {
         }
 
         this.printNewlineIfNeeded();
-        this.printOnNewline(swift`public static let possibleTypes = [`);
+        this.printOnNewline(swift`public static let possibleTypes: [String] = [`);
         this.print(
           join(
             variant.possibleTypes.map(

--- a/packages/apollo/src/commands/client/__tests__/__snapshots__/generate.test.ts.snap
+++ b/packages/apollo/src/commands/client/__tests__/__snapshots__/generate.test.ts.snap
@@ -178,20 +178,20 @@ import Foundation
 
 public final class SimpleQueryQuery: GraphQLQuery {
   /// The raw GraphQL definition of this operation.
-  public let operationDefinition =
+  public let operationDefinition: String =
     \\"\\"\\"
     query SimpleQuery {
       hello
     }
     \\"\\"\\"
 
-  public let operationName = \\"SimpleQuery\\"
+  public let operationName: String = \\"SimpleQuery\\"
 
   public init() {
   }
 
   public struct Data: GraphQLSelectionSet {
-    public static let possibleTypes = [\\"Query\\"]
+    public static let possibleTypes: [String] = [\\"Query\\"]
 
     public static let selections: [GraphQLSelection] = [
       GraphQLField(\\"hello\\", type: .nonNull(.scalar(String.self))),
@@ -228,20 +228,20 @@ import Foundation
 
 public final class SimpleQueryQuery: GraphQLQuery {
   /// The raw GraphQL definition of this operation.
-  public let operationDefinition =
+  public let operationDefinition: String =
     \\"\\"\\"
     query SimpleQuery {
       hello
     }
     \\"\\"\\"
 
-  public let operationName = \\"SimpleQuery\\"
+  public let operationName: String = \\"SimpleQuery\\"
 
   public init() {
   }
 
   public struct Data: GraphQLSelectionSet {
-    public static let possibleTypes = [\\"Query\\"]
+    public static let possibleTypes: [String] = [\\"Query\\"]
 
     public static let selections: [GraphQLSelection] = [
       GraphQLField(\\"hello\\", type: .nonNull(.scalar(String.self))),


### PR DESCRIPTION
Adding explicit type annotations for `operationDefinition`, `operationName`, and `possibleTypes` to help out Swift compile times.

<!--
  Thanks for filing a pull request on Apollo Tooling!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [x] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
