### PR TITLE
Add file system watching to FileSet using chokidar

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4603,6 +4603,7 @@
         "apollo-link-http": "^1.5.5",
         "apollo-server-errors": "^2.0.2",
         "await-to-js": "^2.0.1",
+        "chokidar": "^3.4.0",
         "core-js": "^3.0.1",
         "cosmiconfig": "^5.0.6",
         "dotenv": "^8.0.0",
@@ -5326,6 +5327,11 @@
         "is-windows": "^1.0.0"
       }
     },
+    "binary-extensions": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.0.0.tgz",
+      "integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow=="
+    },
     "bl": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-3.0.0.tgz",
@@ -5731,6 +5737,66 @@
           "dev": true,
           "requires": {
             "@types/node": "*"
+          }
+        }
+      }
+    },
+    "chokidar": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.0.tgz",
+      "integrity": "sha512-aXAaho2VJtisB/1fg1+3nlLJqGOuewTzQpd/Tz0yTg2R0e4IGtshYvtjowyEumcBv2z+y4+kc75Mz7j5xJskcQ==",
+      "requires": {
+        "anymatch": "~3.1.1",
+        "braces": "~3.0.2",
+        "fsevents": "~2.1.2",
+        "glob-parent": "~5.1.0",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.4.0"
+      },
+      "dependencies": {
+        "anymatch": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
+          "integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
+          "requires": {
+            "normalize-path": "^3.0.0",
+            "picomatch": "^2.0.4"
+          }
+        },
+        "braces": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+          "requires": {
+            "fill-range": "^7.0.1"
+          }
+        },
+        "fill-range": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+          "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+          "requires": {
+            "to-regex-range": "^5.0.1"
+          }
+        },
+        "is-number": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
+        },
+        "normalize-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+          "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
+        },
+        "to-regex-range": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+          "requires": {
+            "is-number": "^7.0.0"
           }
         }
       }
@@ -7928,7 +7994,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.2.tgz",
       "integrity": "sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA==",
-      "dev": true,
       "optional": true
     },
     "function-bind": {
@@ -8566,7 +8631,6 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.0.tgz",
       "integrity": "sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==",
-      "dev": true,
       "requires": {
         "is-glob": "^4.0.1"
       }
@@ -9282,6 +9346,14 @@
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
     },
