### PR TITLE
Fix .env api key taking precedence over localSchemaFile

### DIFF
--- a/packages/apollo-language-server/src/config/loadConfig.ts
+++ b/packages/apollo-language-server/src/config/loadConfig.ts
@@ -189,7 +189,13 @@ export async function loadConfig({
               client: {
                 ...DefaultConfigBase,
                 ...(loadedConfig && loadedConfig.config.client),
-                service: serviceName
+                // if there was a `client.service` defined in the loaded config file,
+                // prefer that over the service name defined by the api key in .env
+                ...(loadedConfig &&
+                loadedConfig.config.client &&
+                loadedConfig.config.client.service
+                  ? { service: loadedConfig.config.client.service }
+                  : { service: serviceName })
               }
             }
           : {

--- a/packages/apollo/src/Command.ts
+++ b/packages/apollo/src/Command.ts
@@ -208,7 +208,7 @@ export abstract class ProjectCommand extends Command {
       (config.engine.apiKey && config.engine.apiKey.split(":")) || [];
     if (tokenType == "service" && identifier !== config.graph) {
       throw new Error(
-        `Cannot specify a service token that does not match graph. Graph ${config.graph} does not match graph from token (${identifier})`
+        `Cannot specify a service api key that does not match graph id. Graph id found in config (${config.graph}) does not match graph from api key (${identifier}).`
       );
     }
 

--- a/packages/apollo/src/commands/service/__tests__/check.test.ts
+++ b/packages/apollo/src/commands/service/__tests__/check.test.ts
@@ -533,7 +533,7 @@ describe("service:check", () => {
               `--graph=happy-fun-times`
             ])
           ).rejects.toThrow(
-            /Cannot specify a service token that does not match graph./
+            /Cannot specify a service api key that does not match graph id..*/
           );
         });
 


### PR DESCRIPTION
Previously, if a client project was using a `localSchemaFile` to write operations against but _also_ had a `.env` file with an `APOLLO_KEY` defined, the language server would try to load the schema from apollo graph manager, without regard to the local schema file.

The reason this was happening was in `loadConfig`, the service override at the end where the final config gets built was overwriting the existing `client.service` if there was a `serviceName`. This change should check for a `client.service` to prevent that accidental overwrite.

TODO:

- [ ] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [ ] Make sure all of the significant new logic is covered by tests
- [ ] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests and linter rules pass

\*Make sure changelog entries note which project(s) has been affected. See older entries for examples on what this looks like.
