### PR TITLE
Minimizing autogen files from Phabricator diffs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
   - Add sdl download ability to `client:download-schema` [#1470](https://github.com/apollographql/apollo-tooling/pull/1470)
   - colors: use cyan instead of blue for text highlighting [#1598](https://github.com/apollographql/apollo-tooling/pull/1598)
   - Fix codegen --watch breaking out of watch mode on validation errors [#1627](https://github.com/apollographql/apollo-tooling/pull/1627)
+  - Minimize autogen files on Phabricator [#1698](https://github.com/apollographql/apollo-tooling/pull/1698)
 - `apollo-env@0.6.0`
   - POTENTIALLY BREAKING: Make `apollo-env` a standard TS package
     [#1611](https://github.com/apollographql/apollo-tooling/pull/1611) This PR likely warrants a pre-major version bump so that it isn't accidentally upgraded to for dependents using the ^ range. If this breaks your project, please don't hesitate to let us know and revert back to v0.5.1. This PR removes the handwritten node-fetch types and instead

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 - `apollo-language-server`
   - <First `apollo-language-server` related entry goes here>
 - `apollo-tools`
-  - <First `apollo-tools` related entry goes here>
+  - Minimize autogen files on Phabricator [#1698](https://github.com/apollographql/apollo-tooling/pull/1698)
 - `vscode-apollo`
   - <First `vscode-apollo` related entry goes here>
 
@@ -29,7 +29,6 @@
   - Add sdl download ability to `client:download-schema` [#1470](https://github.com/apollographql/apollo-tooling/pull/1470)
   - colors: use cyan instead of blue for text highlighting [#1598](https://github.com/apollographql/apollo-tooling/pull/1598)
   - Fix codegen --watch breaking out of watch mode on validation errors [#1627](https://github.com/apollographql/apollo-tooling/pull/1627)
-  - Minimize autogen files on Phabricator [#1698](https://github.com/apollographql/apollo-tooling/pull/1698)
 - `apollo-env@0.6.0`
   - POTENTIALLY BREAKING: Make `apollo-env` a standard TS package
     [#1611](https://github.com/apollographql/apollo-tooling/pull/1611) This PR likely warrants a pre-major version bump so that it isn't accidentally upgraded to for dependents using the ^ range. If this breaks your project, please don't hesitate to let us know and revert back to v0.5.1. This PR removes the handwritten node-fetch types and instead

--- a/packages/apollo-codegen-flow/src/__tests__/__snapshots__/codeGeneration.ts.snap
+++ b/packages/apollo-codegen-flow/src/__tests__/__snapshots__/codeGeneration.ts.snap
@@ -4,6 +4,7 @@ exports[`Flow codeGeneration covariant properties with $ReadOnlyArray 1`] = `
 Object {
   "common": "/* @flow */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 //==============================================================
@@ -23,6 +24,7 @@ export type Episode = \\"EMPIRE\\" | \\"JEDI\\" | \\"NEWHOPE\\";
       "content": FlowGeneratedFile {
         "fileContents": "/* @flow */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================
@@ -92,6 +94,7 @@ export type HeroNameVariables = {|
       "content": FlowGeneratedFile {
         "fileContents": "/* @flow */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================
@@ -131,6 +134,7 @@ export type humanFragment = {|
       "content": FlowGeneratedFile {
         "fileContents": "/* @flow */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================
@@ -156,6 +160,7 @@ exports[`Flow codeGeneration fragment spreads with inline fragments 1`] = `
 Object {
   "common": "/* @flow */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 //==============================================================
@@ -175,6 +180,7 @@ export type Episode = \\"EMPIRE\\" | \\"JEDI\\" | \\"NEWHOPE\\";
       "content": FlowGeneratedFile {
         "fileContents": "/* @flow */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================
@@ -244,6 +250,7 @@ export type HeroNameVariables = {
       "content": FlowGeneratedFile {
         "fileContents": "/* @flow */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================
@@ -283,6 +290,7 @@ export type humanFragment = {
       "content": FlowGeneratedFile {
         "fileContents": "/* @flow */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================
@@ -308,6 +316,7 @@ exports[`Flow codeGeneration fragment with fragment spreads 1`] = `
 Object {
   "common": "/* @flow */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 //==============================================================
@@ -322,6 +331,7 @@ Object {
       "content": FlowGeneratedFile {
         "fileContents": "/* @flow */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================
@@ -343,6 +353,7 @@ export type simpleFragment = {
       "content": FlowGeneratedFile {
         "fileContents": "/* @flow */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================
@@ -372,6 +383,7 @@ exports[`Flow codeGeneration fragment with fragment spreads with inline fragment
 Object {
   "common": "/* @flow */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 //==============================================================
@@ -391,6 +403,7 @@ export type Episode = \\"EMPIRE\\" | \\"JEDI\\" | \\"NEWHOPE\\";
       "content": FlowGeneratedFile {
         "fileContents": "/* @flow */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================
@@ -412,6 +425,7 @@ export type simpleFragment = {
       "content": FlowGeneratedFile {
         "fileContents": "/* @flow */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================
@@ -459,6 +473,7 @@ exports[`Flow codeGeneration handles multiline graphql comments 1`] = `
 Object {
   "common": "/* @flow */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 //==============================================================
@@ -473,6 +488,7 @@ Object {
       "content": FlowGeneratedFile {
         "fileContents": "/* @flow */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================
@@ -504,6 +520,7 @@ exports[`Flow codeGeneration inline fragment 1`] = `
 Object {
   "common": "/* @flow */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 //==============================================================
@@ -523,6 +540,7 @@ export type Episode = \\"EMPIRE\\" | \\"JEDI\\" | \\"NEWHOPE\\";
       "content": FlowGeneratedFile {
         "fileContents": "/* @flow */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================
@@ -560,6 +578,7 @@ exports[`Flow codeGeneration inline fragment on type conditions 1`] = `
 Object {
   "common": "/* @flow */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 //==============================================================
@@ -579,6 +598,7 @@ export type Episode = \\"EMPIRE\\" | \\"JEDI\\" | \\"NEWHOPE\\";
       "content": FlowGeneratedFile {
         "fileContents": "/* @flow */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================
@@ -646,6 +666,7 @@ exports[`Flow codeGeneration inline fragment on type conditions with differing i
 Object {
   "common": "/* @flow */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 //==============================================================
@@ -665,6 +686,7 @@ export type Episode = \\"EMPIRE\\" | \\"JEDI\\" | \\"NEWHOPE\\";
       "content": FlowGeneratedFile {
         "fileContents": "/* @flow */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================
@@ -748,6 +770,7 @@ Array [
     "content": FlowGeneratedFile {
       "fileContents": "/* @flow */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================
@@ -781,6 +804,7 @@ export type HeroNameVariables = {
     "content": FlowGeneratedFile {
       "fileContents": "/* @flow */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================
@@ -814,6 +838,7 @@ export type SomeOtherVariables = {
     "content": FlowGeneratedFile {
       "fileContents": "/* @flow */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================
@@ -848,6 +873,7 @@ export type ReviewMovieVariables = {
     "content": FlowGeneratedFile {
       "fileContents": "/* @flow */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================
@@ -873,6 +899,7 @@ exports[`Flow codeGeneration multiple files 3`] = `"common"`;
 exports[`Flow codeGeneration multiple files 4`] = `
 "/* @flow */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 //==============================================================
@@ -911,6 +938,7 @@ exports[`Flow codeGeneration query with fragment spreads 1`] = `
 Object {
   "common": "/* @flow */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 //==============================================================
@@ -930,6 +958,7 @@ export type Episode = \\"EMPIRE\\" | \\"JEDI\\" | \\"NEWHOPE\\";
       "content": FlowGeneratedFile {
         "fileContents": "/* @flow */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================
@@ -963,6 +992,7 @@ export type HeroFragmentVariables = {
       "content": FlowGeneratedFile {
         "fileContents": "/* @flow */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================
@@ -988,6 +1018,7 @@ exports[`Flow codeGeneration simple fragment 1`] = `
 Object {
   "common": "/* @flow */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 //==============================================================
@@ -1002,6 +1033,7 @@ Object {
       "content": FlowGeneratedFile {
         "fileContents": "/* @flow */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================
@@ -1027,6 +1059,7 @@ exports[`Flow codeGeneration simple hero query 1`] = `
 Object {
   "common": "/* @flow */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 //==============================================================
@@ -1046,6 +1079,7 @@ export type Episode = \\"EMPIRE\\" | \\"JEDI\\" | \\"NEWHOPE\\";
       "content": FlowGeneratedFile {
         "fileContents": "/* @flow */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================
@@ -1083,6 +1117,7 @@ exports[`Flow codeGeneration simple mutation 1`] = `
 Object {
   "common": "/* @flow */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 //==============================================================
@@ -1120,6 +1155,7 @@ export type ColorInput = {|
       "content": FlowGeneratedFile {
         "fileContents": "/* @flow */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/packages/apollo-codegen-flow/src/codeGeneration.ts
+++ b/packages/apollo-codegen-flow/src/codeGeneration.ts
@@ -124,6 +124,7 @@ export class FlowAPIGenerator extends FlowGenerator {
       stripIndent`
         /* @flow */
         /* eslint-disable */
+        // @generated
         // This file was automatically generated and should not be edited.
       `
     );

--- a/packages/apollo/src/commands/client/__tests__/__snapshots__/generate.test.ts.snap
+++ b/packages/apollo/src/commands/client/__tests__/__snapshots__/generate.test.ts.snap
@@ -42,6 +42,7 @@ exports[`client:codegen generates operation IDs for swift files when flag is set
 exports[`client:codegen writes exact Flow types when the useFlowExactObjects flag is set 1`] = `
 "/* @flow */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================
@@ -52,6 +53,7 @@ export type SimpleQuery = {|
   hello: string
 |};/* @flow */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 //==============================================================
@@ -66,6 +68,7 @@ export type SimpleQuery = {|
 exports[`client:codegen writes flow types 1`] = `
 "/* @flow */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================
@@ -76,6 +79,7 @@ export type SimpleQuery = {
   hello: string
 };/* @flow */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 //==============================================================
@@ -125,6 +129,7 @@ Object {
 exports[`client:codegen writes read-only Flow types when the deprecated flag is set 1`] = `
 "/* @flow */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================
@@ -135,6 +140,7 @@ export type SimpleQuery = {
   +hello: string
 };/* @flow */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 //==============================================================
@@ -149,6 +155,7 @@ export type SimpleQuery = {
 exports[`client:codegen writes read-only Flow types when the flag is set 1`] = `
 "/* @flow */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================
@@ -159,6 +166,7 @@ export type SimpleQuery = {
   +hello: string
 };/* @flow */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 //==============================================================


### PR DESCRIPTION
Autogenerated files typically do not need to be reviewed. In Phabricator, files with the `// @generated` comment will be minimized, making it easier to browse through a diff while reviewing.

<!--
  Thanks for filing a pull request on Apollo Tooling!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [x] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [x] Make sure all of the significant new logic is covered by tests 
      - There's not really any new logic
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass

\*Make sure changelog entries note which project(s) has been affected. See older entries for examples on what this looks like.
