### PR TITLE
Fix tabular output for unrecognized errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Upcoming
 
 - `apollo`
-  - <First `apollo` related entry goes here>
+  - Fix tabular output for unrecognized errors [#1745](https://github.com/apollographql/apollo-tooling/pull/1745)
 - `apollo-codegen-flow`
   - <First `apollo-codegen-flow` related entry goes here>
 - `apollo-codegen-scala`

--- a/packages/apollo/src/commands/service/check.ts
+++ b/packages/apollo/src/commands/service/check.ts
@@ -643,7 +643,11 @@ export default class ServiceCheck extends ProjectCommand {
         table(
           [
             ["Service", "Field", "Message"],
-            ...compositionErrors.map(Object.values)
+            ...compositionErrors.map(({ service, field, message }) => [
+              service,
+              field,
+              message
+            ])
           ],
           {
             columns: {


### PR DESCRIPTION
"table" package is strict about data and fails on inconsistent rows dimension.

For that kind of composition error

```js
[
  {
    message: 'Field "Mutation.createSomething" can only be defined once.'
  }
]
```

`service:check` ends up with an exception

```
Error: Table must have a consistent number of cells.
    at validateTableData (~/Projects/sandbox/node_modules/table/dist/validateTableData.js:47:15)
    at Object.table (~/Projects/sandbox/node_modules/table/dist/table.js:96:34)
    at ServiceCheck.run (~/Projects/sandbox/node_modules/apollo/lib/commands/service/check.js:326:30)
```

- [x] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass

