### PR TITLE
Make duplicate operations error a failing error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
   - Fix rendering of unexpected composition errors throwing a table cell error [#1806](https://github.com/apollographql/apollo-tooling/pull/1806)
   - Support disabling literal stripping when extracting queries. [1703](https://github.com/apollographql/apollo-tooling/pull/1703)
   - Add ability to define schema download output path that doesn't exist yet [#1807](https://github.com/apollographql/apollo-tooling/pull/1807)
+  - Correctly fail on duplicate operations in client projects [#1812](https://github.com/apollographql/apollo-tooling/pull/1812)
 - `apollo-codegen-flow`
   - Add @generated comment
 - `apollo-codegen-scala`
@@ -20,7 +21,7 @@
 - `apollo-graphql`
   - <First `apollo-graphql` related entry goes here>
 - `apollo-language-server`
-  - <First `apollo-language-server` related entry goes here>
+  - Correctly fail on duplicate operations in client projects [#1812](https://github.com/apollographql/apollo-tooling/pull/1812)
 - `apollo-tools`
   - <First `apollo-tools` related entry goes here>
 - `vscode-apollo`

--- a/packages/apollo-language-server/src/project/base.ts
+++ b/packages/apollo-language-server/src/project/base.ts
@@ -197,13 +197,9 @@ export abstract class GraphQLProject implements GraphQLSchemaProvider {
     // Don't process files of an unsupported filetype
     if (!languageId) return;
 
-    try {
-      const contents = readFileSync(filePath, "utf8");
-      const document = TextDocument.create(uri, languageId, -1, contents);
-      this.documentDidChange(document);
-    } catch (error) {
-      console.error(error);
-    }
+    const contents = readFileSync(filePath, "utf8");
+    const document = TextDocument.create(uri, languageId, -1, contents);
+    this.documentDidChange(document);
   }
 
   fileWasDeleted(uri: DocumentUri) {

--- a/packages/apollo-language-server/src/project/base.ts
+++ b/packages/apollo-language-server/src/project/base.ts
@@ -229,7 +229,7 @@ export abstract class GraphQLProject implements GraphQLSchemaProvider {
         if (definition.kind === Kind.OPERATION_DEFINITION && definition.name) {
           if (operations[definition.name.value]) {
             throw new Error(
-              `️️There are multiple definitions for the ${definition.name.value} operation. All operations in a project must have unique names. If generating types, only the types for the first definition found will be generated.`
+              `️️There are multiple definitions for the \`${definition.name.value}\` operation. Please rename or remove all operations with the duplicated name before continuing.`
             );
           }
           operations[definition.name.value] = definition;


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Tooling!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

This PR aims to fix an issue where some users are pushing client code that errors because the error notifying users of duplicate client operation names doesn't exit appropriately.

the previous error, just told users that duplicate operations aren't permitted in client projects, but never actually _enforced_ that as it should have. This PR should fix that behavior.

TODO:

- [ ] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [ ] Make sure all of the significant new logic is covered by tests
- [ ] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests and linter rules pass

\*Make sure changelog entries note which project(s) has been affected. See older entries for examples on what this looks like.
