### PR TITLE
Revert order change of service schema providers

### DIFF
--- a/packages/apollo-language-server/src/providers/schema/index.ts
+++ b/packages/apollo-language-server/src/providers/schema/index.ts
@@ -25,10 +25,9 @@ export function schemaProviderFromConfig(
   config: ApolloConfig,
   clientIdentity?: ClientIdentity // engine provider needs this
 ): GraphQLSchemaProvider {
-  if (config.service && config.service.endpoint) {
-    return new EndpointSchemaProvider(config.service.endpoint);
-  }
-
+  // we need this to be first because there will pretty much always be a
+  // url (since it's a default). If there is a localSchemaFile, we need to
+  // use that instead of the url.
   if (config.service && config.service.localSchemaFile) {
     const isListOfSchemaFiles = Array.isArray(config.service.localSchemaFile);
     return new FileSchemaProvider(
@@ -36,6 +35,10 @@ export function schemaProviderFromConfig(
         ? { paths: config.service.localSchemaFile as string[] }
         : { path: config.service.localSchemaFile as string }
     );
+  }
+
+  if (config.service && config.service.endpoint) {
+    return new EndpointSchemaProvider(config.service.endpoint);
   }
 
   if (isClientConfig(config)) {


### PR DESCRIPTION
This PR reverts a change to the provider order made in https://github.com/apollographql/apollo-tooling/commit/bb06f49e79f721cb511ef1b5a8880f6d50d6b0d3

This change doesn't work with use of `localSchemaFile`s on service projects, since there is almost always a default url in the config. So the localSchemaFile option won't be hit.


<!--
  Thanks for filing a pull request on Apollo Tooling!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [ ] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [ ] Make sure all of the significant new logic is covered by tests
- [ ] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests and linter rules pass

\*Make sure changelog entries note which project(s) has been affected. See older entries for examples on what this looks like.
