### PR TITLE
[fix] add @types/node-fetch as a devDependency to apollo-env

### DIFF
--- a/packages/apollo-env/package.json
+++ b/packages/apollo-env/package.json
@@ -18,5 +18,8 @@
     "core-js": "^3.0.1",
     "node-fetch": "^2.2.0",
     "sha.js": "^2.4.11"
+  },
+  "devDependencies": {
+    "@types/node-fetch": "*"
   }
 }


### PR DESCRIPTION
fixes #1686

I went with this instead of going to v3 of node-fetch because I didn't want to mess with changing to a major version.

One question I have is why this change isn't breaking the release build somewhere.... cause this is breaking my build now. =(

<!--
  Thanks for filing a pull request on Apollo Tooling!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [ ] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [ ] Make sure all of the significant new logic is covered by tests
- [ ] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests and linter rules pass

\*Make sure changelog entries note which project(s) has been affected. See older entries for examples on what this looks like.
