### PR TITLE
try out github release via orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -208,30 +208,30 @@ workflows:
             # - NodeJS 12 Windows
             # - Test VSCode
             # - Build VSCode
-      - oss/dry_run:
-          name: Dry-run
-          <<: *common_publish_filters
-          requires:
-            # - NodeJS 8
-            - NodeJS 10
+      # - oss/dry_run:
+      #     name: Dry-run
+      #     <<: *common_publish_filters
+      #     requires:
+      #       # - NodeJS 8
+      #       - NodeJS 10
             # - NodeJS 12 Windows
             # - Test VSCode
             # - Build VSCode
-      - oss/confirmation:
-          name: Confirmation
-          type: approval
-          <<: *common_publish_filters
-          requires:
-            - Dry-run
-      - oss/publish:
-          name: Publish
-          <<: *common_publish_filters
-          requires:
-            - Confirmation
-      - Publish VSCode Extension:
-          <<: *common_publish_filters
-          requires:
-            - Confirmation
+      # - oss/confirmation:
+      #     name: Confirmation
+      #     type: approval
+      #     <<: *common_publish_filters
+      #     requires:
+      #       - Dry-run
+      # - oss/publish:
+      #     name: Publish
+      #     <<: *common_publish_filters
+      #     requires:
+      #       - Confirmation
+      # - Publish VSCode Extension:
+      #     <<: *common_publish_filters
+      #     requires:
+      #       - Confirmation
       - Publish GitHub Release:
           # <<: *common_publish_filters
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,9 +95,10 @@ jobs:
             test -d oclif-dist/channels && exit 1 || "Not a pre-release, continuing with publishing"
             go get github.com/tcnksm/ghr
             VERSION=$(ls oclif-dist | cut -d 'v' -f2)
-            echo "Publishing apollo@${VERSION} to GitHub Releases"
+            echo "Publishing apollo@${VERSION} to GitHub Releases using ghr"
+            echo "ghr -t ${GITHUB_TOKEN} -c ${CIRCLE_SHA1} -delete apollo@${VERSION} ./oclif-dist/apollo-v${VERSION}/"
             ls ./oclif-dist/apollo-v${VERSION}/
-            ghr -t ${GITHUB_TOKEN} -c ${CIRCLE_SHA1} -delete apollo@${VERSION} ./oclif-dist/apollo-v${VERSION}/
+            ghr -t ${GITHUB_TOKEN} -c ${CIRCLE_SHA1} -delete apollo@${VERSION} "./oclif-dist/apollo-v${VERSION}/"
 
   Test VSCode:
     executor: { name: oss/node }

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,6 +87,7 @@ jobs:
       - attach_workspace:
           # Must be absolute path or relative path from working_directory
           at: .
+      - checkout
       - run:
           name: "Publish Release on GitHub"
           command: |
@@ -175,22 +176,22 @@ workflows:
   version: 2
   Build:
     jobs:
-      - NodeJS 8:
-          <<: *common_non_publish_filters
+      # - NodeJS 8:
+      #     <<: *common_non_publish_filters
       - NodeJS 10:
           <<: *common_non_publish_filters
-      - NodeJS 12 Windows:
-          <<: *common_non_publish_filters
-      - Test VSCode:
-          <<: *common_non_publish_filters
-      - Build VSCode:
-          <<: *common_non_publish_filters
-      - Linting:
-          <<: *common_non_publish_filters
-      - Query Check:
-          <<: *common_non_publish_filters
-      - Generated Types Check:
-          <<: *common_non_publish_filters
+      # - NodeJS 12 Windows:
+      #     <<: *common_non_publish_filters
+      # - Test VSCode:
+      #     <<: *common_non_publish_filters
+      # - Build VSCode:
+      #     <<: *common_non_publish_filters
+      # - Linting:
+      #     <<: *common_non_publish_filters
+      # - Query Check:
+      #     <<: *common_non_publish_filters
+      # - Generated Types Check:
+      #     <<: *common_non_publish_filters
       - oss/oclif_pack_from_verdaccio_storage:
           name: Build CLI
           package: apollo
@@ -201,20 +202,20 @@ workflows:
           name: Package tarballs
           <<: *common_non_publish_filters
           requires:
-            - NodeJS 8
+            # - NodeJS 8
             - NodeJS 10
-            - NodeJS 12 Windows
-            - Test VSCode
-            - Build VSCode
+            # - NodeJS 12 Windows
+            # - Test VSCode
+            # - Build VSCode
       - oss/dry_run:
           name: Dry-run
           <<: *common_publish_filters
           requires:
-            - NodeJS 8
+            # - NodeJS 8
             - NodeJS 10
-            - NodeJS 12 Windows
-            - Test VSCode
-            - Build VSCode
+            # - NodeJS 12 Windows
+            # - Test VSCode
+            # - Build VSCode
       - oss/confirmation:
           name: Confirmation
           type: approval

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ version: 2.1
 orbs:
   # `oss` is a local reference to the package.  The source for Apollo Orbs can
   # be found at http://github.com/apollographql/CircleCI-Orbs.
-  oss: apollo/oss-ci-cd-tooling@dev:0.0.9
+  oss: apollo/oss-ci-cd-tooling@0.0.9
   # win is a windows orb provided by circleci
   win: circleci/windows@2.0.0
 
@@ -179,22 +179,22 @@ workflows:
   version: 2
   Build:
     jobs:
-      # - NodeJS 8:
-      #     <<: *common_non_publish_filters
+      - NodeJS 8:
+          <<: *common_non_publish_filters
       - NodeJS 10:
           <<: *common_non_publish_filters
-      # - NodeJS 12 Windows:
-      #     <<: *common_non_publish_filters
-      # - Test VSCode:
-      #     <<: *common_non_publish_filters
-      # - Build VSCode:
-      #     <<: *common_non_publish_filters
-      # - Linting:
-      #     <<: *common_non_publish_filters
-      # - Query Check:
-      #     <<: *common_non_publish_filters
-      # - Generated Types Check:
-      #     <<: *common_non_publish_filters
+      - NodeJS 12 Windows:
+          <<: *common_non_publish_filters
+      - Test VSCode:
+          <<: *common_non_publish_filters
+      - Build VSCode:
+          <<: *common_non_publish_filters
+      - Linting:
+          <<: *common_non_publish_filters
+      - Query Check:
+          <<: *common_non_publish_filters
+      - Generated Types Check:
+          <<: *common_non_publish_filters
       - oss/oclif_pack_from_verdaccio_storage:
           name: Build CLI
           package: apollo
@@ -205,39 +205,38 @@ workflows:
           name: Package tarballs
           <<: *common_non_publish_filters
           requires:
-            # - NodeJS 8
+            - NodeJS 8
             - NodeJS 10
-            # - NodeJS 12 Windows
-            # - Test VSCode
-            # - Build VSCode
-      # - oss/dry_run:
-      #     name: Dry-run
-      #     <<: *common_publish_filters
-      #     requires:
-      #       # - NodeJS 8
-      #       - NodeJS 10
-            # - NodeJS 12 Windows
-            # - Test VSCode
-            # - Build VSCode
-      # - oss/confirmation:
-      #     name: Confirmation
-      #     type: approval
-      #     <<: *common_publish_filters
-      #     requires:
-      #       - Dry-run
-      # - oss/publish:
-      #     name: Publish
-      #     <<: *common_publish_filters
-      #     requires:
-      #       - Confirmation
-      # - Publish VSCode Extension:
-      #     <<: *common_publish_filters
-      #     requires:
-      #       - Confirmation
+            - NodeJS 12 Windows
+            - Test VSCode
+            - Build VSCode
       - Publish GitHub Release:
-          # <<: *common_publish_filters
+          <<: *common_publish_filters
           requires:
-            # - Confirmation
             - Build CLI
