### PR TITLE
fix: add missing @types/node-fetch dep

### DIFF
--- a/packages/apollo-env/package.json
+++ b/packages/apollo-env/package.json
@@ -15,6 +15,7 @@
     "node": ">=8"
   },
   "dependencies": {
+    "@types/node-fetch": "^2.5.4",
     "core-js": "^3.0.1",
     "node-fetch": "^2.2.0",
     "sha.js": "^2.4.11"


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Tooling!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

Due to https://github.com/apollographql/apollo-tooling/blob/51fad9ecb6ad9d6ee64094f9c5ed9ba56edbfd78/packages/apollo-env/src/fetch/fetch.ts#L32. Otherwise we get a type error on CI: 
![image](https://user-images.githubusercontent.com/1404810/71083690-e5f26a80-2193-11ea-9293-3b87999ce388.png)


- [ ] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests and linter rules pass

\*Make sure changelog entries note which project(s) has been affected. See older entries for examples on what this looks like.
