### PR TITLE
Rename "Engine" to "Apollo Graph Manager" in ouput

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,13 @@
 ## Upcoming
 
 - `apollo`
-  - <First `apollo` related entry goes here>
+  - Rename "Engine" to "Apollo Graph Manager" in ouput [#1705](https://github.com/apollographql/apollo-tooling/pull/1705)
 - `apollo-codegen-flow`
   - <First `apollo-codegen-flow` related entry goes here>
 - `apollo-codegen-scala`
   - <First `apollo-codegen-scala` related entry goes here>
 - `apollo-codegen-swift`
-  - Add additional type annotations to improve compile times.  [1638](https://github.com/apollographql/apollo-tooling/pull/1638)
+  - Add additional type annotations to improve compile times. [1638](https://github.com/apollographql/apollo-tooling/pull/1638)
 - `apollo-codegen-typescript`
   - <First `apollo-codegen-typescript` related entry goes here>
 - `apollo-env`
@@ -17,7 +17,7 @@
 - `apollo-graphql`
   - [#1618] Fixes an issue when enums with a value of 0 fail to resolve when using a Federated Schema (https://github.com/apollographql/apollo-tooling/pull/1618)
 - `apollo-language-server`
-  - <First `apollo-language-server` related entry goes here>
+  - Rename "Engine" to "Apollo Graph Manager" in ouput [#1705](https://github.com/apollographql/apollo-tooling/pull/1705)
 - `apollo-tools`
   - <First `apollo-tools` related entry goes here>
 - `vscode-apollo`

--- a/packages/apollo-language-server/src/engine/index.ts
+++ b/packages/apollo-language-server/src/engine/index.ts
@@ -46,7 +46,7 @@ export type FieldStats = Map<string, Map<string, number | null>>;
 export function noServiceError(service: string | undefined, endpoint?: string) {
   return `Could not find service ${
     service ? service : ""
-  } from Engine at ${endpoint}. Please check your API key and service name`;
+  } from Apollo Graph Manager at ${endpoint}. Please check your API key and service name`;
 }
 
 export class ApolloEngineClient extends GraphQLDataSource {
@@ -98,7 +98,7 @@ export class ApolloEngineClient extends GraphQLDataSource {
       }
 
       if (!(data && data.service)) {
-        throw new Error("Error in request from Engine");
+        throw new Error("Error in request from Apollo Graph Manager");
       }
       return data.service;
     });
@@ -121,7 +121,7 @@ export class ApolloEngineClient extends GraphQLDataSource {
       }
 
       if (!(data && data.service)) {
-        throw new Error("Error in request from Engine");
+        throw new Error("Error in request from Apollo Graph Manager");
       }
       return data.service.checkSchema;
     });
@@ -144,7 +144,7 @@ export class ApolloEngineClient extends GraphQLDataSource {
       }
 
       if (!(data && data.service)) {
-        throw new Error("Error in request from Engine");
+        throw new Error("Error in request from Apollo Graph Manager");
       }
       return data.service.uploadSchema;
     });
@@ -169,7 +169,7 @@ export class ApolloEngineClient extends GraphQLDataSource {
       }
 
       if (!(data && data.service)) {
-        throw new Error("Error in request from Engine");
+        throw new Error("Error in request from Apollo Graph Manager");
       }
       return data.service.upsertImplementingServiceAndTriggerComposition;
     });
@@ -194,7 +194,7 @@ export class ApolloEngineClient extends GraphQLDataSource {
       }
 
       if (!(data && data.service)) {
-        throw new Error("Error in request from Engine");
+        throw new Error("Error in request from Apollo Graph Manager");
       }
       return data.service.checkPartialSchema;
     });
@@ -212,7 +212,7 @@ export class ApolloEngineClient extends GraphQLDataSource {
       }
 
       if (!data || !data.service) {
-        throw new Error("Error in request from Engine");
+        throw new Error("Error in request from Apollo Graph Manager");
       }
 
       return data.service.removeImplementingServiceAndTriggerComposition;
@@ -236,7 +236,7 @@ export class ApolloEngineClient extends GraphQLDataSource {
       }
 
       if (!(data && data.service)) {
-        throw new Error("Error in request from Engine");
+        throw new Error("Error in request from Apollo Graph Manager");
       }
 
       return data.service.validateOperations.validationResults;
@@ -262,7 +262,7 @@ export class ApolloEngineClient extends GraphQLDataSource {
       if (
         !(data && data.service && data.service.registerOperationsWithResponse)
       ) {
-        throw new Error("Error in request from Engine");
+        throw new Error("Error in request from Apollo Graph Manager");
       }
       return data.service.registerOperationsWithResponse;
     });

--- a/packages/apollo-language-server/src/project/client.ts
+++ b/packages/apollo-language-server/src/project/client.ts
@@ -339,7 +339,7 @@ export class GraphQLClientProject extends GraphQLProject {
     if (!serviceID) return;
 
     await this.loadingHandler.handle(
-      `Loading Engine data for ${this.displayName}`,
+      `Loading Apollo Graph Manager data for ${this.displayName}`,
       (async () => {
         try {
           const {

--- a/packages/apollo-language-server/src/providers/schema/engine.ts
+++ b/packages/apollo-language-server/src/providers/schema/engine.ts
@@ -84,13 +84,13 @@ export class EngineSchemaProvider implements GraphQLSchemaProvider {
   onSchemaChange(
     _handler: NotificationHandler<GraphQLSchema>
   ): SchemaChangeUnsubscribeHandler {
-    throw new Error("Polling of Engine not implemented yet");
+    throw new Error("Polling of Apollo Graph Manager not implemented yet");
     return () => {};
   }
 
   async resolveFederatedServiceSDL() {
     Debug.error(
-      "Cannot resolve a federated service's SDL from engine. Use an endpoint or a file instead"
+      "Cannot resolve a federated service's SDL from Apollo Graph Manager. Use an endpoint or a file instead"
     );
     return;
   }

--- a/packages/apollo/src/commands/client/check.ts
+++ b/packages/apollo/src/commands/client/check.ts
@@ -42,7 +42,7 @@ export default class ClientCheck extends ClientCommand {
           task: async ctx => {
             if (!config.name) {
               throw new Error(
-                "No service found to link to Engine. Engine is required for this command."
+                "No service found to link to Apollo Graph Manager. Graph Manager is required for this command."
               );
             }
             ctx.gitContext = await gitInfo(this.log);

--- a/packages/apollo/src/commands/client/codegen.ts
+++ b/packages/apollo/src/commands/client/codegen.ts
@@ -26,7 +26,7 @@ const waitForKey = async () => {
 export default class Generate extends ClientCommand {
   static aliases = ["codegen:generate"];
   static description =
-    "Generate static types for GraphQL queries. Can use the published schema in Apollo Engine or a downloaded schema.";
+    "Generate static types for GraphQL queries. Can use the published schema in Apollo Graph Manager or a downloaded schema.";
 
   static flags = {
     ...ClientCommand.flags,

--- a/packages/apollo/src/commands/client/download-schema.ts
+++ b/packages/apollo/src/commands/client/download-schema.ts
@@ -6,7 +6,7 @@ import { ClientCommand } from "../../Command";
 
 export default class SchemaDownload extends ClientCommand {
   static description =
-    "Download a schema from engine or a GraphQL endpoint in JSON or SDL format";
+    "Download a schema from Apollo Graph Manager or a GraphQL endpoint in JSON or SDL format";
 
   static flags = {
     ...ClientCommand.flags

--- a/packages/apollo/src/commands/client/push.ts
+++ b/packages/apollo/src/commands/client/push.ts
@@ -61,7 +61,7 @@ export default class ClientPush extends ClientCommand {
             task: async (_, task) => {
               if (!config.name) {
                 throw new Error(
-                  "No service found to link to Engine. Engine is required for this command."
+                  "No service found to link to Apollo Graph Manager. Graph Manager is required for this command."
                 );
               }
 

--- a/packages/apollo/src/commands/service/__tests__/check.test.ts
+++ b/packages/apollo/src/commands/service/__tests__/check.test.ts
@@ -19,13 +19,13 @@ const localURL = "http://localhost:4000";
 /**
  * Default API key. This is not an actual API key but a randomly generated string.
  *
- * If you need to use the `nock` recorder, then this will not work because we won't be able to access engine
+ * If you need to use the `nock` recorder, then this will not work because we won't be able to access graph manager
  * with a fake API key.
  */
 const fakeApiKey = "service:engine:9YC5AooMa2yO11eFlZat11";
 
 /**
- * Engine API key we're using.
+ * Graph Manager API key we're using.
  *
  * This is hard-coded to `fakeApiKey` because this is out day-to-day usage should be. If we're going to be
  * updating the mocked data; we'll need to use a real API key (see [README#Regenerating Mocked Network
@@ -35,7 +35,7 @@ const fakeApiKey = "service:engine:9YC5AooMa2yO11eFlZat11";
 const apiKey = fakeApiKey;
 
 /**
- * An array that we'll spread into all CLI commands to pass the engine api key.
+ * An array that we'll spread into all CLI commands to pass the graph manager api key.
  */
 const cliKeyParameter = [`--key=${apiKey}`];
 

--- a/packages/apollo/src/commands/service/__tests__/list.test.ts
+++ b/packages/apollo/src/commands/service/__tests__/list.test.ts
@@ -8,13 +8,13 @@ const stagingAPI = "https://engine-staging-graphql.apollographql.com:443";
 /**
  * Default API key. This is not an actual API key but a randomly generated string.
  *
- * If you need to use the `nock` recorder, then this will not work because we won't be able to access engine
+ * If you need to use the `nock` recorder, then this will not work because we won't be able to access graph manager
  * with a fake API key.
  */
 const fakeApiKey = "service:engine:9YC5AooMa2yO11eFlZat11";
 
 /**
- * Engine API key we're using.
+ * Graph Manager API key we're using.
  *
  * This is hard-coded to `fakeApiKey` because this is out day-to-day usage should be. If we're going to be
  * updating the mocked data; we'll need to use a real API key (see [README#Regenerating Mocked Network
@@ -24,7 +24,7 @@ const fakeApiKey = "service:engine:9YC5AooMa2yO11eFlZat11";
 const apiKey = fakeApiKey;
 
 /**
- * An array that we'll spread into all CLI commands to pass the engine api key.
+ * An array that we'll spread into all CLI commands to pass the graph manager api key.
  */
 const cliKeyParameter = [`--key=${apiKey}`];
 

--- a/packages/apollo/src/commands/service/check.ts
+++ b/packages/apollo/src/commands/service/check.ts
@@ -304,7 +304,7 @@ export default class ServiceCheck extends ProjectCommand {
           const serviceName: string | undefined = flags.serviceName;
 
           if (!graphID) {
-            throw new Error("No service found to link to Engine");
+            throw new Error("No service found to link to Apollo Graph Manager");
           }
 
           // Add some fields to output that are required for producing
@@ -455,10 +455,12 @@ export default class ServiceCheck extends ProjectCommand {
                 };
 
                 const { schema: _, ...restVariables } = variables;
-                this.debug("Variables sent to Engine:");
+                this.debug("Variables sent to Apollo Graph Manager:");
                 this.debug(restVariables);
                 if (schema) {
-                  this.debug("SDL of introspection sent to Engine:");
+                  this.debug(
+                    "SDL of introspection sent to Apollo Graph Manager:"
+                  );
                   this.debug(printSchema(schema));
                 } else {
                   this.debug("Schema hash generated:");

--- a/packages/apollo/src/commands/service/delete.ts
+++ b/packages/apollo/src/commands/service/delete.ts
@@ -4,7 +4,7 @@ import { ProjectCommand } from "../../Command";
 
 export default class ServiceDelete extends ProjectCommand {
   static description =
-    "Delete a federated service from Engine and recompose remaining services";
+    "Delete a federated service from Apollo Graph Manager and recompose remaining services";
   static flags = {
     ...ProjectCommand.flags,
     tag: flags.string({
@@ -29,10 +29,10 @@ export default class ServiceDelete extends ProjectCommand {
     let result;
     await this.runTasks(({ flags, project, config }) => [
       {
-        title: "Removing service from Engine",
+        title: "Removing service from Apollo Graph Manager",
         task: async () => {
           if (!config.name) {
-            throw new Error("No service found to link to Engine");
+            throw new Error("No service found to link to Apollo Graph Manager");
           }
 
           if (flags.federated) {

--- a/packages/apollo/src/commands/service/download.ts
+++ b/packages/apollo/src/commands/service/download.ts
@@ -53,7 +53,7 @@ export default class ServiceDownload extends ProjectCommand {
               );
               this.log(
                 chalk.red(
-                  "If you're trying to download a schema from Apollo Engine, use the `client:download-schema` command instead."
+                  "If you're trying to download a schema from Apollo Graph Manager, use the `client:download-schema` command instead."
                 )
               );
             }

--- a/packages/apollo/src/commands/service/list.ts
+++ b/packages/apollo/src/commands/service/list.ts
@@ -114,7 +114,7 @@ export default class ServiceList extends ProjectCommand {
         graphVariant = flags.tag || config.tag || "current";
 
         if (!graphID) {
-          throw new Error("No service found to link to Engine");
+          throw new Error("No service found to link to Apollo Graph Manager");
         }
 
         return [

--- a/packages/apollo/src/commands/service/push.ts
+++ b/packages/apollo/src/commands/service/push.ts
@@ -9,7 +9,7 @@ import chalk from "chalk";
 
 export default class ServicePush extends ProjectCommand {
   static aliases = ["schema:publish"];
-  static description = "Push a service to Engine";
+  static description = "Push a service to Apollo Graph Manager";
   static flags = {
     ...ProjectCommand.flags,
     tag: flags.string({
@@ -48,10 +48,10 @@ export default class ServicePush extends ProjectCommand {
     let gitContext;
     await this.runTasks(({ flags, project, config }) => [
       {
-        title: "Uploading service to Engine",
+        title: "Uploading service to Apollo Graph Manager",
         task: async () => {
           if (!config.name) {
-            throw new Error("No service found to link to Engine");
+            throw new Error("No service found to link to Apollo Graph Manager");
           }
 
           if (flags.federated) {
@@ -130,9 +130,9 @@ export default class ServicePush extends ProjectCommand {
           };
 
           const { schema: _, ...restVariables } = variables;
-          this.debug("Variables sent to Engine:");
+          this.debug("Variables sent to Apollo Graph Manager:");
           this.debug(restVariables);
-          this.debug("SDL of introspection sent to Engine:");
+          this.debug("SDL of introspection sent to Apollo Graph Manager:");
           this.debug(printSchema(schema));
 
           const response = await project.engine.uploadSchema(variables);
@@ -143,7 +143,7 @@ export default class ServicePush extends ProjectCommand {
               hash: response.tag ? response.tag.schema.hash : null,
               code: response.code
             };
-            this.debug("Result received from Engine:");
+            this.debug("Result received from Apollo Graph Manager:");
             this.debug(result);
           }
         }


### PR DESCRIPTION
Right now, the messaging in the CLI and language-server is split between "Engine" and "Apollo Graph Manager". 

This PR updates the logged output to be all "Apollo Graph Manager"

<!--
  Thanks for filing a pull request on Apollo Tooling!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [x] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass

\*Make sure changelog entries note which project(s) has been affected. See older entries for examples on what this looks like.
