### PR TITLE
Fix CLI and VSCode from crashing when discovering a path named like a file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Upcoming
 
 - `apollo`
-  - <First `apollo` related entry goes here>
+  - Fix CLI crashing when trying to open a directory that is named like a file [#1948](https://github.com/apollographql/apollo-tooling/pull/1948).
 - `apollo-codegen-flow`
   - <First `apollo-codegen-flow` related entry goes here>
 - `apollo-codegen-scala`

--- a/packages/apollo-language-server/src/project/base.ts
+++ b/packages/apollo-language-server/src/project/base.ts
@@ -1,5 +1,5 @@
 import { extname } from "path";
-import { readFileSync } from "fs";
+import { lstatSync, readFileSync } from "fs";
 import URI from "vscode-uri";
 
 import {
@@ -196,6 +196,10 @@ export abstract class GraphQLProject implements GraphQLSchemaProvider {
 
     // Don't process files of an unsupported filetype
     if (!languageId) return;
+
+    // Don't process directories. Directories might be named like files so
+    // we have to explicitly check.
+    if (!lstatSync(filePath).isFile()) return;
 
     const contents = readFileSync(filePath, "utf8");
     const document = TextDocument.create(uri, languageId, -1, contents);


### PR DESCRIPTION
If there is a directory named like a file, meaning the path ends in something like `.ts`, then the glob in an apollo config could pick up directories. We need to make sure we are trying to open a file before we run `readFileSync` or having this weirdly named path will cause the CLI and VSCode Extension to crash.

FWIW We're seeing this in AGM right now because [Cypress](https://www.cypress.io/) creates screenshots for tests with the test filename as the directory name in the screenshots directory.

<!--
  Thanks for filing a pull request on Apollo Tooling!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [x] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass

\*Make sure changelog entries note which project(s) has been affected. See older entries for examples on what this looks like.
