### PR TITLE
Update @apollo/federation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3643,7 +3643,7 @@
     "apollo-language-server": {
       "version": "file:packages/apollo-language-server",
       "requires": {
-        "@apollo/federation": "0.10.2",
+        "@apollo/federation": "0.10.3",
         "@apollographql/apollo-tools": "file:packages/apollo-tools",
         "@apollographql/graphql-language-service-interface": "^2.0.2",
         "@endemolshinegroup/cosmiconfig-typescript-loader": "^1.0.0",

--- a/packages/apollo-language-server/package.json
+++ b/packages/apollo-language-server/package.json
@@ -17,7 +17,7 @@
     "npm": ">=6"
   },
   "dependencies": {
-    "@apollo/federation": "0.10.2",
+    "@apollo/federation": "0.10.3",
     "@apollographql/apollo-tools": "file:../apollo-tools",
     "@apollographql/graphql-language-service-interface": "^2.0.2",
     "@endemolshinegroup/cosmiconfig-typescript-loader": "^1.0.0",


### PR DESCRIPTION
This update to the federation package removes the circular dependency
between this monorepo and the apollo-server monorepo. The circular
dependency currently blocks publishing / building of the tooling
repo due to the federation + apollo-env cycle.

<!--
  Thanks for filing a pull request on Apollo Tooling!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [ ] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass

\*Make sure changelog entries note which project(s) has been affected. See older entries for examples on what this looks like.
