### PR TITLE
Add errors for 404 and HTML responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
   - [#1618] Fixes an issue when enums with a value of 0 fail to resolve when using a Federated Schema (https://github.com/apollographql/apollo-tooling/pull/1618)
 - `apollo-language-server`
   - Rename "Engine" to "Apollo Graph Manager" in ouput [#1705](https://github.com/apollographql/apollo-tooling/pull/1705)
+  - Add helpful messages for common errors when introspecting schemas [#1713](https://github.com/apollographql/apollo-tooling/pull/1713)
 - `apollo-tools`
   - <First `apollo-tools` related entry goes here>
 - `vscode-apollo`

--- a/packages/apollo-language-server/src/providers/schema/endpoint.ts
+++ b/packages/apollo-language-server/src/providers/schema/endpoint.ts
@@ -41,7 +41,7 @@ export class EndpointSchemaProvider implements GraphQLSchemaProvider {
         context: { headers }
       })
     ).catch(e => {
-      // error message specific to the default endpoint url -- this gets hit quite often
+      // html response from introspection
       if (isString(e.message) && e.message.includes("token <")) {
         throw new Error(
           "Apollo tried to introspect a running GraphQL service at " +
@@ -54,6 +54,8 @@ export class EndpointSchemaProvider implements GraphQLSchemaProvider {
             e.message
         );
       }
+
+      // 404 encountered with the default url
       if (
         url === DefaultServiceConfig.endpoint.url &&
         isString(e.message) &&
@@ -70,6 +72,14 @@ export class EndpointSchemaProvider implements GraphQLSchemaProvider {
             "The following error occurred: \n" +
             "-----------------------------\n" +
             e.message
+        );
+      }
+      // 404 with a non-default url
+      if (isString(e.message) && e.message.includes("ECONNREFUSED")) {
+        throw new Error(
+          "Failed to connect to a running GraphQL endpoint at " +
+            url +
+            "\nThis may be because you didn't start your service or the endpoint URL is incorrect."
         );
       }
       throw new Error(e);


### PR DESCRIPTION
Two of the most common errors that people encounter in the CLI and VS Code extension revolve around introspecting of schemas.

1. Unless an API key, endpoint, or `localSchemaFile` are provided, the language server relies on the default endpoint `http://localhost:4000`. If there is no server running there, it will 404. If the user _has_ a service to run there (or anywhere else) but forgets to start it up, it will also 404. This PR adds an error for both of those cases. If the URL IS the default one, it will provide info about that. 
2. If users are trying to introspect a url without authentication (or some other cases) the endpoint will return an HTML response, which the CLI can't parse. This PR adds an error mentioning auth and potentially invalid URLs.

<img width="1237" alt="Screen Shot 2019-12-09 at 10 17 04 AM" src="https://user-images.githubusercontent.com/9259509/70449060-52bc8500-1a6f-11ea-9d75-63b28c962f32.png">

<img width="1057" alt="Screen Shot 2019-12-09 at 10 37 00 AM" src="https://user-images.githubusercontent.com/9259509/70449377-dd04e900-1a6f-11ea-85d0-e81d0c592869.png">

<img width="1061" alt="Screen Shot 2019-12-09 at 10 10 41 AM" src="https://user-images.githubusercontent.com/9259509/70448998-391b3d80-1a6f-11ea-8b26-29066b4b9e75.png">





<!--
  Thanks for filing a pull request on Apollo Tooling!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [x] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass

\*Make sure changelog entries note which project(s) has been affected. See older entries for examples on what this looks like.
