### PR TITLE
Change non-existent service message to be correct

### DIFF
--- a/packages/apollo-language-server/src/engine/index.ts
+++ b/packages/apollo-language-server/src/engine/index.ts
@@ -92,9 +92,7 @@ export class ApolloEngineClient extends GraphQLDataSource {
       }
 
       if (data && !data.service) {
-        throw new Error(
-          noServiceError(getServiceFromKey(this.engineKey), this.baseURL)
-        );
+        throw new Error(noServiceError(variables.id, this.baseURL));
       }
 
       if (!(data && data.service)) {

--- a/packages/apollo-language-server/src/engine/index.ts
+++ b/packages/apollo-language-server/src/engine/index.ts
@@ -113,9 +113,7 @@ export class ApolloEngineClient extends GraphQLDataSource {
       }
 
       if (data && !data.service) {
-        throw new Error(
-          noServiceError(getServiceFromKey(this.engineKey), this.baseURL)
-        );
+        throw new Error(noServiceError(variables.id, this.baseURL));
       }
 
       if (!(data && data.service)) {
@@ -136,9 +134,7 @@ export class ApolloEngineClient extends GraphQLDataSource {
       }
 
       if (data && !data.service) {
-        throw new Error(
-          noServiceError(getServiceFromKey(this.engineKey), this.baseURL)
-        );
+        throw new Error(noServiceError(variables.id, this.baseURL));
       }
 
       if (!(data && data.service)) {
@@ -161,9 +157,7 @@ export class ApolloEngineClient extends GraphQLDataSource {
       }
 
       if (data && !data.service) {
-        throw new Error(
-          noServiceError(getServiceFromKey(this.engineKey), this.baseURL)
-        );
+        throw new Error(noServiceError(variables.id, this.baseURL));
       }
 
       if (!(data && data.service)) {
@@ -186,9 +180,7 @@ export class ApolloEngineClient extends GraphQLDataSource {
       }
 
       if (data && !data.service) {
-        throw new Error(
-          noServiceError(getServiceFromKey(this.engineKey), this.baseURL)
-        );
+        throw new Error(noServiceError(variables.id, this.baseURL));
       }
 
       if (!(data && data.service)) {
@@ -228,9 +220,7 @@ export class ApolloEngineClient extends GraphQLDataSource {
       }
 
       if (data && !data.service) {
-        throw new Error(
-          noServiceError(getServiceFromKey(this.engineKey), this.baseURL)
-        );
+        throw new Error(noServiceError(variables.id, this.baseURL));
       }
 
       if (!(data && data.service)) {
@@ -252,9 +242,7 @@ export class ApolloEngineClient extends GraphQLDataSource {
       }
 
       if (data && !data.service) {
-        throw new Error(
-          noServiceError(getServiceFromKey(this.engineKey), this.baseURL)
-        );
+        throw new Error(noServiceError(variables.id, this.baseURL));
       }
 
       if (


### PR DESCRIPTION
Currently, the message we provide to users for querying a service that
does not exist (or that they do not have access to) looks up the service
ID from the key rather than using the actual variable that it passed to
AGM when looking it up. This changes such messages to always use the
actual service ID that they were searching for.

Specifically, this is to support user tokens, where the graph in
question may not, in fact, be in the key, but instead by provided by
apollo.config.js

<!--
  Thanks for filing a pull request on Apollo Tooling!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [ ] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [ ] Make sure all of the significant new logic is covered by tests
- [ ] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests and linter rules pass

\*Make sure changelog entries note which project(s) has been affected. See older entries for examples on what this looks like.
