### PR TITLE
Generate optional TypeScript fields when @include or @skip directive is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 - `apollo-codegen-swift`
   - <First `apollo-codegen-swift` related entry goes here>
 - `apollo-codegen-typescript`
-  - <First `apollo-codegen-typescript` related entry goes here>
+  - Generate optional TypeScript fields when @include directive is used [#1854](https://github.com/apollographql/apollo-tooling/pull/1854)
 - `apollo-codegen-core`
   - <First `apollo-codegen-core` related entry goes here>
 - `apollo-env`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 - `apollo-codegen-swift`
   - <First `apollo-codegen-swift` related entry goes here>
 - `apollo-codegen-typescript`
-  - Generate optional TypeScript fields when @include directive is used [#1854](https://github.com/apollographql/apollo-tooling/pull/1854)
+  - Generate optional TypeScript fields when @include or @skip directive is used [#1854](https://github.com/apollographql/apollo-tooling/pull/1854)
 - `apollo-codegen-core`
   - <First `apollo-codegen-core` related entry goes here>
 - `apollo-env`

--- a/packages/apollo-codegen-typescript/src/__tests__/__snapshots__/codeGeneration.ts.snap
+++ b/packages/apollo-codegen-typescript/src/__tests__/__snapshots__/codeGeneration.ts.snap
@@ -43,6 +43,49 @@ export interface SimpleFragment {
 }
 `;
 
+exports[`Typescript codeGeneration @skip directive 1`] = `
+Object {
+  "common": "/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+//==============================================================
+// START Enums and Input Objects
+//==============================================================
+
+//==============================================================
+// END Enums and Input Objects
+//==============================================================
+",
+  "generatedFiles": Array [
+    Object {
+      "content": TypescriptGeneratedFile {
+        "fileContents": "/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL fragment: SimpleFragment
+// ====================================================
+
+export interface SimpleFragment {
+  __typename: \\"Human\\" | \\"Droid\\";
+  /**
+   * The name of the character
+   */
+  name?: string;
+}
+",
+      },
+      "fileName": "SimpleFragment.ts",
+      "sourcePath": "GraphQL request",
+    },
+  ],
+}
+`;
+
 exports[`Typescript codeGeneration fragment spreads with inline fragments 1`] = `
 Object {
   "common": "/* tslint:disable */

--- a/packages/apollo-codegen-typescript/src/__tests__/__snapshots__/codeGeneration.ts.snap
+++ b/packages/apollo-codegen-typescript/src/__tests__/__snapshots__/codeGeneration.ts.snap
@@ -1,5 +1,48 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Typescript codeGeneration @include directive 1`] = `
+Object {
+  "common": "/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+//==============================================================
+// START Enums and Input Objects
+//==============================================================
+
+//==============================================================
+// END Enums and Input Objects
+//==============================================================
+",
+  "generatedFiles": Array [
+    Object {
+      "content": TypescriptGeneratedFile {
+        "fileContents": "/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL fragment: SimpleFragment
+// ====================================================
+
+export interface SimpleFragment {
+  __typename: \\"Human\\" | \\"Droid\\";
+  /**
+   * The name of the character
+   */
+  name?: string;
+}
+",
+      },
+      "fileName": "SimpleFragment.ts",
+      "sourcePath": "GraphQL request",
+    },
+  ],
+}
+`;
+
 exports[`Typescript codeGeneration fragment spreads with inline fragments 1`] = `
 Object {
   "common": "/* tslint:disable */

--- a/packages/apollo-codegen-typescript/src/__tests__/codeGeneration.ts
+++ b/packages/apollo-codegen-typescript/src/__tests__/codeGeneration.ts
@@ -297,6 +297,17 @@ describe("Typescript codeGeneration", () => {
     const output = generateSource(context);
     expect(output).toMatchSnapshot();
   });
+
+  test("@skip directive", () => {
+    const context = compile(`
+      fragment SimpleFragment on Character{
+        name @skip(if: $includeName)
+      }
+    `);
+
+    const output = generateSource(context);
+    expect(output).toMatchSnapshot();
+  });
 });
 
 describe("Typescript codeGeneration local / global", () => {

--- a/packages/apollo-codegen-typescript/src/__tests__/codeGeneration.ts
+++ b/packages/apollo-codegen-typescript/src/__tests__/codeGeneration.ts
@@ -286,6 +286,17 @@ describe("Typescript codeGeneration", () => {
     const output = generateSource(context);
     expect(output).toMatchSnapshot();
   });
+
+  test("@include directive", () => {
+    const context = compile(`
+      fragment SimpleFragment on Character{
+        name @include(if: $includeName)
+      }
+    `);
+
+    const output = generateSource(context);
+    expect(output).toMatchSnapshot();
+  });
 });
 
 describe("Typescript codeGeneration local / global", () => {

--- a/packages/apollo-codegen-typescript/src/codeGeneration.ts
+++ b/packages/apollo-codegen-typescript/src/codeGeneration.ts
@@ -285,7 +285,8 @@ export class TypescriptAPIGenerator extends TypescriptGenerator {
             interfaceName,
             variables.map(variable => ({
               name: variable.name,
-              type: this.typeFromGraphQLType(variable.type)
+              type: this.typeFromGraphQLType(variable.type),
+              isConditional: false
             })),
             { keyInheritsNullability: true }
           )
@@ -559,7 +560,8 @@ export class TypescriptAPIGenerator extends TypescriptGenerator {
     return {
       name: field.alias ? field.alias : field.name,
       description: field.description,
-      type
+      type,
+      isConditional: field.isConditional || false
     };
   }
 
@@ -573,14 +575,16 @@ export class TypescriptAPIGenerator extends TypescriptGenerator {
       res = {
         name: field.alias ? field.alias : field.name,
         description: field.description,
-        type: t.TSUnionType(types)
+        type: t.TSUnionType(types),
+        isConditional: field.isConditional || false
       };
     } else {
       // TODO: Double check that this works
       res = {
         name: field.alias ? field.alias : field.name,
         description: field.description,
-        type: this.typeFromGraphQLType(field.type)
+        type: this.typeFromGraphQLType(field.type),
+        isConditional: field.isConditional || false
       };
     }
 

--- a/packages/apollo-codegen-typescript/src/language.ts
+++ b/packages/apollo-codegen-typescript/src/language.ts
@@ -14,6 +14,7 @@ export type ObjectProperty = {
   name: string;
   description?: string | null | undefined;
   type: t.TSType;
+  isConditional: boolean;
 };
 
 export default class TypescriptGenerator {
@@ -61,7 +62,8 @@ export default class TypescriptGenerator {
       const field = fieldMap[fieldName];
       return {
         name: fieldName,
-        type: this.typeFromGraphQLType(field.type)
+        type: this.typeFromGraphQLType(field.type),
+        isConditional: false
       };
     });
 
@@ -92,7 +94,7 @@ export default class TypescriptGenerator {
       keyInheritsNullability?: boolean;
     } = {}
   ) {
-    return fields.map(({ name, description, type }) => {
+    return fields.map(({ name, description, type, isConditional }) => {
       const propertySignatureType = t.TSPropertySignature(
         t.identifier(name),
         t.TSTypeAnnotation(type)
@@ -100,7 +102,7 @@ export default class TypescriptGenerator {
 
       // TODO: Check if this works
       propertySignatureType.optional =
-        keyInheritsNullability && this.isNullableType(type);
+        (keyInheritsNullability && this.isNullableType(type)) || isConditional;
 
       if (this.options.useReadOnlyTypes) {
         propertySignatureType.readonly = true;


### PR DESCRIPTION
This makes generated TypeScript fields optional if the `@include` directive is used. Fixes #888.