### PR TITLE
Replace deprecated use of `getErrors` with `onError`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
   - <First `apollo-graphql` related entry goes here>
 - `apollo-language-server`
   - Fix definition navigation for vscode using localSchemaFile [#1996](https://github.com/apollographql/apollo-tooling/pull/1996)
+  - Replace deprecated use of `getErrors` with `onError` [#1908](https://github.com/apollographql/apollo-tooling/pull/1908)
 - `apollo-tools`
   - <First `apollo-tools` related entry goes here>
 - `vscode-apollo`

--- a/packages/apollo-language-server/src/errors/validation.ts
+++ b/packages/apollo-language-server/src/errors/validation.ts
@@ -51,7 +51,12 @@ export function getValidationErrors(
   rules: ValidationRule[] = defaultValidationRules
 ) {
   const typeInfo = new TypeInfo(schema);
-  const context = new ValidationContext(schema, document, typeInfo);
+
+  const errors: GraphQLError[] = [];
+
+  const context = new ValidationContext(schema, document, typeInfo, error =>
+    errors.push(error)
+  );
 
   if (fragments) {
     (context as any)._fragments = fragments;
@@ -60,7 +65,7 @@ export function getValidationErrors(
   const visitors = rules.map(rule => rule(context));
   // Visit the whole document with each instance of all provided rules.
   visit(document, visitWithTypeInfo(typeInfo, visitInParallel(visitors)));
-  return context.getErrors();
+  return errors;
 }
 
 export function validateQueryDocument(

--- a/packages/apollo-language-server/src/errors/validation.ts
+++ b/packages/apollo-language-server/src/errors/validation.ts
@@ -71,8 +71,9 @@ export function getValidationErrors(
 
   // In `graphql@15.0.0`, `context.getErrors` was removed.
   // If this function is available, then we prefer to use it, as the user
-  // may be on a version of `graphql` that is pre-14.5.0 (and therefore `errors`)
+  // may be on a version of `graphql` that is pre-14.5.0, and therefore `errors`
   // will be empty as it's never called above.
+  // This can be removed in a major release if pre-14.5.0 support is dropped.
   if (typeof context.getErrors === "function") {
     return context.getErrors();
   }

--- a/packages/apollo-language-server/src/errors/validation.ts
+++ b/packages/apollo-language-server/src/errors/validation.ts
@@ -54,6 +54,9 @@ export function getValidationErrors(
 
   const errors: GraphQLError[] = [];
 
+  // The fourth `onError` parameter in the constructor of `ValidationContext`
+  // was introduced in `graphql@14.5.0`. It is safe to use this in pre-14.5.0
+  // versions too, as there was no fourth parameter in any earlier version.
   const context = new ValidationContext(schema, document, typeInfo, error =>
     errors.push(error)
   );
@@ -65,6 +68,14 @@ export function getValidationErrors(
   const visitors = rules.map(rule => rule(context));
   // Visit the whole document with each instance of all provided rules.
   visit(document, visitWithTypeInfo(typeInfo, visitInParallel(visitors)));
+
+  // In `graphql@15.0.0`, `context.getErrors` was removed.
+  // If this function is available, then we prefer to use it, as the user
+  // may be on a version of `graphql` that is pre-14.5.0 (and therefore `errors`)
+  // will be empty as it's never called above.
+  if (typeof context.getErrors === "function") {
+    return context.getErrors();
+  }
   return errors;
 }
 


### PR DESCRIPTION
`graphql@15.0.0` has a breaking change removing the deprecated `getErrors` method (see https://github.com/graphql/graphql-js/pull/2130). This PR replaces it with the supported `onError` method specified in the constructor.

**TODO:**

- [x] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass

\*Make sure changelog entries note which project(s) has been affected. See older entries for examples on what this looks like.