+    "is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "requires": {
+        "binary-extensions": "^2.0.0"
+      }
+    },
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
@@ -9360,8 +9432,7 @@
     "is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-      "dev": true
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
     },
     "is-finite": {
       "version": "1.0.2",
@@ -9387,7 +9458,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
       "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
-      "dev": true,
       "requires": {
         "is-extglob": "^2.1.1"
       }
@@ -15527,8 +15597,7 @@
     "picomatch": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.0.7.tgz",
-      "integrity": "sha512-oLHIdio3tZ0qH76NybpeneBhYVj0QFTfXEFTc/B3zKQspYfYYkWYgFsmzo+4kvId/bQRcNkVeguI3y+CD22BtA==",
-      "dev": true
+      "integrity": "sha512-oLHIdio3tZ0qH76NybpeneBhYVj0QFTfXEFTc/B3zKQspYfYYkWYgFsmzo+4kvId/bQRcNkVeguI3y+CD22BtA=="
     },
     "pify": {
       "version": "4.0.1",
@@ -16410,6 +16479,21 @@
         "dezalgo": "^1.0.0",
         "graceful-fs": "^4.1.2",
         "once": "^1.3.0"
+      }
+    },
+    "readdirp": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.4.0.tgz",
+      "integrity": "sha512-0xe001vZBnJEK+uKcj8qOhyAKPzIT+gStxWr3LCB0DwcXR5NZJ3IaC+yGnHCYzB/S7ov3m3EEbZI2zeNvX+hGQ==",
+      "requires": {
+        "picomatch": "^2.2.1"
+      },
+      "dependencies": {
+        "picomatch": {
+          "version": "2.2.2",
+          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
+          "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg=="
+        }
       }
     },
     "realpath-native": {

--- a/packages/apollo-language-server/package.json
+++ b/packages/apollo-language-server/package.json
@@ -30,6 +30,7 @@
     "apollo-link-http": "^1.5.5",
     "apollo-server-errors": "^2.0.2",
     "await-to-js": "^2.0.1",
+    "chokidar": "^3.4.0",
     "core-js": "^3.0.1",
     "cosmiconfig": "^5.0.6",
     "dotenv": "^8.0.0",

--- a/packages/apollo-language-server/src/fileSet.ts
+++ b/packages/apollo-language-server/src/fileSet.ts
@@ -1,14 +1,17 @@
-import { relative } from "path";
-import minimatch = require("minimatch");
 import glob from "glob";
 import { invariant } from "@apollographql/apollo-tools";
 import URI from "vscode-uri";
 import { normalizeURI } from "./utilities";
+import chokidar from "chokidar";
+import path from "path";
 
 export class FileSet {
   private rootURI: URI;
   private includes: string[];
   private excludes: string[];
+  private files: string[] = [];
+  private watcher: chokidar.FSWatcher;
+  private ready: boolean = false;
 
   constructor({
     rootURI,
@@ -28,6 +31,25 @@ export class FileSet {
     this.rootURI = rootURI;
     this.includes = includes;
     this.excludes = excludes;
+
+    this.watcher = chokidar.watch(includes, {
+      cwd: rootURI.fsPath,
+      ignored: excludes,
+      ignoreInitial: true
+    });
+
+    const absRoot = path.resolve(rootURI.fsPath);
+    function getFullPath(p: string) {
+      return normalizeURI(path.join(absRoot, p));
+    }
+
+    this.watcher.on("add", p => this.files.push(getFullPath(p)));
+    this.watcher.on("unlink", p => {
+      const index = this.files.indexOf(getFullPath(p));
+      if (index > -1) {
+        this.files.splice(index, 1);
+      }
+    });
   }
 
   includesFile(filePath: string): boolean {
@@ -35,11 +57,20 @@ export class FileSet {
   }
 
   allFiles(): string[] {
+    if (!this.ready) {
+      this.globInitial();
+      this.ready = true;
+    }
+
+    return this.files;
+  }
+
+  private globInitial() {
     // since glob.sync takes a single pattern, but we allow an array of `includes`, we can join all the
     // `includes` globs into a single pattern and pass to glob.sync. The `ignore` option does, however, allow
     // an array of globs to ignore, so we can pass it in directly
     const joinedIncludes = `{${this.includes.join(",")}}`;
-    return glob
+    this.files = glob
       .sync(joinedIncludes, {
         cwd: this.rootURI.fsPath,
         absolute: true,

--- a/packages/apollo-language-server/src/fileSet.ts
+++ b/packages/apollo-language-server/src/fileSet.ts
@@ -65,6 +65,10 @@ export class FileSet {
     return this.files;
   }
 
+  close() {
+    this.watcher.close();
+  }
+
   private globInitial() {
     // since glob.sync takes a single pattern, but we allow an array of `includes`, we can join all the
     // `includes` globs into a single pattern and pass to glob.sync. The `ignore` option does, however, allow

--- a/packages/apollo-language-server/src/project/base.ts
+++ b/packages/apollo-language-server/src/project/base.ts
@@ -269,6 +269,10 @@ export abstract class GraphQLProject implements GraphQLSchemaProvider {
 
   abstract validate(): void;
 
+  close() {
+    this.fileSet.close();
+  }
+
   clearAllDiagnostics() {
     if (!this._onDiagnostics) return;
 

--- a/packages/apollo-language-server/src/workspace.ts
+++ b/packages/apollo-language-server/src/workspace.ts
@@ -164,6 +164,7 @@ export class GraphQLWorkspace {
       this.projectsByFolderUri.set(
         uri,
         projects.map(project => {
+          project.close();
           project.clearAllDiagnostics();
           return this.createProject({
             config: project.config,


### PR DESCRIPTION
As pointed out in the discussion on #1061 the performance issues appear to be due to file globbing occurring over and over again.

This changes it to using chokidar to watch for changes, and only perform the glob once, the first time `FileSet.allFiles()` is called.

Fixes #1061