+      - oss/dry_run:
+          name: Dry-run
+          <<: *common_publish_filters
+          requires:
+            - NodeJS 8
+            - NodeJS 10
+            - NodeJS 12 Windows
+            - Test VSCode
+            - Build VSCode
+      - oss/confirmation:
+          name: Confirmation
+          type: approval
+          <<: *common_publish_filters
+          requires:
+            - Dry-run
+      - oss/publish:
+          name: Publish
+          <<: *common_publish_filters
+          requires:
+            - Confirmation
+      - Publish VSCode Extension:
+          <<: *common_publish_filters
+          requires:
+            - Confirmation
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,8 +95,9 @@ jobs:
             test -d oclif-dist/channels && exit 1 || "Not a pre-release, continuing with publishing"
             go get github.com/tcnksm/ghr
             VERSION=$(ls oclif-dist | cut -d 'v' -f2)
-            echo "Publishing ${VERSION} to GitHub Releases"
-            ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -delete apollo@${VERSION} ./oclif-dist/apollo-v${VERSION}/
+            echo "Publishing apollo@${VERSION} to GitHub Releases"
+            ls ./oclif-dist/apollo-v${VERSION}/
+            ghr -t ${GITHUB_TOKEN} -c ${CIRCLE_SHA1} -delete apollo@${VERSION} ./oclif-dist/apollo-v${VERSION}/
 
   Test VSCode:
     executor: { name: oss/node }

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -230,7 +230,8 @@ workflows:
           requires:
             - Confirmation
       - Publish GitHub Release:
-        requires:
-          - Confirmation
-        <<: *common_publish_filters
+          <<: *common_publish_filters
+          requires:
+            - Confirmation
+
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,7 +93,8 @@ jobs:
             ls ./oclif-dist
             go get github.com/tcnksm/ghr
             VERSION=$(ls oclif-dist | cut -d 'v' -f2)
-            ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -delete ${VERSION} ./oclif-dist/apollo-v${VERSION}/
+            echo "Publishing ${VERSION} to GitHub Releases"
+            ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -delete apollo@${VERSION} ./oclif-dist/apollo-v${VERSION}/
 
   Test VSCode:
     executor: { name: oss/node }

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,6 +85,7 @@ jobs:
       - image: circleci/golang:latest
     steps:
       - attach_workspace:
+          # Must be absolute path or relative path from working_directory
           at: ./oclif-dist
       - run:
           name: "Publish Release on GitHub"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,7 +91,8 @@ jobs:
       - run:
           name: "Publish Release on GitHub"
           command: |
-            ls ./oclif-dist
+            set +e
+            test -d oclif-dist/channels && exit 1 || "Not a pre-release, continuing with publishing"
             go get github.com/tcnksm/ghr
             VERSION=$(ls oclif-dist | cut -d 'v' -f2)
             echo "Publishing ${VERSION} to GitHub Releases"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -230,8 +230,9 @@ workflows:
           requires:
             - Confirmation
       - Publish GitHub Release:
-          <<: *common_publish_filters
+          # <<: *common_publish_filters
           requires:
-            - Confirmation
+            # - Confirmation
+            - Build CLI
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,7 +94,7 @@ jobs:
         default: './.verdaccio-storage'
     steps:
       - attach_workspace:
