### PR TITLE
Support disabling literal stripping when extracting operations.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Upcoming
 
 - `apollo`
-  - <First `apollo` related entry goes here>
+  - Support disabling literal stripping when extracting queries.  [1703](https://github.com/apollographql/apollo-tooling/pull/1703)
 - `apollo-codegen-flow`
   - <First `apollo-codegen-flow` related entry goes here>
 - `apollo-codegen-scala`

--- a/packages/apollo-graphql/src/__tests__/__snapshots__/operationId.test.ts.snap
+++ b/packages/apollo-graphql/src/__tests__/__snapshots__/operationId.test.ts.snap
@@ -28,7 +28,7 @@ exports[`defaultOperationRegistrySignature fragments in various order 1`] = `"fr
 
 exports[`defaultOperationRegistrySignature full test 1`] = `"fragment Bar on User{age@skip(if:$a)...Nested}fragment Nested on User{blah}query Foo($a:Boolean,$b:Int){user(age:0,name:\\"\\"){aliased:name tz...Bar...on User{bee hello}}}"`;
 
-exports[`defaultOperationRegistrySignature test with stripLiterals=false 1`] = `"query Foo($b:Int){user(age:5,name:\\"hello\\"){a@skip(if:true)b@include(if:false)c(value:4){d}...Bar...on User{hello@directive(arg:\\"Value!\\")}}}"`;
+exports[`defaultOperationRegistrySignature test with preserveStringAndNumericLiterals=true 1`] = `"query Foo($b:Int){user(age:5,name:\\"hello\\"){a@skip(if:true)b@include(if:false)c(value:4){d}...Bar...on User{hello@directive(arg:\\"Value!\\")}}}"`;
 
 exports[`defaultOperationRegistrySignature with various argument types 1`] = `"query OpName($a:[[Boolean!]!],$b:EnumType,$c:Int!){user{name(apple:$a,bag:$b,cat:$c)}}"`;
 

--- a/packages/apollo-graphql/src/__tests__/__snapshots__/operationId.test.ts.snap
+++ b/packages/apollo-graphql/src/__tests__/__snapshots__/operationId.test.ts.snap
@@ -28,6 +28,8 @@ exports[`defaultOperationRegistrySignature fragments in various order 1`] = `"fr
 
 exports[`defaultOperationRegistrySignature full test 1`] = `"fragment Bar on User{age@skip(if:$a)...Nested}fragment Nested on User{blah}query Foo($a:Boolean,$b:Int){user(age:0,name:\\"\\"){aliased:name tz...Bar...on User{bee hello}}}"`;
 
+exports[`defaultOperationRegistrySignature test with stripLiterals=false 1`] = `"query Foo($b:Int){user(age:5,name:\\"hello\\"){a@skip(if:true)b@include(if:false)c(value:4){d}...Bar...on User{hello@directive(arg:\\"Value!\\")}}}"`;
+
 exports[`defaultOperationRegistrySignature with various argument types 1`] = `"query OpName($a:[[Boolean!]!],$b:EnumType,$c:Int!){user{name(apple:$a,bag:$b,cat:$c)}}"`;
 
 exports[`defaultOperationRegistrySignature with various inline types 1`] = `"query OpName{user{name(apple:[[0]],bag:{input:\\"\\"},cat:ENUM_VALUE)}}"`;

--- a/packages/apollo-graphql/src/__tests__/__snapshots__/operationId.test.ts.snap
+++ b/packages/apollo-graphql/src/__tests__/__snapshots__/operationId.test.ts.snap
@@ -16,20 +16,20 @@ exports[`defaultEngineReportingSignature with various argument types 1`] = `"que
 
 exports[`defaultEngineReportingSignature with various inline types 1`] = `"query OpName{user{name(apple:[],bag:{},cat:ENUM_VALUE)}}"`;
 
-exports[`defaultOperationRegistrySignature basic test 1`] = `"{user{name}}"`;
+exports[`operationRegistrySignature basic test 1`] = `"{user{name}}"`;
 
-exports[`defaultOperationRegistrySignature basic test with query 1`] = `"{user{name}}"`;
+exports[`operationRegistrySignature basic test with query 1`] = `"{user{name}}"`;
 
-exports[`defaultOperationRegistrySignature basic with operation name 1`] = `"query OpName{user{name}}"`;
+exports[`operationRegistrySignature basic with operation name 1`] = `"query OpName{user{name}}"`;
 
-exports[`defaultOperationRegistrySignature fragment 1`] = `"fragment Bar on User{asd}{user{name...Bar}}"`;
+exports[`operationRegistrySignature fragment 1`] = `"fragment Bar on User{asd}{user{name...Bar}}"`;
 
-exports[`defaultOperationRegistrySignature fragments in various order 1`] = `"fragment Bar on User{asd}{user{name...Bar}}"`;
+exports[`operationRegistrySignature fragments in various order 1`] = `"fragment Bar on User{asd}{user{name...Bar}}"`;
 
-exports[`defaultOperationRegistrySignature full test 1`] = `"fragment Bar on User{age@skip(if:$a)...Nested}fragment Nested on User{blah}query Foo($a:Boolean,$b:Int){user(age:0,name:\\"\\"){aliased:name tz...Bar...on User{bee hello}}}"`;
+exports[`operationRegistrySignature full test 1`] = `"fragment Bar on User{age@skip(if:$a)...Nested}fragment Nested on User{blah}query Foo($a:Boolean,$b:Int){user(age:0,name:\\"\\"){aliased:name tz...Bar...on User{bee hello}}}"`;
 
-exports[`defaultOperationRegistrySignature test with preserveStringAndNumericLiterals=true 1`] = `"query Foo($b:Int){user(age:5,name:\\"hello\\"){a@skip(if:true)b@include(if:false)c(value:4){d}...Bar...on User{hello@directive(arg:\\"Value!\\")}}}"`;
+exports[`operationRegistrySignature test with preserveStringAndNumericLiterals=true 1`] = `"query Foo($b:Int){user(age:5,name:\\"hello\\"){a@skip(if:true)b@include(if:false)c(value:4){d}...Bar...on User{hello@directive(arg:\\"Value!\\")}}}"`;
 
-exports[`defaultOperationRegistrySignature with various argument types 1`] = `"query OpName($a:[[Boolean!]!],$b:EnumType,$c:Int!){user{name(apple:$a,bag:$b,cat:$c)}}"`;
+exports[`operationRegistrySignature with various argument types 1`] = `"query OpName($a:[[Boolean!]!],$b:EnumType,$c:Int!){user{name(apple:$a,bag:$b,cat:$c)}}"`;
 
-exports[`defaultOperationRegistrySignature with various inline types 1`] = `"query OpName{user{name(apple:[[0]],bag:{input:\\"\\"},cat:ENUM_VALUE)}}"`;
+exports[`operationRegistrySignature with various inline types 1`] = `"query OpName{user{name(apple:[[0]],bag:{input:\\"\\"},cat:ENUM_VALUE)}}"`;

--- a/packages/apollo-graphql/src/__tests__/operationId.test.ts
+++ b/packages/apollo-graphql/src/__tests__/operationId.test.ts
@@ -275,7 +275,7 @@ describe("defaultOperationRegistrySignature", () => {
       `
     },
     {
-      name: "test with stripLiterals=false",
+      name: "test with preserveStringAndNumericLiterals=true",
       operationName: "Foo",
       input: gql`
         query Foo($b: Int) {
@@ -292,7 +292,7 @@ describe("defaultOperationRegistrySignature", () => {
           }
         }
       `,
-      options: { stripLiterals: false }
+      options: { preserveStringAndNumericLiterals: true }
     }
   ];
   cases.forEach(({ name, operationName, input, options }) => {

--- a/packages/apollo-graphql/src/__tests__/operationId.test.ts
+++ b/packages/apollo-graphql/src/__tests__/operationId.test.ts
@@ -1,7 +1,7 @@
 import { default as gql, disableFragmentWarnings } from "graphql-tag";
 import {
   defaultEngineReportingSignature,
-  defaultOperationRegistrySignature
+  operationRegistrySignature
 } from "../operationId";
 
 // The gql duplicate fragment warning feature really is just warnings; nothing
@@ -146,7 +146,7 @@ describe("defaultEngineReportingSignature", () => {
   });
 });
 
