### PR TITLE
Update deprecation message of ENGINE_API_KEY to include alternative of APOLLO_KEY

### DIFF
--- a/packages/apollo-language-server/src/config/loadConfig.ts
+++ b/packages/apollo-language-server/src/config/loadConfig.ts
@@ -135,7 +135,7 @@ export async function loadConfig({
       }
       if (legacyKey) {
         Debug.warning(
-          `[Deprecation warning] Setting the key via ${legacyKeyEnvVar} is deprecated and will not be supported in future versions.`
+          `[Deprecation warning] Setting the key via ${legacyKeyEnvVar} is deprecated and will not be supported in future versions. Please use ${keyEnvVar} instead.`
         );
       }
       apiKey = key || legacyKey;


### PR DESCRIPTION
The message that appeared for users using `ENGINE_API_KEY` was not actionable before this change. This updates the message to suggest using `APOLLO_KEY` in lieu of `ENGINE_API_KEY` :)

I don't _think_ this kind of change really necessitates a CHANGELOG entry, but happy to add one if requested.

<!--
  Thanks for filing a pull request on Apollo Tooling!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass

\*Make sure changelog entries note which project(s) has been affected. See older entries for examples on what this looks like.
