### PR TITLE
Fix silent codegen errors on syntax errors

### DIFF
--- a/packages/apollo-language-server/src/document.ts
+++ b/packages/apollo-language-server/src/document.ts
@@ -32,6 +32,7 @@ export class GraphQLDocument {
         source,
         rangeOfTokenAtLocation(error.locations[0], source.body)
       );
+      console.log(error.message, source.name);
       this.syntaxErrors.push({
         severity: DiagnosticSeverity.Error,
         message: error.message,

--- a/packages/apollo-language-server/src/document.ts
+++ b/packages/apollo-language-server/src/document.ts
@@ -32,7 +32,6 @@ export class GraphQLDocument {
         source,
         rangeOfTokenAtLocation(error.locations[0], source.body)
       );
-      console.log(error.message, source.name);
       this.syntaxErrors.push({
         severity: DiagnosticSeverity.Error,
         message: error.message,

--- a/packages/apollo-language-server/src/graphqlTypes.ts
+++ b/packages/apollo-language-server/src/graphqlTypes.ts
@@ -1722,6 +1722,7 @@ export interface IntrospectionDirectiveInput {
   description?: string | null;
   locations: IntrospectionDirectiveLocation[];
   args: IntrospectionInputValueInput[];
+  isRepeatable?: boolean | null;
 }
 
 /**
@@ -1765,6 +1766,7 @@ export interface IntrospectionSchemaInput {
   mutationType?: IntrospectionTypeRefInput | null;
   subscriptionType?: IntrospectionTypeRefInput | null;
   directives: IntrospectionDirectiveInput[];
+  description?: string | null;
 }
 
 /**

--- a/packages/apollo/src/commands/client/codegen.ts
+++ b/packages/apollo/src/commands/client/codegen.ts
@@ -190,15 +190,15 @@ export default class Generate extends ClientCommand {
                 // to prevent silent erroring of syntax errors, we check the project's
                 // documents to make sure there are no errors. If there are, we error here
                 // instead of project initialization
-                // for (const document of this.project.documents) {
-                //   if (document.syntaxErrors) {
-                //     const errors = document.syntaxErrors.map(
-                //       e =>
-                //         `Syntax error in ${document.source.name}: ${e.message}\n`
-                //     );
-                //     throw new Error(errors.toString());
-                //   }
-                // }
+                for (const document of this.project.documents) {
+                  if (document.syntaxErrors) {
+                    const errors = document.syntaxErrors.map(
+                      e =>
+                        `Syntax error in ${document.source.name}: ${e.message}\n`
+                    );
+                    throw new Error(errors.toString());
+                  }
+                }
 
                 const operations = Object.values(this.project.operations);
                 const fragments = Object.values(this.project.fragments);

--- a/packages/apollo/src/commands/client/codegen.ts
+++ b/packages/apollo/src/commands/client/codegen.ts
@@ -191,7 +191,7 @@ export default class Generate extends ClientCommand {
                 // documents to make sure there are no errors. If there are, we error here
                 // instead of project initialization
                 for (const document of this.project.documents) {
-                  if (document.syntaxErrors) {
+                  if (document.syntaxErrors.length) {
                     const errors = document.syntaxErrors.map(
                       e =>
                         `Syntax error in ${document.source.name}: ${e.message}\n`

--- a/packages/apollo/src/commands/client/codegen.ts
+++ b/packages/apollo/src/commands/client/codegen.ts
@@ -190,15 +190,15 @@ export default class Generate extends ClientCommand {
                 // to prevent silent erroring of syntax errors, we check the project's
                 // documents to make sure there are no errors. If there are, we error here
                 // instead of project initialization
-                for (const document of this.project.documents) {
-                  if (document.syntaxErrors) {
-                    const errors = document.syntaxErrors.map(
-                      e =>
-                        `Syntax error in ${document.source.name}: ${e.message}\n`
-                    );
-                    throw new Error(errors.toString());
-                  }
-                }
+                // for (const document of this.project.documents) {
+                //   if (document.syntaxErrors) {
+                //     const errors = document.syntaxErrors.map(
+                //       e =>
+                //         `Syntax error in ${document.source.name}: ${e.message}\n`
+                //     );
+                //     throw new Error(errors.toString());
+                //   }
+                // }
 
                 const operations = Object.values(this.project.operations);
                 const fragments = Object.values(this.project.fragments);

--- a/packages/apollo/src/commands/client/codegen.ts
+++ b/packages/apollo/src/commands/client/codegen.ts
@@ -187,6 +187,19 @@ export default class Generate extends ClientCommand {
                 // are valid documents
                 project.validate();
 
+                // to prevent silent erroring of syntax errors, we check the project's
+                // documents to make sure there are no errors. If there are, we error here
+                // instead of project initialization
+                for (const document of this.project.documents) {
+                  if (document.syntaxErrors) {
+                    const errors = document.syntaxErrors.map(
+                      e =>
+                        `Syntax error in ${document.source.name}: ${e.message}\n`
+                    );
+                    throw new Error(errors.toString());
+                  }
+                }
+
                 const operations = Object.values(this.project.operations);
                 const fragments = Object.values(this.project.fragments);
 


### PR DESCRIPTION
resolves #1897 

During document parsing, syntax errors are silently
added to the document, but errors are never thrown.

This PR checks at the _command-level_ for these errors
and if they exist, prints them to the user.

I didn't want to change at the document setup level, because
I have a feeling the silent erroring was intention for the sake
of the operation registry or something. So I added in an error
where it was immediately causing an issue, in the client
codegen command.

<!--
  Thanks for filing a pull request on Apollo Tooling!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [ ] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [ ] Make sure all of the significant new logic is covered by tests
- [ ] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests and linter rules pass

\*Make sure changelog entries note which project(s) has been affected. See older entries for examples on what this looks like.
