### PR TITLE
Improve error message for failing to provide service endpoint

### DIFF
--- a/packages/apollo-language-server/src/providers/schema/endpoint.ts
+++ b/packages/apollo-language-server/src/providers/schema/endpoint.ts
@@ -29,6 +29,17 @@ export class EndpointSchemaProvider implements GraphQLSchemaProvider {
       uri: url,
       fetch
     };
+
+    if (!url) {
+      throw new Error(
+        "This command requires either the --endpoint option or the" +
+          "\n--localSchemaFile option to obtain your service's schema." +
+          "\nYou can also provide one of these values in your apollo.config.js file.\n" +
+          "-----------------------------\n" +
+          "For more information, please refer to: https://www.apollographql.com/docs/graph-manager/schema-registry/"
+      );
+    }
+
     if (url.startsWith("https:") && skipSSLValidation) {
       options.fetchOptions = {
         agent: new HTTPSAgent({ rejectUnauthorized: false })


### PR DESCRIPTION
Currently if you run `apollo service:push` failing to provide an endpoint or localSchemaFile, you get an unhelpful error:

```
TypeError: Cannot read property 'startsWith' of undefined
```