### PR TITLE
Ignore non-file documents when checking operation duplicates

### DIFF
--- a/packages/apollo-language-server/src/project/base.ts
+++ b/packages/apollo-language-server/src/project/base.ts
@@ -208,6 +208,8 @@ export abstract class GraphQLProject implements GraphQLSchemaProvider {
   }
 
   documentDidChange(document: TextDocument) {
+    if (!document.uri.startsWith("file://")) return;
+
     const documents = extractGraphQLDocuments(
       document,
       this.config.client && this.config.client.tagName


### PR DESCRIPTION
I'm using the Apollo GraphQL extension for VS Code and I regularly run into `️️There are multiple definitions for the '...' operation.` errors when viewing Git diffs in the side bar.

That's because whenever a new editor is opened [`GraphQLProject#documentDidChange`](https://github.com/shroudedcode/apollo-tooling/blob/cffba044d2fd5057ad6a762fbfc917d09e1e68fa/packages/apollo-language-server/src/project/base.ts#L210) is called with the editor's `TextDocument` object. The document's URI and contents are then stored and later used for checking whether there are duplicate operations in the project. This happens regardless of whether the document is an actual file (URI starting with `file://`) or something else like a Git diff (URI starting with `git:`).

This PR adds a check to ensure only actual files are scanned for duplicate operation names.