### PR TITLE
service:check Add ignoreFailures flag

### DIFF
--- a/packages/apollo-language-server/src/graphqlTypes.ts
+++ b/packages/apollo-language-server/src/graphqlTypes.ts
@@ -69,14 +69,14 @@ export interface CheckPartialSchema_service_checkPartialSchema_checkSchemaResult
   /**
    * delta in seconds from current time that determines the start of the window
    * for reported metrics included in a schema diff. A day window from the present
-   * day would have a \`from\` value of -86400. In rare cases, this could be an ISO
+   * day would have a `from` value of -86400. In rare cases, this could be an ISO
    * timestamp if the user passed one in on diff creation
    */
   from: any | null;
   /**
    * delta in seconds from current time that determines the end of the
    * window for reported metrics included in a schema diff. A day window
-   * from the present day would have a \`to\` value of -0. In rare
+   * from the present day would have a `to` value of -0. In rare
    * cases, this could be an ISO timestamp if the user passed one in on diff
    * creation
    */
@@ -207,14 +207,14 @@ export interface CheckSchema_service_checkSchema_diffToPrevious_validationConfig
   /**
    * delta in seconds from current time that determines the start of the window
    * for reported metrics included in a schema diff. A day window from the present
-   * day would have a \`from\` value of -86400. In rare cases, this could be an ISO
+   * day would have a `from` value of -86400. In rare cases, this could be an ISO
    * timestamp if the user passed one in on diff creation
    */
   from: any | null;
   /**
    * delta in seconds from current time that determines the end of the
    * window for reported metrics included in a schema diff. A day window
-   * from the present day would have a \`to\` value of -0. In rare
+   * from the present day would have a `to` value of -0. In rare
    * cases, this could be an ISO timestamp if the user passed one in on diff
    * creation
    */
@@ -520,7 +520,13 @@ export interface SchemaTagsAndFieldStats_service_stats_fieldStats_metrics {
 
 export interface SchemaTagsAndFieldStats_service_stats_fieldStats {
   __typename: "ServiceFieldStatsRecord";
+  /**
+   * Dimensions of ServiceFieldStats that can be grouped by.
+   */
   groupBy: SchemaTagsAndFieldStats_service_stats_fieldStats_groupBy;
+  /**
+   * Metrics of ServiceFieldStats that can be aggregated over.
+   */
   metrics: SchemaTagsAndFieldStats_service_stats_fieldStats_metrics;
 }
 

--- a/packages/apollo/src/commands/service/check.ts
+++ b/packages/apollo/src/commands/service/check.ts
@@ -279,7 +279,7 @@ export default class ServiceCheck extends ProjectCommand {
       description:
         "Provides the name of the implementing service for a federated graph. This flag will indicate that the schema is a partial schema from a federated service"
     }),
-    successOnCompletion: flags.boolean({
+    ignoreFailures: flags.boolean({
       description:
         "Exit with status 0 when the check completes, even if errors are found"
     })
@@ -325,7 +325,7 @@ export default class ServiceCheck extends ProjectCommand {
           // Add some fields to output that are required for post-processing
           taskOutput.shouldOutputJson = !!flags.json;
           taskOutput.shouldOutputMarkdown = !!flags.markdown;
-          taskOutput.shouldAlwaysExit0 = !!flags.successOnCompletion;
+          taskOutput.shouldAlwaysExit0 = !!flags.ignoreFailures;
           taskOutput.serviceName = flags.serviceName;
           taskOutput.config = config;
 


### PR DESCRIPTION
When using the GitHub integration, it's often recommended to run
service:check && echo "ignoring output" because GH status will be
updated by the command. Adding this option makes using the command with
GH integration cleaner by exiting with 0 on all schema errors.

Fixes #1852 

<!--
  Thanks for filing a pull request on Apollo Tooling!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [ ] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [ ] Make sure all of the significant new logic is covered by tests
- [ ] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests and linter rules pass

\*Make sure changelog entries note which project(s) has been affected. See older entries for examples on what this looks like.
