### PR TITLE
Remove "hidden: true" from variant flag in service:push

### DIFF
--- a/packages/apollo/src/commands/service/push.ts
+++ b/packages/apollo/src/commands/service/push.ts
@@ -24,7 +24,6 @@ export default class ServicePush extends ProjectCommand {
       char: "v",
       description:
         "The variant to publish your service to in Apollo Graph Manager",
-      hidden: true,
       exclusive: ["tag"]
     }),
     graph: flags.string({


### PR DESCRIPTION
When running `npx apollo service:push --help`, there is no entry for `--variant`, due to `hidden: true` being used in the options for the flag (#1849). This PR removes the `hidden: true`.

TODO:

- [ ] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
