### PR TITLE
Add ability to define schema download output path that doesn't exist yet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@
 
 - `apollo`
   - Update shortlinks to use go.apollo.dev instead of bitly [#1790](https://github.com/apollographql/apollo-tooling/pull/1790)
-  - Support disabling literal stripping when extracting queries. [1703](https://github.com/apollographql/apollo-tooling/pull/1703)
   - Fix rendering of unexpected composition errors throwing a table cell error [#1806](https://github.com/apollographql/apollo-tooling/pull/1806)
+  - Support disabling literal stripping when extracting queries. [1703](https://github.com/apollographql/apollo-tooling/pull/1703)
+  - Add ability to define schema download output path that doesn't exist yet [#1807](https://github.com/apollographql/apollo-tooling/pull/1807)
 - `apollo-codegen-flow`
   - Add @generated comment
 - `apollo-codegen-scala`

--- a/package-lock.json
+++ b/package-lock.json
@@ -3165,6 +3165,15 @@
       "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
       "dev": true
     },
+    "@types/mkdirp": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@types/mkdirp/-/mkdirp-1.0.0.tgz",
+      "integrity": "sha512-ONFY9//bCEr3DWKON3iDv/Q8LXnhaYYaNDeFSN0AtO5o4sLf9F0pstJKKKjQhXE0kJEeHs8eR6SAsROhhc2Csw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/mocha": {
       "version": "5.2.7",
       "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-5.2.7.tgz",

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "@types/lodash.pickby": "4.6.6",
     "@types/lodash.sortby": "4.7.6",
     "@types/minimatch": "3.0.3",
+    "@types/mkdirp": "^1.0.0",
     "@types/nock": "10.0.3",
     "@types/node": "8.10.56",
     "@types/node-fetch": "2.5.4",

--- a/packages/apollo/package.json
+++ b/packages/apollo/package.json
@@ -59,6 +59,7 @@
     "listr": "0.14.3",
     "lodash.identity": "3.0.0",
     "lodash.pickby": "4.6.0",
+    "mkdirp": "^1.0.3",
     "moment": "2.24.0",
     "strip-ansi": "5.2.0",
     "table": "5.4.6",

--- a/packages/apollo/src/commands/client/download-schema.ts
+++ b/packages/apollo/src/commands/client/download-schema.ts
@@ -1,8 +1,8 @@
-import { flags } from "@oclif/command";
 import { introspectionFromSchema, printSchema } from "graphql";
-import { writeFileSync } from "fs";
-
 import { ClientCommand } from "../../Command";
+import mkdirp from "mkdirp";
+import fs from "fs";
+import { dirname as getDirName } from "path";
 
 export default class SchemaDownload extends ClientCommand {
   static description =
@@ -23,8 +23,6 @@ export default class SchemaDownload extends ClientCommand {
   ];
 
   async run() {
-    let result;
-    let gitContext;
     await this.runTasks(({ args, project, flags }) => {
       const extension = args.output.split(".").pop();
       const isSDLFormat = ["graphql", "graphqls", "gql"].includes(extension);
@@ -36,7 +34,13 @@ export default class SchemaDownload extends ClientCommand {
             const formattedSchema = isSDLFormat
               ? printSchema(schema)
               : JSON.stringify(introspectionFromSchema(schema), null, 2);
-            writeFileSync(args.output, formattedSchema);
+
+            try {
+              await mkdirp(getDirName(args.output));
+              fs.writeFileSync(args.output, formattedSchema);
+            } catch (err) {
+              throw err;
+            }
           }
         }
       ];

--- a/packages/apollo/src/commands/service/download.ts
+++ b/packages/apollo/src/commands/service/download.ts
@@ -1,8 +1,10 @@
 import { flags } from "@oclif/command";
 import { introspectionFromSchema } from "graphql";
-import { writeFileSync } from "fs";
 import chalk from "chalk";
 import { ProjectCommand } from "../../Command";
+import mkdirp from "mkdirp";
+import fs from "fs";
+import { dirname as getDirName } from "path";
 
 export default class ServiceDownload extends ProjectCommand {
   static aliases = ["schema:download"];
@@ -24,22 +26,22 @@ export default class ServiceDownload extends ProjectCommand {
   static args = [
     {
       name: "output",
-      description: "Path to write the introspection result to",
+      description:
+        "Path to write the introspection result to. Supports .json output only.",
       required: true,
       default: "schema.json"
     }
   ];
 
   async run() {
-    let result;
-    let gitContext;
     await this.runTasks(({ args, project, flags }) => [
       {
         title: `Saving schema to ${args.output}`,
         task: async () => {
           try {
             const schema = await project.resolveSchema({ tag: flags.tag });
-            writeFileSync(
+            await mkdirp(getDirName(args.output));
+            fs.writeFileSync(
               args.output,
               JSON.stringify(introspectionFromSchema(schema), null, 2)
             );


### PR DESCRIPTION
resolves #1788 

Previously, the CLI couldn't download schemas in `apollo service:download` or `apollo client:download-schema` when the path in the `OUTPUT` didn't exist.

This PR aims to add the ability to create a path given in the `OUTPUT` and to save the outputted schema to that path :)

<img width="1131" alt="Screen Shot 2020-02-21 at 10 14 58 AM" src="https://user-images.githubusercontent.com/9259509/75046461-1bb51780-5493-11ea-9cc8-75ce862a9b98.png">
<img width="967" alt="Screen Shot 2020-02-21 at 10 16 24 AM" src="https://user-images.githubusercontent.com/9259509/75046529-3d160380-5493-11ea-8c0e-7ad43e3d18eb.png">


<!--
  Thanks for filing a pull request on Apollo Tooling!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [ ] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [ ] Make sure all of the significant new logic is covered by tests
- [ ] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests and linter rules pass

\*Make sure changelog entries note which project(s) has been affected. See older entries for examples on what this looks like.