-describe("defaultOperationRegistrySignature", () => {
+describe("operationRegistrySignature", () => {
   const cases = [
     // Test cases borrowed from optics-agent-js.
     {
@@ -298,7 +298,7 @@ describe("defaultOperationRegistrySignature", () => {
   cases.forEach(({ name, operationName, input, options }) => {
     test(name, () => {
       expect(
-        defaultOperationRegistrySignature(input, operationName, options)
+        operationRegistrySignature(input, operationName, options)
       ).toMatchSnapshot();
     });
   });

--- a/packages/apollo-graphql/src/__tests__/operationId.test.ts
+++ b/packages/apollo-graphql/src/__tests__/operationId.test.ts
@@ -273,12 +273,32 @@ describe("defaultOperationRegistrySignature", () => {
           blah
         }
       `
+    },
+    {
+      name: "test with stripLiterals=false",
+      operationName: "Foo",
+      input: gql`
+        query Foo($b: Int) {
+          user(name: "hello", age: 5) {
+            ...Bar
+            a @skip(if: true)
+            b @include(if: false)
+            c(value: 4) {
+              d
+            }
+            ... on User {
+              hello @directive(arg: "Value!")
+            }
+          }
+        }
+      `,
+      options: { stripLiterals: false }
     }
   ];
-  cases.forEach(({ name, operationName, input }) => {
+  cases.forEach(({ name, operationName, input, options }) => {
     test(name, () => {
       expect(
-        defaultOperationRegistrySignature(input, operationName)
+        defaultOperationRegistrySignature(input, operationName, options)
       ).toMatchSnapshot();
     });
   });

--- a/packages/apollo-graphql/src/index.ts
+++ b/packages/apollo-graphql/src/index.ts
@@ -1,6 +1,7 @@
 export {
   defaultEngineReportingSignature,
   defaultOperationRegistrySignature,
+  operationRegistrySignature,
   operationHash
 } from "./operationId";
 export * from "./schema";

--- a/packages/apollo-graphql/src/operationId.ts
+++ b/packages/apollo-graphql/src/operationId.ts
@@ -72,7 +72,7 @@ export function defaultEngineReportingSignature(
 // sorting the AST in a deterministic manner, potentially hiding string and numeric
 // literals, and removing unused definitions. This is a less aggressive transform
 // than its engine reporting signature counterpart.
-export function defaultOperationRegistrySignature(
+export function operationRegistrySignature(
   ast: DocumentNode,
   operationName: string,
   options: { preserveStringAndNumericLiterals: boolean } = {
@@ -84,6 +84,15 @@ export function defaultOperationRegistrySignature(
     ? withoutUnusedDefs
     : hideStringAndNumericLiterals(withoutUnusedDefs);
   return printWithReducedWhitespace(sortAST(maybeWithLiterals));
+}
+
+export function defaultOperationRegistrySignature(
+  ast: DocumentNode,
+  operationName: string
+): string {
+  return operationRegistrySignature(ast, operationName, {
+    preserveStringAndNumericLiterals: false
+  });
 }
 
 export function operationHash(operation: string): string {

--- a/packages/apollo-graphql/src/operationId.ts
+++ b/packages/apollo-graphql/src/operationId.ts
@@ -75,12 +75,14 @@ export function defaultEngineReportingSignature(
 export function defaultOperationRegistrySignature(
   ast: DocumentNode,
   operationName: string,
-  options: { stripLiterals: boolean } = { stripLiterals: true }
+  options: { preserveStringAndNumericLiterals: boolean } = {
+    preserveStringAndNumericLiterals: false
+  }
 ): string {
   const withoutUnusedDefs = dropUnusedDefinitions(ast, operationName);
-  const maybeWithLiterals = options.stripLiterals
-    ? hideStringAndNumericLiterals(withoutUnusedDefs)
-    : withoutUnusedDefs;
+  const maybeWithLiterals = options.preserveStringAndNumericLiterals
+    ? withoutUnusedDefs
+    : hideStringAndNumericLiterals(withoutUnusedDefs);
   return printWithReducedWhitespace(sortAST(maybeWithLiterals));
 }
 

--- a/packages/apollo-graphql/src/operationId.ts
+++ b/packages/apollo-graphql/src/operationId.ts
@@ -69,25 +69,19 @@ export function defaultEngineReportingSignature(
 }
 
 // The operation registry signature function consists of removing extra whitespace,
-// sorting the AST in a deterministic manner, hiding string and numeric literals,
-// and removing unused definitions. This is a less aggressive transform than its
-// engine reporting signature counterpart.
-//
-// XXX
-// The hiding of literals is currently being discussed. This behavior
-// should not be depended on in the future, as it's likely we will choose not
-// to hide them at all. The rationale being, if queries are being shipped to
-// a client bundle, exposing PII via this signature is a very small concern,
-// relatively speaking.
+// sorting the AST in a deterministic manner, potentially hiding string and numeric
+// literals, and removing unused definitions. This is a less aggressive transform
+// than its engine reporting signature counterpart.
 export function defaultOperationRegistrySignature(
   ast: DocumentNode,
-  operationName: string
+  operationName: string,
+  options: { stripLiterals: boolean } = { stripLiterals: true }
 ): string {
-  return printWithReducedWhitespace(
-    sortAST(
-      hideStringAndNumericLiterals(dropUnusedDefinitions(ast, operationName))
-    )
-  );
+  const withoutUnusedDefs = dropUnusedDefinitions(ast, operationName);
+  const maybeWithLiterals = options.stripLiterals
+    ? hideStringAndNumericLiterals(withoutUnusedDefs)
+    : withoutUnusedDefs;
+  return printWithReducedWhitespace(sortAST(maybeWithLiterals));
 }
 
 export function operationHash(operation: string): string {

--- a/packages/apollo/README.md
+++ b/packages/apollo/README.md
@@ -278,6 +278,8 @@ OPTIONS
 
   --queries=queries                      Deprecated in favor of the includes flag
 
+  --[no-]stripLiterals                   Whether to strip literals from extracted queries. DEFAULT: true
+
   --tagName=tagName                      Name of the template literal tag used to identify template literals containing
                                          GraphQL queries in Javascript/Typescript code
 ```

--- a/packages/apollo/README.md
+++ b/packages/apollo/README.md
@@ -278,7 +278,11 @@ OPTIONS
 
   --queries=queries                      Deprecated in favor of the includes flag
 
-  --[no-]stripLiterals                   Whether to strip literals from extracted queries. DEFAULT: true
+  --preserveStringAndNumericLiterals     Disable redaction of string and numerical literals. Without this flag, these
+                                         values will be replaced with empty strings (`''`) and zeroes (`0`)
+                                         respectively. This redaction is intended to avoid inadvertently outputting
+                                         potentially personally identifiable information (e.g. embedded passwords or
+                                         API keys) into operation manifests.  DEFAULT: false
 
   --tagName=tagName                      Name of the template literal tag used to identify template literals containing
                                          GraphQL queries in Javascript/Typescript code

--- a/packages/apollo/src/commands/client/extract.ts
+++ b/packages/apollo/src/commands/client/extract.ts
@@ -11,11 +11,13 @@ export default class ClientExtract extends ClientCommand {
   static description = "Extract queries from a client";
   static flags = {
     ...ClientCommand.flags,
-    stripLiterals: flags.boolean({
+    preserveStringAndNumericLiterals: flags.boolean({
       description:
-        "Whether to strip literals from extracted queries. DEFAULT: true",
-      default: true,
-      allowNo: true
+        "Disable redaction of string and numerical literals.  Without this flag, these values will be replaced" +
+        " with empty strings (`''`) and zeroes (`0`) respectively.  This redaction is intended to avoid " +
+        " inadvertently outputting potentially personally identifiable information (e.g. embedded passwords " +
+        " or API keys) into operation manifests",
+      default: false
     })
   };
 
@@ -38,7 +40,8 @@ export default class ClientExtract extends ClientCommand {
         title: "Extracting operations from project",
         task: async ctx => {
           ctx.operations = getOperationManifestFromProject(this.project, {
-            stripLiterals: flags.stripLiterals
+            preserveStringAndNumericLiterals:
+              flags.preserveStringAndNumericLiterals
           });
           ctx.clientIdentity = config.client;
         }

--- a/packages/apollo/src/commands/client/extract.ts
+++ b/packages/apollo/src/commands/client/extract.ts
@@ -1,3 +1,4 @@
+import { flags } from "@oclif/command";
 import { writeFileSync } from "fs";
 import { ClientCommand } from "../../Command";
 import {
@@ -9,7 +10,13 @@ import { ClientIdentity } from "apollo-language-server";
 export default class ClientExtract extends ClientCommand {
   static description = "Extract queries from a client";
   static flags = {
-    ...ClientCommand.flags
+    ...ClientCommand.flags,
+    stripLiterals: flags.boolean({
+      description:
+        "Whether to strip literals from extracted queries. DEFAULT: true",
+      default: true,
+      allowNo: true
+    })
   };
 
   static args = [
@@ -30,7 +37,9 @@ export default class ClientExtract extends ClientCommand {
       {
         title: "Extracting operations from project",
         task: async ctx => {
-          ctx.operations = getOperationManifestFromProject(this.project);
+          ctx.operations = getOperationManifestFromProject(this.project, {
+            stripLiterals: flags.stripLiterals
+          });
           ctx.clientIdentity = config.client;
         }
       },

--- a/packages/apollo/src/utils/getOperationManifestFromProject.ts
+++ b/packages/apollo/src/utils/getOperationManifestFromProject.ts
@@ -13,14 +13,16 @@ export interface ManifestEntry {
 }
 
 export function getOperationManifestFromProject(
-  project: GraphQLClientProject
+  project: GraphQLClientProject,
+  options: { stripLiterals: boolean } = { stripLiterals: true }
 ): ManifestEntry[] {
   const manifest = Object.entries(
     project.mergedOperationsAndFragmentsForService
   ).map(([operationName, operationAST]) => {
     const printed = defaultOperationRegistrySignature(
       operationAST,
-      operationName
+      operationName,
+      { stripLiterals: options.stripLiterals }
     );
 
     return {

--- a/packages/apollo/src/utils/getOperationManifestFromProject.ts
+++ b/packages/apollo/src/utils/getOperationManifestFromProject.ts
@@ -14,7 +14,9 @@ export interface ManifestEntry {
 
 export function getOperationManifestFromProject(
   project: GraphQLClientProject,
-  options: { stripLiterals: boolean } = { stripLiterals: true }
+  options: { preserveStringAndNumericLiterals: boolean } = {
+    preserveStringAndNumericLiterals: false
+  }
 ): ManifestEntry[] {
   const manifest = Object.entries(
     project.mergedOperationsAndFragmentsForService
@@ -22,7 +24,10 @@ export function getOperationManifestFromProject(
     const printed = defaultOperationRegistrySignature(
       operationAST,
       operationName,
-      { stripLiterals: options.stripLiterals }
+      {
+        preserveStringAndNumericLiterals:
+          options.preserveStringAndNumericLiterals
+      }
     );
 
     return {

--- a/packages/apollo/src/utils/getOperationManifestFromProject.ts
+++ b/packages/apollo/src/utils/getOperationManifestFromProject.ts
@@ -1,8 +1,5 @@
 import { GraphQLClientProject } from "apollo-language-server";
-import {
-  defaultOperationRegistrySignature,
-  operationHash
-} from "apollo-graphql";
+import { operationHash, operationRegistrySignature } from "apollo-graphql";
 
 export interface ManifestEntry {
   signature: string;
@@ -21,14 +18,9 @@ export function getOperationManifestFromProject(
   const manifest = Object.entries(
     project.mergedOperationsAndFragmentsForService
   ).map(([operationName, operationAST]) => {
-    const printed = defaultOperationRegistrySignature(
-      operationAST,
-      operationName,
-      {
-        preserveStringAndNumericLiterals:
-          options.preserveStringAndNumericLiterals
-      }
-    );
+    const printed = operationRegistrySignature(operationAST, operationName, {
+      preserveStringAndNumericLiterals: options.preserveStringAndNumericLiterals
+    });
 
     return {
       signature: operationHash(printed),


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Tooling!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

Fixes #1099

Adds a flag `--[no]-preserveStringAndNumericLiterals` to `client:extract`
that controls whether literals are preserved in extracted queries. Prior to
this flag, object and list literals were already preserved; that's unaffected
by this change.

As noted in the linked issue, there are a few reasons to do this, but generally
they boil down to relying on the extracted queries for some functionality, and
literals in the queries controlling important behavior (e.g. generating mock data
for queries might rely on literal args).

A flag is preferred to changing the behavior outright since older clients likely
rely on the current behavior.

TODO:

- [x] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass

\*Make sure changelog entries note which project(s) has been affected. See older entries for examples on what this looks like.
