### PR TITLE
Change json-modern target to use legacy IR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Upcoming
 
 - `apollo`
-  - Change json-modern target to use legacy IR as base, similar to json target []().
+  - Change json-modern target to use legacy IR as base, similar to json target [#1916](https://github.com/apollographql/apollo-tooling/pull/1916).
 - `apollo-codegen-flow`
   - <First `apollo-codegen-flow` related entry goes here>
 - `apollo-codegen-scala`
@@ -13,7 +13,7 @@
 - `apollo-codegen-typescript`
   - <First `apollo-codegen-typescript` related entry goes here>
 - `apollo-codegen-core`
-  - Change json-modern target to use legacy IR as base, similar to json target []().
+  - Change json-modern target to use legacy IR as base, similar to json target [#1916](https://github.com/apollographql/apollo-tooling/pull/1916).
 - `apollo-env`
   - <First `apollo-env` related entry goes here>
 - `apollo-graphql`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Upcoming
 
 - `apollo`
-  - <First `apollo` related entry goes here>
+  - Change json-modern target to use legacy IR as base, similar to json target []().
 - `apollo-codegen-flow`
   - <First `apollo-codegen-flow` related entry goes here>
 - `apollo-codegen-scala`
@@ -13,7 +13,7 @@
 - `apollo-codegen-typescript`
   - <First `apollo-codegen-typescript` related entry goes here>
 - `apollo-codegen-core`
-  - <First `apollo-codegen-core` related entry goes here>
+  - Change json-modern target to use legacy IR as base, similar to json target []().
 - `apollo-env`
   - <First `apollo-env` related entry goes here>
 - `apollo-graphql`
@@ -26,8 +26,9 @@
   - <First `vscode-apollo` related entry goes here>
 
 ## `apollo@2.27.2`
+
 - `apollo@2.27.2`
-    - Setup automatically creating a GitHub release [#1876](https://github.com/apollographql/apollo-tooling/pull/1876)
+  - Setup automatically creating a GitHub release [#1876](https://github.com/apollographql/apollo-tooling/pull/1876)
 
 ## `apollo@2.27.0`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - `apollo`
   - Change json-modern target to use legacy IR as base, similar to json target [#1916](https://github.com/apollographql/apollo-tooling/pull/1916).
+  - Update json-modern IR to expose `typeNode`s on `typesUsed` [#1916](https://github.com/apollographql/apollo-tooling/pull/1916)
 - `apollo-codegen-flow`
   - <First `apollo-codegen-flow` related entry goes here>
 - `apollo-codegen-scala`
@@ -14,6 +15,7 @@
   - <First `apollo-codegen-typescript` related entry goes here>
 - `apollo-codegen-core`
   - Change json-modern target to use legacy IR as base, similar to json target [#1916](https://github.com/apollographql/apollo-tooling/pull/1916).
+  - Update json-modern IR to expose `typeNode`s on `typesUsed` [#1916](https://github.com/apollographql/apollo-tooling/pull/1916)
 - `apollo-env`
   - <First `apollo-env` related entry goes here>
 - `apollo-graphql`

--- a/package-lock.json
+++ b/package-lock.json
@@ -4659,7 +4659,7 @@
         "lodash.debounce": "^4.0.8",
         "lodash.merge": "^4.6.1",
         "minimatch": "^3.0.4",
-        "moment": "^2.24.0",
+        "moment": "2.24.0",
         "vscode-languageserver": "^5.1.0",
         "vscode-uri": "1.0.6"
       }

--- a/packages/apollo-codegen-core/src/compiler/legacyIR.ts
+++ b/packages/apollo-codegen-core/src/compiler/legacyIR.ts
@@ -4,7 +4,8 @@ import {
   GraphQLObjectType,
   GraphQLCompositeType,
   GraphQLInputType,
-  DocumentNode
+  DocumentNode,
+  TypeNode
 } from "graphql";
 
 import {
@@ -29,7 +30,7 @@ export interface CompilerOptions {
   customScalarsPrefix?: string;
   namespace?: string;
   generateOperationIds?: boolean;
-  exposeRawTypes?: boolean;
+  exposeTypeNodes?: boolean;
 }
 
 export interface LegacyCompilerContext {
@@ -81,6 +82,7 @@ export interface LegacyField {
   fieldName: string;
   args?: Argument[];
   type: GraphQLType;
+  typeNode?: TypeNode;
   description?: string;
   isConditional?: boolean;
   conditions?: BooleanCondition[];
@@ -107,7 +109,7 @@ export function compileToLegacyIR(
   document: DocumentNode,
   options: CompilerOptions = {
     mergeInFieldsFromFragmentSpreads: true,
-    exposeRawTypes: false
+    exposeTypeNodes: false
   }
 ): LegacyCompilerContext {
   const context = compileToIR(schema, document, options);
@@ -252,6 +254,7 @@ class LegacyIRTransformer {
       const {
         args,
         type,
+        typeNode,
         isConditional,
         description,
         isDeprecated,
@@ -272,6 +275,7 @@ class LegacyIRTransformer {
         responseName: field.alias || field.name,
         fieldName: field.name,
         type,
+        typeNode,
         args,
         isConditional,
         conditions,

--- a/packages/apollo-codegen-core/src/serializeToJSON.ts
+++ b/packages/apollo-codegen-core/src/serializeToJSON.ts
@@ -6,20 +6,32 @@ import {
   GraphQLInputObjectType,
   isEnumType,
   isInputObjectType,
-  isScalarType
+  isScalarType,
+  parseType
 } from "graphql";
 
 import { LegacyCompilerContext } from "./compiler/legacyIR";
-import { CompilerContext } from "./compiler";
+import { CompilerContext, stripProp } from "./compiler";
+
+/**
+ * These options are passed from the generate function, which
+ * This option needs to be passed to the input object serializer
+ * to print the `typeNode` key. We do this here instead of in the
+ * compiler, since  modifying the types there get really hacky and unpleasant
+ */
+interface serializeOptions {
+  exposeTypeNodes: boolean;
+}
 
 export default function serializeToJSON(
-  context: LegacyCompilerContext | CompilerContext
+  context: LegacyCompilerContext | CompilerContext,
+  options: serializeOptions
 ) {
   return serializeAST(
     {
       operations: Object.values(context.operations),
       fragments: Object.values(context.fragments),
-      typesUsed: context.typesUsed.map(serializeType)
+      typesUsed: context.typesUsed.map(type => serializeType(type, options))
     },
     "\t"
   );
@@ -39,11 +51,11 @@ export function serializeAST(ast: any, space?: string) {
   );
 }
 
-function serializeType(type: GraphQLType) {
+function serializeType(type: GraphQLType, options: serializeOptions) {
   if (isEnumType(type)) {
     return serializeEnumType(type);
   } else if (isInputObjectType(type)) {
-    return serializeInputObjectType(type);
+    return serializeInputObjectType(type, options);
   } else if (isScalarType(type)) {
     return serializeScalarType(type);
   } else {
@@ -68,7 +80,10 @@ function serializeEnumType(type: GraphQLEnumType) {
   };
 }
 
-function serializeInputObjectType(type: GraphQLInputObjectType) {
+function serializeInputObjectType(
+  type: GraphQLInputObjectType,
+  options: serializeOptions
+) {
   const { name, description } = type;
   const fields = Object.values(type.getFields());
 
@@ -79,10 +94,13 @@ function serializeInputObjectType(type: GraphQLInputObjectType) {
     fields: fields.map(field => ({
       name: field.name,
       type: String(field.type),
+      typeNode: options.exposeTypeNodes
+        ? stripProp("loc", parseType(field.type.toString()))
+        : undefined,
       description: field.description,
       defaultValue: field.defaultValue
     }))
-  };
+  } as any;
 }
 
 function serializeScalarType(type: GraphQLScalarType) {

--- a/packages/apollo-codegen-core/src/serializeToJSON.ts
+++ b/packages/apollo-codegen-core/src/serializeToJSON.ts
@@ -82,7 +82,7 @@ function serializeEnumType(type: GraphQLEnumType) {
 
 function serializeInputObjectType(
   type: GraphQLInputObjectType,
-  options: serializeOptions
+  options?: serializeOptions
 ) {
   const { name, description } = type;
   const fields = Object.values(type.getFields());
@@ -94,9 +94,10 @@ function serializeInputObjectType(
     fields: fields.map(field => ({
       name: field.name,
       type: String(field.type),
-      typeNode: options.exposeTypeNodes
-        ? stripProp("loc", parseType(field.type.toString()))
-        : undefined,
+      typeNode:
+        options && options.exposeTypeNodes
+          ? stripProp("loc", parseType(field.type.toString()))
+          : undefined,
       description: field.description,
       defaultValue: field.defaultValue
     }))

--- a/packages/apollo-language-server/package.json
+++ b/packages/apollo-language-server/package.json
@@ -39,7 +39,7 @@
     "lodash.debounce": "^4.0.8",
     "lodash.merge": "^4.6.1",
     "minimatch": "^3.0.4",
-    "moment": "^2.24.0",
+    "moment": "2.24.0",
     "vscode-languageserver": "^5.1.0",
     "vscode-uri": "1.0.6"
   },

--- a/packages/apollo/src/commands/client/__tests__/__snapshots__/generate.test.ts.snap
+++ b/packages/apollo/src/commands/client/__tests__/__snapshots__/generate.test.ts.snap
@@ -133,38 +133,40 @@ Object {
   "fragments": Array [],
   "operations": Array [
     Object {
-      "filePath": "",
-      "operationName": "SimpleQuery",
-      "operationType": "query",
-      "rootType": "Query",
-      "selectionSet": Object {
-        "possibleTypes": Array [
-          "Query",
-        ],
-        "selections": Array [
-          Object {
-            "isDeprecated": false,
-            "kind": "Field",
-            "name": "hello",
-            "responseKey": "hello",
-            "type": "String!",
-            "typeNode": Object {
-              "kind": "NonNullType",
-              "type": Object {
-                "kind": "NamedType",
-                "name": Object {
-                  "kind": "Name",
-                  "value": "String",
-                },
+      "fields": Array [
+        Object {
+          "fieldName": "hello",
+          "isConditional": false,
+          "isDeprecated": false,
+          "responseName": "hello",
+          "type": "String!",
+          "typeNode": Object {
+            "kind": "NonNullType",
+            "type": Object {
+              "kind": "NamedType",
+              "name": Object {
+                "kind": "Name",
+                "value": "String",
               },
             },
           },
-        ],
-      },
-      "source": "query SimpleQuery {
+        },
+      ],
+      "filePath": "",
+      "fragmentSpreads": Array [],
+      "fragmentsReferenced": Array [],
+      "inlineFragments": Array [],
+      "operationId": "4de1e386589b0853a102a87a3f21ca25266116517e59c1e8be9442e2571f00bc",
+          "operationName": "SimpleQuery",
+          "operationType": "query",
+          "rootType": "Query",
+          "source": "query SimpleQuery {
   hello
 }",
-      "variables": Array [],
+       "sourceWithFragments": "query SimpleQuery {
+  hello
+}",
+            "variables": Array [],
     },
   ],
   "typesUsed": Array [],

--- a/packages/apollo/src/commands/client/__tests__/__snapshots__/generate.test.ts.snap
+++ b/packages/apollo/src/commands/client/__tests__/__snapshots__/generate.test.ts.snap
@@ -157,16 +157,16 @@ Object {
       "fragmentsReferenced": Array [],
       "inlineFragments": Array [],
       "operationId": "4de1e386589b0853a102a87a3f21ca25266116517e59c1e8be9442e2571f00bc",
-          "operationName": "SimpleQuery",
-          "operationType": "query",
-          "rootType": "Query",
-          "source": "query SimpleQuery {
+      "operationName": "SimpleQuery",
+      "operationType": "query",
+      "rootType": "Query",
+      "source": "query SimpleQuery {
   hello
 }",
-       "sourceWithFragments": "query SimpleQuery {
+      "sourceWithFragments": "query SimpleQuery {
   hello
 }",
-            "variables": Array [],
+      "variables": Array [],
     },
   ],
   "typesUsed": Array [],

--- a/packages/apollo/src/generate.ts
+++ b/packages/apollo/src/generate.ts
@@ -210,15 +210,12 @@ export default function generate(
     }
   } else {
     let output;
-    const context = compileToLegacyIR(schema, document, options);
+    const context = compileToLegacyIR(schema, document, {
+      ...options,
+      exposeTypeNodes: target === "json-modern"
+    });
     switch (target) {
       case "json-modern":
-        const ir = compileToLegacyIR(schema, document, {
-          ...options,
-          exposeTypeNodes: true
-        });
-        output = serializeToJSON(ir);
-        break;
       case "json":
         output = serializeToJSON(context);
         break;

--- a/packages/apollo/src/generate.ts
+++ b/packages/apollo/src/generate.ts
@@ -213,8 +213,10 @@ export default function generate(
     const context = compileToLegacyIR(schema, document, options);
     switch (target) {
       case "json-modern":
-        const ir = compileToIR(schema, document, options);
-        // console.log(JSON.stringify(ir));
+        const ir = compileToLegacyIR(schema, document, {
+          ...options,
+          exposeTypeNodes: true
+        });
         output = serializeToJSON(ir);
         break;
       case "json":

--- a/packages/apollo/src/generate.ts
+++ b/packages/apollo/src/generate.ts
@@ -217,7 +217,9 @@ export default function generate(
     switch (target) {
       case "json-modern":
       case "json":
-        output = serializeToJSON(context);
+        output = serializeToJSON(context, {
+          exposeTypeNodes: Boolean(options.exposeTypeNodes)
+        });
         break;
       case "scala":
         output = generateScalaSource(context);


### PR DESCRIPTION
Hopefully resolves #1909 

The legacy IR contains information that codegen in swift needs to
work properly. When building the json-modern target, I didn't
account for everything that was dropped from the original json
output :sad:. This commit changes the json-modern codegen target
so it uses the legacy IR generation with the exposeTypeNodes option
set to true (which passes it to the new ir codegen since legacy
uses that under the hood lol).

<!--
  Thanks for filing a pull request on Apollo Tooling!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [x] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass

\*Make sure changelog entries note which project(s) has been affected. See older entries for examples on what this looks like.
