### PR TITLE
Update "no service found to link..." error

### DIFF
--- a/packages/apollo/src/commands/client/check.ts
+++ b/packages/apollo/src/commands/client/check.ts
@@ -8,6 +8,7 @@ import { relative } from "path";
 import { graphqlTypes } from "apollo-language-server";
 import chalk from "chalk";
 import envCi from "env-ci";
+import { graphUndefinedError } from "../../utils/errors";
 
 const { ValidationErrorType } = graphqlTypes;
 type ValidationResult = graphqlTypes.ValidateOperations_service_validateOperations_validationResults;
@@ -41,9 +42,7 @@ export default class ClientCheck extends ClientCommand {
           title: "Checking client compatibility with service",
           task: async ctx => {
             if (!config.name) {
-              throw new Error(
-                "No service found to link to Apollo Graph Manager. Graph Manager is required for this command."
-              );
+              throw graphUndefinedError;
             }
             ctx.gitContext = await gitInfo(this.log);
 

--- a/packages/apollo/src/commands/client/push.ts
+++ b/packages/apollo/src/commands/client/push.ts
@@ -14,6 +14,7 @@ import {
   ApolloConfig,
   graphqlTypes
 } from "apollo-language-server";
+import { graphUndefinedError } from "../../utils/errors";
 
 export default class ClientPush extends ClientCommand {
   static description =
@@ -60,9 +61,7 @@ export default class ClientPush extends ClientCommand {
             title: "Pushing operations to operation registry",
             task: async (_, task) => {
               if (!config.name) {
-                throw new Error(
-                  "No service found to link to Apollo Graph Manager. Graph Manager is required for this command."
-                );
+                throw graphUndefinedError;
               }
 
               const operationManifest = getOperationManifestFromProject(

--- a/packages/apollo/src/commands/service/check.ts
+++ b/packages/apollo/src/commands/service/check.ts
@@ -22,6 +22,7 @@ import { ApolloConfig, isServiceProject } from "apollo-language-server";
 import moment from "moment";
 import sortBy from "lodash.sortby";
 import { isNotNullOrUndefined } from "apollo-env";
+import { graphUndefinedError } from "../../utils/errors";
 
 const formatChange = (change: Change) => {
   let color = (x: string): string => x;
@@ -304,7 +305,7 @@ export default class ServiceCheck extends ProjectCommand {
           const serviceName: string | undefined = flags.serviceName;
 
           if (!graphID) {
-            throw new Error("No service found to link to Apollo Graph Manager");
+            throw graphUndefinedError;
           }
 
           // Add some fields to output that are required for producing

--- a/packages/apollo/src/commands/service/delete.ts
+++ b/packages/apollo/src/commands/service/delete.ts
@@ -2,6 +2,7 @@ import cli from "cli-ux";
 import { flags } from "@oclif/command";
 
 import { ProjectCommand } from "../../Command";
+import { graphUndefinedError } from "../../utils/errors";
 
 export default class ServiceDelete extends ProjectCommand {
   static description =
@@ -52,7 +53,7 @@ export default class ServiceDelete extends ProjectCommand {
         title: "Removing service from Apollo Graph Manager",
         task: async () => {
           if (!config.name) {
-            throw new Error("No service found to link to Apollo Graph Manager");
+            throw graphUndefinedError;
           }
 
           if (flags.federated) {

--- a/packages/apollo/src/commands/service/list.ts
+++ b/packages/apollo/src/commands/service/list.ts
@@ -4,17 +4,12 @@ import { GraphQLSchema } from "graphql";
 import sortBy from "lodash.sortby";
 import { table } from "table";
 import moment from "moment";
-import {
-  ApolloConfig,
-  isServiceProject,
-  DefaultEngineConfig
-} from "apollo-language-server";
+import { ApolloConfig, DefaultEngineConfig } from "apollo-language-server";
 import chalk from "chalk";
 import {
   ListServices_service_implementingServices,
   ListServices_service_implementingServices_FederatedImplementingServices_services
 } from "apollo-language-server/lib/graphqlTypes";
-import { CLIError } from "@oclif/errors";
 import { graphUndefinedError } from "../../utils/errors";
 
 interface TasksOutput {

--- a/packages/apollo/src/commands/service/list.ts
+++ b/packages/apollo/src/commands/service/list.ts
@@ -14,6 +14,8 @@ import {
   ListServices_service_implementingServices,
   ListServices_service_implementingServices_FederatedImplementingServices_services
 } from "apollo-language-server/lib/graphqlTypes";
+import { CLIError } from "@oclif/errors";
+import { graphUndefinedError } from "../../utils/errors";
 
 interface TasksOutput {
   config: ApolloConfig;
@@ -114,7 +116,7 @@ export default class ServiceList extends ProjectCommand {
         graphVariant = flags.tag || config.tag || "current";
 
         if (!graphID) {
-          throw new Error("No service found to link to Apollo Graph Manager");
+          throw graphUndefinedError;
         }
 
         return [

--- a/packages/apollo/src/commands/service/push.ts
+++ b/packages/apollo/src/commands/service/push.ts
@@ -6,6 +6,7 @@ import { ProjectCommand } from "../../Command";
 import { UploadSchemaVariables } from "apollo-language-server/lib/graphqlTypes";
 import { GraphQLServiceProject } from "apollo-language-server";
 import chalk from "chalk";
+import { graphUndefinedError } from "../../utils/errors";
 
 export default class ServicePush extends ProjectCommand {
   static aliases = ["schema:publish"];
@@ -51,7 +52,7 @@ export default class ServicePush extends ProjectCommand {
         title: "Uploading service to Apollo Graph Manager",
         task: async () => {
           if (!config.name) {
-            throw new Error("No service found to link to Apollo Graph Manager");
+            throw graphUndefinedError;
           }
 
           if (flags.federated) {

--- a/packages/apollo/src/utils/errors.ts
+++ b/packages/apollo/src/utils/errors.ts
@@ -4,6 +4,6 @@ const errorMessage = [
   "No graph (i.e. service) found to link to Apollo Graph Manager.",
   "In order to run this command, please provide a graph ID using the 'apollo.config.js' file.",
   "\n\nFor more information on configuring the Apollo CLI, please go to",
-  "https://www.apollographql.com/docs/devtools/apollo-config/"
+  "https://go.apollo.dev/t/config"
 ].join(" ");
 export const graphUndefinedError = new CLIError(errorMessage);

--- a/packages/apollo/src/utils/errors.ts
+++ b/packages/apollo/src/utils/errors.ts
@@ -1,0 +1,9 @@
+import { CLIError } from "@oclif/errors";
+
+const errorMessage = [
+  "No graph (i.e. service) found to link to Apollo Graph Manager.",
+  "In order to run this command, please provide a graph ID using the 'apollo.config.js' file.",
+  "\n\nFor more information on configuring the Apollo CLI, please go to",
+  "https://www.apollographql.com/docs/devtools/apollo-config/"
+].join(" ");
+export const graphUndefinedError = new CLIError(errorMessage);


### PR DESCRIPTION
This updates the error message that occurs when a config.service.name is
required in order to execute a command. Before this commit, there were
two distinct messages that were used in commands to communicate this
error to the user, which were slightly different in their wording. This
updates the wording to provide an explanation as well as next steps on
how to remedy the issue. Additionally, it uses the `CLIError` class in
order to print out an error in a "friendly" way without a stack trace,
as recommended by the @oclif/errors package we are using: https://oclif.io/docs/commands#thiserrormessage-string--error-options-code-string-exit-number

For changelog entry, please see https://github.com/apollographql/apollo-tooling/pull/1849

<!--
  Thanks for filing a pull request on Apollo Tooling!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [x] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass

\*Make sure changelog entries note which project(s) has been affected. See older entries for examples on what this looks like.
