### PR TITLE
Fix display of unformatted errors in composition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 - `apollo`
   - Update shortlinks to use go.apollo.dev instead of bitly [#1790](https://github.com/apollographql/apollo-tooling/pull/1790)
-  - Support disabling literal stripping when extracting queries.  [1703](https://github.com/apollographql/apollo-tooling/pull/1703)
+  - Support disabling literal stripping when extracting queries. [1703](https://github.com/apollographql/apollo-tooling/pull/1703)
+  - Fix rendering of unexpected composition errors throwing a table cell error [#1806](https://github.com/apollographql/apollo-tooling/pull/1806)
 - `apollo-codegen-flow`
   - Add @generated comment
 - `apollo-codegen-scala`

--- a/packages/apollo-language-server/src/graphqlTypes.ts
+++ b/packages/apollo-language-server/src/graphqlTypes.ts
@@ -355,6 +355,9 @@ export interface ListServices_service {
 }
 
 export interface ListServices {
+  /**
+   * Service by ID
+   */
   service: ListServices_service | null;
 }
 
@@ -537,6 +540,9 @@ export interface SchemaTagsAndFieldStats_service {
 }
 
 export interface SchemaTagsAndFieldStats {
+  /**
+   * Service by ID
+   */
   service: SchemaTagsAndFieldStats_service | null;
 }
 
@@ -1148,6 +1154,9 @@ export interface GetSchemaByTag_service {
 }
 
 export interface GetSchemaByTag {
+  /**
+   * Service by ID
+   */
   service: GetSchemaByTag_service | null;
 }
 


### PR DESCRIPTION
Right now, `apollo service:check` for federated services expects a specifically shaped error message from composition errors, but not all errors are the expected shape. When that happens, we are not formatting the errors properly for display, and users are seeing a cryptic error about an inconsistent number of cells in the display table. This PR aims to fix that by displaying unformatted (unexpected) errors separately from the ones we can recognize and format.

before:

<img width="795" alt="Screen Shot 2020-02-20 at 11 49 35 AM" src="https://user-images.githubusercontent.com/9259509/74958540-1a261980-53d7-11ea-8f53-20c9ab00ae10.png">

after: 

<img width="695" alt="Screen Shot 2020-02-20 at 11 49 11 AM" src="https://user-images.githubusercontent.com/9259509/74958531-172b2900-53d7-11ea-8437-b44bae1413b5.png">

<!--
  Thanks for filing a pull request on Apollo Tooling!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [x] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [ ] Make sure all of the significant new logic is covered by tests
- [ ] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests and linter rules pass

\*Make sure changelog entries note which project(s) has been affected. See older entries for examples on what this looks like.