-        at: << parameters.backup_path >>/**
+          at: << parameters.backup_path >>/**
       - run:
           name: "Publish Release on GitHub"
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -209,7 +209,7 @@ workflows:
             - Build VSCode
       - Publish GitHub Release:
           requires:
-            - Package tarballs
+            - Build CLI
         # <<: *common_publish_filters
         # requires:
         #   - Confirmation

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,12 +83,22 @@ jobs:
   Publish GitHub Release:
     docker:
       - image: circleci/golang:latest
+    parameters:
+      verdaccio_path:
+        type: string
+        description: The location of the Verdaccio installation store
+        default: '$HOME/.config/verdaccio/storage/'
+      backup_path:
+        type: string
+        description: The location where Verdaccio will be backed up to.
+        default: './.verdaccio-storage'
     steps:
-      - checkout
+      - attach_workspace:
+        at: << parameters.backup_path >>/**
       - run:
           name: "Publish Release on GitHub"
           command: |
-            ls oclif-dist
+            ls ./.verdaccio-storage
             go get github.com/tcnksm/ghr
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,22 +83,13 @@ jobs:
   Publish GitHub Release:
     docker:
       - image: circleci/golang:latest
-    parameters:
-      verdaccio_path:
-        type: string
-        description: The location of the Verdaccio installation store
-        default: '$HOME/.config/verdaccio/storage/'
-      backup_path:
-        type: string
-        description: The location where Verdaccio will be backed up to.
-        default: './.verdaccio-storage'
     steps:
       - attach_workspace:
-          at: << parameters.backup_path >>/**
+          at: ./oclif-dist
       - run:
           name: "Publish Release on GitHub"
           command: |
-            ls ./.verdaccio-storage
+            ls ./oclif-dist
             go get github.com/tcnksm/ghr
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ version: 2.1
 orbs:
   # `oss` is a local reference to the package.  The source for Apollo Orbs can
   # be found at http://github.com/apollographql/CircleCI-Orbs.
-  oss: apollo/oss-ci-cd-tooling@0.0.8
+  oss: apollo/oss-ci-cd-tooling@dev:0.0.9
   # win is a windows orb provided by circleci
   win: circleci/windows@2.0.0
 
@@ -78,6 +78,22 @@ jobs:
       - checkout
       - oss/npm_clean_install_with_caching
       - run: npm run publish-extension
+
+
+  Publish GitHub Release:
+    docker:
+      - image: circleci/golang:latest
+    steps:
+      - checkout
+      - run:
+          name: "Publish Release on GitHub"
+          command: |
+            ls oclif-dist
+            go get github.com/tcnksm/ghr
+
+
+      # VERSION=$(ls oclif-dist | cut -d 'v' -f2)
+      # ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -delete ${VERSION} ./artifacts/
 
   Test VSCode:
     executor: { name: oss/node }
@@ -189,6 +205,12 @@ workflows:
             - NodeJS 12 Windows
             - Test VSCode
             - Build VSCode
+      - Publish GitHub Release:
+          requires:
+            - Package tarballs
+        # <<: *common_publish_filters
+        # requires:
+        #   - Confirmation
       - oss/dry_run:
           name: Dry-run
           <<: *common_publish_filters

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,9 +96,9 @@ jobs:
             go get github.com/tcnksm/ghr
             VERSION=$(ls oclif-dist | cut -d 'v' -f2)
             echo "Publishing apollo@${VERSION} to GitHub Releases using ghr"
-            echo "ghr -t ${GITHUB_TOKEN} -c ${CIRCLE_SHA1} -delete apollo@${VERSION} ./oclif-dist/apollo-v${VERSION}/"
+            echo "ghr -t ${GH_TOKEN} -c ${CIRCLE_SHA1} -delete apollo@${VERSION} ./oclif-dist/apollo-v${VERSION}/"
             ls ./oclif-dist/apollo-v${VERSION}/
-            ghr -t ${GITHUB_TOKEN} -c ${CIRCLE_SHA1} -delete apollo@${VERSION} "./oclif-dist/apollo-v${VERSION}/"
+            ghr -t ${GH_TOKEN} -c ${CIRCLE_SHA1} -delete apollo@${VERSION} "./oclif-dist/apollo-v${VERSION}/"
 
   Test VSCode:
     executor: { name: oss/node }

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,16 +86,14 @@ jobs:
     steps:
       - attach_workspace:
           # Must be absolute path or relative path from working_directory
-          at: ./oclif-dist
+          at: .
       - run:
           name: "Publish Release on GitHub"
           command: |
             ls ./oclif-dist
             go get github.com/tcnksm/ghr
-
-
-      # VERSION=$(ls oclif-dist | cut -d 'v' -f2)
-      # ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -delete ${VERSION} ./artifacts/
+            VERSION=$(ls oclif-dist | cut -d 'v' -f2)
+            ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -delete ${VERSION} ./oclif-dist/apollo-v${VERSION}/
 
   Test VSCode:
     executor: { name: oss/node }
@@ -207,12 +205,6 @@ workflows:
             - NodeJS 12 Windows
             - Test VSCode
             - Build VSCode
-      - Publish GitHub Release:
-          requires:
-            - Build CLI
-        # <<: *common_publish_filters
-        # requires:
-        #   - Confirmation
       - oss/dry_run:
           name: Dry-run
           <<: *common_publish_filters
@@ -237,3 +229,8 @@ workflows:
           <<: *common_publish_filters
           requires:
             - Confirmation
+      - Publish GitHub Release:
+        requires:
+          - Confirmation
+        <<: *common_publish_filters
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@
 - `vscode-apollo`
   - <First `vscode-apollo` related entry goes here>
 
+## `apollo@2.27.1-alpha.0`
+- `apollo@2.27.1-alpha.0`
+    - Setup automatically creating a GitHub release [#1876](https://github.com/apollographql/apollo-tooling/pull/1876)
+
 ## `apollo@2.27.0`
 
 - `apollo@2.27.0`

--- a/packages/apollo-codegen-core/package.json
+++ b/packages/apollo-codegen-core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "apollo-codegen-core",
   "description": "Core generator APIs for Apollo Codegen",
-  "version": "0.36.7-alpha.0",
+  "version": "0.36.7",
   "author": "Apollo GraphQL <opensource@apollographql.com>",
   "license": "MIT",
   "repository": {

--- a/packages/apollo-codegen-core/package.json
+++ b/packages/apollo-codegen-core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "apollo-codegen-core",
   "description": "Core generator APIs for Apollo Codegen",
-  "version": "0.36.6",
+  "version": "0.36.7-alpha.0",
   "author": "Apollo GraphQL <opensource@apollographql.com>",
   "license": "MIT",
   "repository": {

--- a/packages/apollo-codegen-flow/package.json
+++ b/packages/apollo-codegen-flow/package.json
@@ -1,7 +1,7 @@
 {
   "name": "apollo-codegen-flow",
   "description": "Flow generator module for Apollo Codegen",
-  "version": "0.34.7-alpha.0",
+  "version": "0.34.7",
   "author": "Apollo GraphQL <opensource@apollographql.com>",
   "license": "MIT",
   "repository": {

--- a/packages/apollo-codegen-flow/package.json
+++ b/packages/apollo-codegen-flow/package.json
@@ -1,7 +1,7 @@
 {
   "name": "apollo-codegen-flow",
   "description": "Flow generator module for Apollo Codegen",
-  "version": "0.34.6",
+  "version": "0.34.7-alpha.0",
   "author": "Apollo GraphQL <opensource@apollographql.com>",
   "license": "MIT",
   "repository": {

--- a/packages/apollo-codegen-scala/package.json
+++ b/packages/apollo-codegen-scala/package.json
@@ -1,7 +1,7 @@
 {
   "name": "apollo-codegen-scala",
   "description": "Scala generator module for Apollo Codegen",
-  "version": "0.35.6",
+  "version": "0.35.7-alpha.0",
   "author": "Apollo GraphQL <opensource@apollographql.com>",
   "license": "MIT",
   "repository": {

--- a/packages/apollo-codegen-scala/package.json
+++ b/packages/apollo-codegen-scala/package.json
@@ -1,7 +1,7 @@
 {
   "name": "apollo-codegen-scala",
   "description": "Scala generator module for Apollo Codegen",
-  "version": "0.35.7-alpha.0",
+  "version": "0.35.7",
   "author": "Apollo GraphQL <opensource@apollographql.com>",
   "license": "MIT",
   "repository": {

--- a/packages/apollo-codegen-swift/package.json
+++ b/packages/apollo-codegen-swift/package.json
@@ -1,7 +1,7 @@
 {
   "name": "apollo-codegen-swift",
   "description": "Swift generator module for Apollo Codegen",
-  "version": "0.36.6",
+  "version": "0.36.7-alpha.0",
   "author": "Apollo GraphQL <opensource@apollographql.com>",
   "license": "MIT",
   "repository": {

--- a/packages/apollo-codegen-swift/package.json
+++ b/packages/apollo-codegen-swift/package.json
@@ -1,7 +1,7 @@
 {
   "name": "apollo-codegen-swift",
   "description": "Swift generator module for Apollo Codegen",
-  "version": "0.36.7-alpha.0",
+  "version": "0.36.7",
   "author": "Apollo GraphQL <opensource@apollographql.com>",
   "license": "MIT",
   "repository": {

--- a/packages/apollo-codegen-typescript/package.json
+++ b/packages/apollo-codegen-typescript/package.json
@@ -1,7 +1,7 @@
 {
   "name": "apollo-codegen-typescript",
   "description": "TypeScript generator module for Apollo Codegen",
-  "version": "0.36.7-alpha.0",
+  "version": "0.36.7",
   "author": "Apollo GraphQL <opensource@apollographql.com>",
   "license": "MIT",
   "repository": {

--- a/packages/apollo-codegen-typescript/package.json
+++ b/packages/apollo-codegen-typescript/package.json
@@ -1,7 +1,7 @@
 {
   "name": "apollo-codegen-typescript",
   "description": "TypeScript generator module for Apollo Codegen",
-  "version": "0.36.6",
+  "version": "0.36.7-alpha.0",
   "author": "Apollo GraphQL <opensource@apollographql.com>",
   "license": "MIT",
   "repository": {

--- a/packages/apollo-env/package.json
+++ b/packages/apollo-env/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-env",
-  "version": "0.6.3-alpha.0",
+  "version": "0.6.3",
   "author": "opensource@apollographql.com",
   "license": "MIT",
   "repository": {

--- a/packages/apollo-env/package.json
+++ b/packages/apollo-env/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-env",
-  "version": "0.6.2",
+  "version": "0.6.3-alpha.0",
   "author": "opensource@apollographql.com",
   "license": "MIT",
   "repository": {

--- a/packages/apollo-graphql/package.json
+++ b/packages/apollo-graphql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-graphql",
-  "version": "0.4.1",
+  "version": "0.4.2-alpha.0",
   "description": "Apollo GraphQL utility library",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/apollo-graphql/package.json
+++ b/packages/apollo-graphql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-graphql",
-  "version": "0.4.2-alpha.0",
+  "version": "0.4.2",
   "description": "Apollo GraphQL utility library",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/apollo-language-server/package.json
+++ b/packages/apollo-language-server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "apollo-language-server",
   "description": "A language server for Apollo GraphQL projects",
-  "version": "1.21.2-alpha.0",
+  "version": "1.21.2",
   "author": "Apollo GraphQL <opensource@apollographql.com>",
   "license": "MIT",
   "repository": {

--- a/packages/apollo-language-server/package.json
+++ b/packages/apollo-language-server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "apollo-language-server",
   "description": "A language server for Apollo GraphQL projects",
-  "version": "1.21.1",
+  "version": "1.21.2-alpha.0",
   "author": "Apollo GraphQL <opensource@apollographql.com>",
   "license": "MIT",
   "repository": {

--- a/packages/apollo-language-server/src/graphqlTypes.ts
+++ b/packages/apollo-language-server/src/graphqlTypes.ts
@@ -1722,6 +1722,7 @@ export interface IntrospectionDirectiveInput {
   description?: string | null;
   locations: IntrospectionDirectiveLocation[];
   args: IntrospectionInputValueInput[];
+  isRepeatable?: boolean | null;
 }
 
 /**
@@ -1765,6 +1766,7 @@ export interface IntrospectionSchemaInput {
   mutationType?: IntrospectionTypeRefInput | null;
   subscriptionType?: IntrospectionTypeRefInput | null;
   directives: IntrospectionDirectiveInput[];
+  description?: string | null;
 }
 
 /**

--- a/packages/apollo-tools/package.json
+++ b/packages/apollo-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apollographql/apollo-tools",
-  "version": "0.4.5",
+  "version": "0.4.6-alpha.0",
   "author": "Apollo GraphQL <opensource@apollographql.com>",
   "license": "MIT",
   "repository": {

--- a/packages/apollo-tools/package.json
+++ b/packages/apollo-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apollographql/apollo-tools",
-  "version": "0.4.6-alpha.0",
+  "version": "0.4.6",
   "author": "Apollo GraphQL <opensource@apollographql.com>",
   "license": "MIT",
   "repository": {

--- a/packages/apollo/README.md
+++ b/packages/apollo/README.md
@@ -23,7 +23,7 @@ $ npm install -g apollo
 $ apollo COMMAND
 running command...
 $ apollo (-v|--version|version)
-apollo/2.27.1-alpha.0 linux-x64 node-v12.8.1
+apollo/2.27.1 linux-x64 node-v12.8.1
 $ apollo --help [COMMAND]
 USAGE
   $ apollo COMMAND

--- a/packages/apollo/README.md
+++ b/packages/apollo/README.md
@@ -23,7 +23,7 @@ $ npm install -g apollo
 $ apollo COMMAND
 running command...
 $ apollo (-v|--version|version)
-apollo/2.27.0 darwin-x64 node-v10.15.3
+apollo/2.27.1-alpha.0 linux-x64 node-v12.8.1
 $ apollo --help [COMMAND]
 USAGE
   $ apollo COMMAND

--- a/packages/apollo/package.json
+++ b/packages/apollo/package.json
@@ -1,7 +1,7 @@
 {
   "name": "apollo",
   "description": "Command line tool for Apollo GraphQL",
-  "version": "2.27.0",
+  "version": "2.27.1-alpha.0",
   "referenceID": "21ad0845-c235-422e-be7d-a998310df972",
   "author": "Apollo GraphQL <opensource@apollographql.com>",
   "license": "MIT",

--- a/packages/apollo/package.json
+++ b/packages/apollo/package.json
@@ -1,7 +1,7 @@
 {
   "name": "apollo",
   "description": "Command line tool for Apollo GraphQL",
-  "version": "2.27.1-alpha.0",
+  "version": "2.27.1",
   "referenceID": "21ad0845-c235-422e-be7d-a998310df972",
   "author": "Apollo GraphQL <opensource@apollographql.com>",
   "license": "MIT",

--- a/packages/vscode-apollo/package.json
+++ b/packages/vscode-apollo/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-apollo",
   "displayName": "Apollo GraphQL",
   "description": "Rich editor support for GraphQL client and server development that seamlessly integrates with the Apollo platform",
-  "version": "1.15.2-alpha.0",
+  "version": "1.15.2",
   "referenceID": "87197759-7617-40d0-b32e-46d378e907c7",
   "author": "Apollo GraphQL <opensource@apollographql.com>",
   "license": "MIT",

--- a/packages/vscode-apollo/package.json
+++ b/packages/vscode-apollo/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-apollo",
   "displayName": "Apollo GraphQL",
   "description": "Rich editor support for GraphQL client and server development that seamlessly integrates with the Apollo platform",
-  "version": "1.15.1",
+  "version": "1.15.2-alpha.0",
   "referenceID": "87197759-7617-40d0-b32e-46d378e907c7",
   "author": "Apollo GraphQL <opensource@apollographql.com>",
   "license": "MIT",


### PR DESCRIPTION
With CircleCI dropping artifcats after 30 days soon, we want to move all releases to publish to GitHub releases as a more stable storage spot for downloads of builds. This PR tries out the changes to the shared ci-cd orb to add publishing to GitHub Releases 