### PR TITLE
add customizable persisted query id generation

### DIFF
--- a/packages/apollo-codegen-core/src/compiler/index.ts
+++ b/packages/apollo-codegen-core/src/compiler/index.ts
@@ -33,6 +33,7 @@ import {
   withTypenameFieldAddedWhereNeeded,
   isMetaFieldName
 } from "../utilities/graphql";
+import { OperationIdGenerator } from "./visitors/generateOperationId";
 
 export interface CompilerOptions {
   addTypename?: boolean;
@@ -41,6 +42,7 @@ export interface CompilerOptions {
   customScalarsPrefix?: string;
   namespace?: string;
   generateOperationIds?: boolean;
+  operationIdGenerator?: OperationIdGenerator;
   operationIdsPath?: string;
   // this option is only implemented in the ts codegen, so we name it
   // `ts` fileExtension for now.

--- a/packages/apollo-codegen-core/src/compiler/legacyIR.ts
+++ b/packages/apollo-codegen-core/src/compiler/legacyIR.ts
@@ -141,7 +141,8 @@ class LegacyIRTransformer {
       const { sourceWithFragments, operationId } = generateOperationId(
         operation,
         this.context.fragments,
-        fragmentsReferenced
+        fragmentsReferenced,
+        this.context.options.operationIdGenerator
       );
 
       operations[operationName] = {

--- a/packages/apollo-codegen-core/src/compiler/visitors/generateOperationId.ts
+++ b/packages/apollo-codegen-core/src/compiler/visitors/generateOperationId.ts
@@ -2,10 +2,21 @@ import { Operation, Fragment } from "../";
 import { collectFragmentsReferenced } from "./collectFragmentsReferenced";
 import { createHash } from "crypto";
 
+export interface OperationIdGenerator {
+  (operationDocument: string): string;
+}
+
+const Sha256IdGenerator: OperationIdGenerator = operationDocument => {
+  const hash = createHash("sha256");
+  hash.update(operationDocument);
+  return hash.digest("hex");
+};
+
 export function generateOperationId(
   operation: Operation,
   fragments: { [fragmentName: string]: Fragment },
-  fragmentsReferenced?: Iterable<string>
+  fragmentsReferenced?: Iterable<string>,
+  idGenerator: OperationIdGenerator = Sha256IdGenerator
 ) {
   if (!fragmentsReferenced) {
     fragmentsReferenced = collectFragmentsReferenced(
@@ -25,9 +36,6 @@ export function generateOperationId(
     })
   ].join("\n");
 
-  const hash = createHash("sha256");
-  hash.update(sourceWithFragments);
-  const operationId = hash.digest("hex");
-
+  const operationId = idGenerator(sourceWithFragments);
   return { operationId, sourceWithFragments };
 }

--- a/packages/apollo-codegen-swift/src/codeGeneration.ts
+++ b/packages/apollo-codegen-swift/src/codeGeneration.ts
@@ -247,7 +247,8 @@ export class SwiftAPIGenerator extends SwiftGenerator<CompilerContext> {
           const { operationId } = generateOperationId(
             operation,
             fragments,
-            fragmentsReferenced
+            fragmentsReferenced,
+            this.context.options.operationIdGenerator
           );
           operation.operationId = operationId;
           this.printNewlineIfNeeded();


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Tooling!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

+ fix #1742 

This adds a new feature to the Codegen tasks of the CLI to allow a custom persisted query ID generation. This is an effort continued from apollo-android project https://github.com/apollographql/apollo-android/pull/1849 to have it for swift and typescript projects. 

I would appreciate some initial feedback on the approach in this PR. I'll continue further efforts in this PR regarding tests and documentation.

TODO:

- [ ] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [ ] Make sure all of the significant new logic is covered by tests
- [ ] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests and linter rules pass

\*Make sure changelog entries note which project(s) has been affected. See older entries for examples on what this looks like.
