### PR TITLE
Swift: Make selections a var instead of a let

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - `apollo-codegen-scala`
   - <First `apollo-codegen-scala` related entry goes here>
 - `apollo-codegen-swift`
-  - <First `apollo-codegen-swift` related entry goes here>
+  - Change selection sets to computed vars to remove unnecessary  memory use [#1950](https://github.com/apollographql/apollo-tooling/pull/1950)
 - `apollo-codegen-typescript`
   - <First `apollo-codegen-typescript` related entry goes here>
 - `apollo-codegen-core`

--- a/packages/apollo-codegen-swift/src/__tests__/__snapshots__/codeGeneration.ts.snap
+++ b/packages/apollo-codegen-swift/src/__tests__/__snapshots__/codeGeneration.ts.snap
@@ -32,9 +32,11 @@ exports[`Swift code generation #classDeclarationForOperation() should correctly 
   public struct Data: GraphQLSelectionSet {
     public static let possibleTypes: [String] = [\\"Mutation\\"]
 
-    public private(set) static var selections: [GraphQLSelection] = [
-      GraphQLField(\\"createReview\\", arguments: [\\"episode\\": GraphQLVariable(\\"episode\\"), \\"review\\": [\\"stars\\": 5, \\"commentary\\": \\"Wow!\\\\n I thought\\\\n  This movie ROCKED!\\"]], type: .object(CreateReview.selections)),
-    ]
+    public static var selections: [GraphQLSelection] {
+      return [
+        GraphQLField(\\"createReview\\", arguments: [\\"episode\\": GraphQLVariable(\\"episode\\"), \\"review\\": [\\"stars\\": 5, \\"commentary\\": \\"Wow!\\\\n I thought\\\\n  This movie ROCKED!\\"]], type: .object(CreateReview.selections)),
+      ]
+    }
 
     public private(set) var resultMap: ResultMap
 
@@ -58,10 +60,12 @@ exports[`Swift code generation #classDeclarationForOperation() should correctly 
     public struct CreateReview: GraphQLSelectionSet {
       public static let possibleTypes: [String] = [\\"Review\\"]
 
-      public private(set) static var selections: [GraphQLSelection] = [
-        GraphQLField(\\"stars\\", type: .nonNull(.scalar(Int.self))),
-        GraphQLField(\\"commentary\\", type: .scalar(String.self)),
-      ]
+      public static var selections: [GraphQLSelection] {
+        return [
+          GraphQLField(\\"stars\\", type: .nonNull(.scalar(Int.self))),
+          GraphQLField(\\"commentary\\", type: .scalar(String.self)),
+        ]
+      }
 
       public private(set) var resultMap: ResultMap
 
@@ -129,9 +133,11 @@ exports[`Swift code generation #classDeclarationForOperation() should correctly 
   public struct Data: GraphQLSelectionSet {
     public static let possibleTypes: [String] = [\\"Mutation\\"]
 
-    public private(set) static var selections: [GraphQLSelection] = [
-      GraphQLField(\\"createReview\\", arguments: [\\"episode\\": GraphQLVariable(\\"episode\\"), \\"review\\": [\\"stars\\": 5, \\"commentary\\": \\"Wow!\\\\n I thought\\\\n  This movie \\\\\\\\ ROCKED!\\"]], type: .object(CreateReview.selections)),
-    ]
+    public static var selections: [GraphQLSelection] {
+      return [
+        GraphQLField(\\"createReview\\", arguments: [\\"episode\\": GraphQLVariable(\\"episode\\"), \\"review\\": [\\"stars\\": 5, \\"commentary\\": \\"Wow!\\\\n I thought\\\\n  This movie \\\\\\\\ ROCKED!\\"]], type: .object(CreateReview.selections)),
+      ]
+    }
 
     public private(set) var resultMap: ResultMap
 
@@ -155,10 +161,12 @@ exports[`Swift code generation #classDeclarationForOperation() should correctly 
     public struct CreateReview: GraphQLSelectionSet {
       public static let possibleTypes: [String] = [\\"Review\\"]
 
-      public private(set) static var selections: [GraphQLSelection] = [
-        GraphQLField(\\"stars\\", type: .nonNull(.scalar(Int.self))),
-        GraphQLField(\\"commentary\\", type: .scalar(String.self)),
-      ]
+      public static var selections: [GraphQLSelection] {
+        return [
+          GraphQLField(\\"stars\\", type: .nonNull(.scalar(Int.self))),
+          GraphQLField(\\"commentary\\", type: .scalar(String.self)),
+        ]
+      }
 
       public private(set) var resultMap: ResultMap
 
@@ -222,9 +230,11 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
   public struct Data: GraphQLSelectionSet {
     public static let possibleTypes: [String] = [\\"Mutation\\"]
 
-    public private(set) static var selections: [GraphQLSelection] = [
-      GraphQLField(\\"createReview\\", arguments: [\\"episode\\": GraphQLVariable(\\"episode\\"), \\"review\\": [\\"stars\\": 5, \\"commentary\\": \\"Wow!\\"]], type: .object(CreateReview.selections)),
-    ]
+    public static var selections: [GraphQLSelection] {
+      return [
+        GraphQLField(\\"createReview\\", arguments: [\\"episode\\": GraphQLVariable(\\"episode\\"), \\"review\\": [\\"stars\\": 5, \\"commentary\\": \\"Wow!\\"]], type: .object(CreateReview.selections)),
+      ]
+    }
 
     public private(set) var resultMap: ResultMap
 
@@ -248,10 +258,12 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
     public struct CreateReview: GraphQLSelectionSet {
       public static let possibleTypes: [String] = [\\"Review\\"]
 
-      public private(set) static var selections: [GraphQLSelection] = [
-        GraphQLField(\\"stars\\", type: .nonNull(.scalar(Int.self))),
-        GraphQLField(\\"commentary\\", type: .scalar(String.self)),
-      ]
+      public static var selections: [GraphQLSelection] {
+        return [
+          GraphQLField(\\"stars\\", type: .nonNull(.scalar(Int.self))),
+          GraphQLField(\\"commentary\\", type: .scalar(String.self)),
+        ]
+      }
 
       public private(set) var resultMap: ResultMap
 
@@ -311,9 +323,11 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
   public struct Data: GraphQLSelectionSet {
     public static let possibleTypes: [String] = [\\"Query\\"]
 
-    public private(set) static var selections: [GraphQLSelection] = [
-      GraphQLField(\\"hero\\", type: .object(Hero.selections)),
-    ]
+    public static var selections: [GraphQLSelection] {
+      return [
+        GraphQLField(\\"hero\\", type: .object(Hero.selections)),
+      ]
+    }
 
     public private(set) var resultMap: ResultMap
 
@@ -337,13 +351,15 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
     public struct Hero: GraphQLSelectionSet {
       public static let possibleTypes: [String] = [\\"Human\\", \\"Droid\\"]
 
-      public private(set) static var selections: [GraphQLSelection] = [
-        GraphQLTypeCase(
-          variants: [\\"Droid\\": AsDroid.selections],
-          default: [
-          ]
-        )
-      ]
+      public static var selections: [GraphQLSelection] {
+        return [
+          GraphQLTypeCase(
+            variants: [\\"Droid\\": AsDroid.selections],
+            default: [
+            ]
+          )
+        ]
+      }
 
       public private(set) var resultMap: ResultMap
 
@@ -373,9 +389,11 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
       public struct AsDroid: GraphQLSelectionSet {
         public static let possibleTypes: [String] = [\\"Droid\\"]
 
-        public private(set) static var selections: [GraphQLSelection] = [
-          GraphQLField(\\"name\\", type: .nonNull(.scalar(String.self))),
-        ]
+        public static var selections: [GraphQLSelection] {
+          return [
+            GraphQLField(\\"name\\", type: .nonNull(.scalar(String.self))),
+          ]
+        }
 
         public private(set) var resultMap: ResultMap
 
@@ -450,9 +468,11 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
   public struct Data: GraphQLSelectionSet {
     public static let possibleTypes: [String] = [\\"Query\\"]
 
-    public private(set) static var selections: [GraphQLSelection] = [
-      GraphQLField(\\"hero\\", type: .object(Hero.selections)),
-    ]
+    public static var selections: [GraphQLSelection] {
+      return [
+        GraphQLField(\\"hero\\", type: .object(Hero.selections)),
+      ]
+    }
 
     public private(set) var resultMap: ResultMap
 
@@ -476,13 +496,15 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
     public struct Hero: GraphQLSelectionSet {
       public static let possibleTypes: [String] = [\\"Human\\", \\"Droid\\"]
 
-      public private(set) static var selections: [GraphQLSelection] = [
-        GraphQLTypeCase(
-          variants: [\\"Droid\\": AsDroid.selections],
-          default: [
-          ]
-        )
-      ]
+      public static var selections: [GraphQLSelection] {
+        return [
+          GraphQLTypeCase(
+            variants: [\\"Droid\\": AsDroid.selections],
+            default: [
+            ]
+          )
+        ]
+      }
 
       public private(set) var resultMap: ResultMap
 
@@ -540,9 +562,11 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
       public struct AsDroid: GraphQLSelectionSet {
         public static let possibleTypes: [String] = [\\"Droid\\"]
 
-        public private(set) static var selections: [GraphQLSelection] = [
-          GraphQLField(\\"primaryFunction\\", type: .scalar(String.self)),
-        ]
+        public static var selections: [GraphQLSelection] {
+          return [
+            GraphQLField(\\"primaryFunction\\", type: .scalar(String.self)),
+          ]
+        }
 
         public private(set) var resultMap: ResultMap
 
@@ -617,9 +641,11 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
   public struct Data: GraphQLSelectionSet {
     public static let possibleTypes: [String] = [\\"Query\\"]
 
-    public private(set) static var selections: [GraphQLSelection] = [
-      GraphQLField(\\"hero\\", type: .object(Hero.selections)),
-    ]
+    public static var selections: [GraphQLSelection] {
+      return [
+        GraphQLField(\\"hero\\", type: .object(Hero.selections)),
+      ]
+    }
 
     public private(set) var resultMap: ResultMap
 
@@ -643,9 +669,11 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
     public struct Hero: GraphQLSelectionSet {
       public static let possibleTypes: [String] = [\\"Human\\", \\"Droid\\"]
 
-      public private(set) static var selections: [GraphQLSelection] = [
-        GraphQLField(\\"name\\", type: .nonNull(.scalar(String.self))),
-      ]
+      public static var selections: [GraphQLSelection] {
+        return [
+          GraphQLField(\\"name\\", type: .nonNull(.scalar(String.self))),
+        ]
+      }
 
       public private(set) var resultMap: ResultMap
 
@@ -728,9 +756,11 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
   public struct Data: GraphQLSelectionSet {
     public static let possibleTypes: [String] = [\\"Query\\"]
 
-    public private(set) static var selections: [GraphQLSelection] = [
-      GraphQLField(\\"hero\\", arguments: [\\"episode\\": GraphQLVariable(\\"episode\\")], type: .object(Hero.selections)),
-    ]
+    public static var selections: [GraphQLSelection] {
+      return [
+        GraphQLField(\\"hero\\", arguments: [\\"episode\\": GraphQLVariable(\\"episode\\")], type: .object(Hero.selections)),
+      ]
+    }
 
     public private(set) var resultMap: ResultMap
 
@@ -754,9 +784,11 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
     public struct Hero: GraphQLSelectionSet {
       public static let possibleTypes: [String] = [\\"Human\\", \\"Droid\\"]
 
-      public private(set) static var selections: [GraphQLSelection] = [
-        GraphQLField(\\"name\\", type: .nonNull(.scalar(String.self))),
-      ]
+      public static var selections: [GraphQLSelection] {
+        return [
+          GraphQLField(\\"name\\", type: .nonNull(.scalar(String.self))),
+        ]
+      }
 
       public private(set) var resultMap: ResultMap
 
@@ -810,9 +842,11 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
   public struct Data: GraphQLSelectionSet {
     public static let possibleTypes: [String] = [\\"Query\\"]
 
-    public private(set) static var selections: [GraphQLSelection] = [
-      GraphQLField(\\"hero\\", type: .object(Hero.selections)),
-    ]
+    public static var selections: [GraphQLSelection] {
+      return [
+        GraphQLField(\\"hero\\", type: .object(Hero.selections)),
+      ]
+    }
 
     public private(set) var resultMap: ResultMap
 
@@ -836,9 +870,11 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
     public struct Hero: GraphQLSelectionSet {
       public static let possibleTypes: [String] = [\\"Human\\", \\"Droid\\"]
 
-      public private(set) static var selections: [GraphQLSelection] = [
-        GraphQLField(\\"name\\", type: .nonNull(.scalar(String.self))),
-      ]
+      public static var selections: [GraphQLSelection] {
+        return [
+          GraphQLField(\\"name\\", type: .nonNull(.scalar(String.self))),
+        ]
+      }
 
       public private(set) var resultMap: ResultMap
 
@@ -926,10 +962,12 @@ exports[`Swift code generation #structDeclarationForFragment() should generate a
 
   public static let possibleTypes: [String] = [\\"Human\\", \\"Droid\\"]
 
-  public private(set) static var selections: [GraphQLSelection] = [
-    GraphQLField(\\"name\\", type: .nonNull(.scalar(String.self))),
-    GraphQLField(\\"appearsIn\\", type: .nonNull(.list(.scalar(Episode.self)))),
-  ]
+  public static var selections: [GraphQLSelection] {
+    return [
+      GraphQLField(\\"name\\", type: .nonNull(.scalar(String.self))),
+      GraphQLField(\\"appearsIn\\", type: .nonNull(.list(.scalar(Episode.self)))),
+    ]
+  }
 
   public private(set) var resultMap: ResultMap
 
@@ -1006,10 +1044,12 @@ exports[`Swift code generation #structDeclarationForFragment() should generate a
 
   public static let possibleTypes: [String] = [\\"Droid\\"]
 
-  public private(set) static var selections: [GraphQLSelection] = [
-    GraphQLField(\\"name\\", type: .nonNull(.scalar(String.self))),
-    GraphQLField(\\"primaryFunction\\", type: .scalar(String.self)),
-  ]
+  public static var selections: [GraphQLSelection] {
+    return [
+      GraphQLField(\\"name\\", type: .nonNull(.scalar(String.self))),
+      GraphQLField(\\"primaryFunction\\", type: .scalar(String.self)),
+    ]
+  }
 
   public private(set) var resultMap: ResultMap
 
@@ -1058,10 +1098,12 @@ exports[`Swift code generation #structDeclarationForFragment() should generate a
 
   public static let possibleTypes: [String] = [\\"Human\\", \\"Droid\\"]
 
-  public private(set) static var selections: [GraphQLSelection] = [
-    GraphQLField(\\"name\\", type: .nonNull(.scalar(String.self))),
-    GraphQLField(\\"friends\\", type: .list(.object(Friend.selections))),
-  ]
+  public static var selections: [GraphQLSelection] {
+    return [
+      GraphQLField(\\"name\\", type: .nonNull(.scalar(String.self))),
+      GraphQLField(\\"friends\\", type: .list(.object(Friend.selections))),
+    ]
+  }
 
   public private(set) var resultMap: ResultMap
 
@@ -1100,9 +1142,11 @@ exports[`Swift code generation #structDeclarationForFragment() should generate a
   public struct Friend: GraphQLSelectionSet {
     public static let possibleTypes: [String] = [\\"Human\\", \\"Droid\\"]
 
-    public private(set) static var selections: [GraphQLSelection] = [
-      GraphQLField(\\"name\\", type: .nonNull(.scalar(String.self))),
-    ]
+    public static var selections: [GraphQLSelection] {
+      return [
+        GraphQLField(\\"name\\", type: .nonNull(.scalar(String.self))),
+      ]
+    }
 
     public private(set) var resultMap: ResultMap
 
@@ -1144,10 +1188,12 @@ exports[`Swift code generation #structDeclarationForFragment() should generate a
 
   public static let possibleTypes: [String] = [\\"Human\\", \\"Droid\\"]
 
-  public private(set) static var selections: [GraphQLSelection] = [
-    GraphQLField(\\"name\\", type: .nonNull(.scalar(String.self))),
-    GraphQLField(\\"appearsIn\\", type: .nonNull(.list(.scalar(Episode.self)))),
-  ]
+  public static var selections: [GraphQLSelection] {
+    return [
+      GraphQLField(\\"name\\", type: .nonNull(.scalar(String.self))),
+      GraphQLField(\\"appearsIn\\", type: .nonNull(.list(.scalar(Episode.self)))),
+    ]
+  }
 
   public private(set) var resultMap: ResultMap
 
@@ -1189,9 +1235,11 @@ exports[`Swift code generation #structDeclarationForSelectionSet() should escape
 "public struct Human: GraphQLSelectionSet {
   public static let possibleTypes: [String] = [\\"Human\\"]
 
-  public private(set) static var selections: [GraphQLSelection] = [
-    GraphQLField(\\"friends\\", alias: \\"self\\", type: .list(.object(\`Self\`.selections))),
-  ]
+  public static var selections: [GraphQLSelection] {
+    return [
+      GraphQLField(\\"friends\\", alias: \\"self\\", type: .list(.object(\`Self\`.selections))),
+    ]
+  }
 
   public private(set) var resultMap: ResultMap
 
@@ -1216,9 +1264,11 @@ exports[`Swift code generation #structDeclarationForSelectionSet() should escape
   public struct \`Self\`: GraphQLSelectionSet {
     public static let possibleTypes: [String] = [\\"Human\\", \\"Droid\\"]
 
-    public private(set) static var selections: [GraphQLSelection] = [
-      GraphQLField(\\"id\\", type: .nonNull(.scalar(GraphQLID.self))),
-    ]
+    public static var selections: [GraphQLSelection] {
+      return [
+        GraphQLField(\\"id\\", type: .nonNull(.scalar(GraphQLID.self))),
+      ]
+    }
 
     public private(set) var resultMap: ResultMap
 
@@ -1249,10 +1299,12 @@ exports[`Swift code generation #structDeclarationForSelectionSet() should escape
 public struct Human: GraphQLSelectionSet {
   public static let possibleTypes: [String] = [\\"Human\\"]
 
-  public private(set) static var selections: [GraphQLSelection] = [
-    GraphQLField(\\"friends\\", alias: \\"self\\", type: .list(.object(\`Self\`.selections))),
-    GraphQLField(\\"name\\", alias: \\"_self\\", type: .nonNull(.scalar(String.self))),
-  ]
+  public static var selections: [GraphQLSelection] {
+    return [
+      GraphQLField(\\"friends\\", alias: \\"self\\", type: .list(.object(\`Self\`.selections))),
+      GraphQLField(\\"name\\", alias: \\"_self\\", type: .nonNull(.scalar(String.self))),
+    ]
+  }
 
   public private(set) var resultMap: ResultMap
 
@@ -1287,9 +1339,11 @@ public struct Human: GraphQLSelectionSet {
   public struct \`Self\`: GraphQLSelectionSet {
     public static let possibleTypes: [String] = [\\"Human\\", \\"Droid\\"]
 
-    public private(set) static var selections: [GraphQLSelection] = [
-      GraphQLField(\\"id\\", type: .nonNull(.scalar(GraphQLID.self))),
-    ]
+    public static var selections: [GraphQLSelection] {
+      return [
+        GraphQLField(\\"id\\", type: .nonNull(.scalar(GraphQLID.self))),
+      ]
+    }
 
     public private(set) var resultMap: ResultMap
 
@@ -1322,10 +1376,12 @@ exports[`Swift code generation #structDeclarationForSelectionSet() should escape
 "public struct Hero: GraphQLSelectionSet {
   public static let possibleTypes: [String] = [\\"Human\\", \\"Droid\\"]
 
-  public private(set) static var selections: [GraphQLSelection] = [
-    GraphQLField(\\"name\\", alias: \\"private\\", type: .nonNull(.scalar(String.self))),
-    GraphQLField(\\"friends\\", alias: \\"self\\", type: .list(.object(\`Self\`.selections))),
-  ]
+  public static var selections: [GraphQLSelection] {
+    return [
+      GraphQLField(\\"name\\", alias: \\"private\\", type: .nonNull(.scalar(String.self))),
+      GraphQLField(\\"friends\\", alias: \\"self\\", type: .list(.object(\`Self\`.selections))),
+    ]
+  }
 
   public private(set) var resultMap: ResultMap
 
@@ -1364,9 +1420,11 @@ exports[`Swift code generation #structDeclarationForSelectionSet() should escape
   public struct \`Self\`: GraphQLSelectionSet {
     public static let possibleTypes: [String] = [\\"Human\\", \\"Droid\\"]
 
-    public private(set) static var selections: [GraphQLSelection] = [
-      GraphQLField(\\"id\\", type: .nonNull(.scalar(GraphQLID.self))),
-    ]
+    public static var selections: [GraphQLSelection] {
+      return [
+        GraphQLField(\\"id\\", type: .nonNull(.scalar(GraphQLID.self))),
+      ]
+    }
 
     public private(set) var resultMap: ResultMap
 
@@ -1399,9 +1457,11 @@ exports[`Swift code generation #structDeclarationForSelectionSet() should genera
 "public struct Hero: GraphQLSelectionSet {
   public static let possibleTypes: [String] = [\\"Human\\", \\"Droid\\"]
 
-  public private(set) static var selections: [GraphQLSelection] = [
-    GraphQLField(\\"friends\\", type: .list(.object(Friend.selections))),
-  ]
+  public static var selections: [GraphQLSelection] {
+    return [
+      GraphQLField(\\"friends\\", type: .list(.object(Friend.selections))),
+    ]
+  }
 
   public private(set) var resultMap: ResultMap
 
@@ -1430,9 +1490,11 @@ exports[`Swift code generation #structDeclarationForSelectionSet() should genera
   public struct Friend: GraphQLSelectionSet {
     public static let possibleTypes: [String] = [\\"Human\\", \\"Droid\\"]
 
-    public private(set) static var selections: [GraphQLSelection] = [
-      GraphQLField(\\"name\\", type: .nonNull(.scalar(String.self))),
-    ]
+    public static var selections: [GraphQLSelection] {
+      return [
+        GraphQLField(\\"name\\", type: .nonNull(.scalar(String.self))),
+      ]
+    }
 
     public private(set) var resultMap: ResultMap
 
@@ -1465,14 +1527,16 @@ exports[`Swift code generation #structDeclarationForSelectionSet() should genera
 "public struct Hero: GraphQLSelectionSet {
   public static let possibleTypes: [String] = [\\"Human\\", \\"Droid\\"]
 
-  public private(set) static var selections: [GraphQLSelection] = [
-    GraphQLTypeCase(
-      variants: [\\"Droid\\": AsDroid.selections],
-      default: [
-        GraphQLField(\\"name\\", type: .nonNull(.scalar(String.self))),
-      ]
-    )
-  ]
+  public static var selections: [GraphQLSelection] {
+    return [
+      GraphQLTypeCase(
+        variants: [\\"Droid\\": AsDroid.selections],
+        default: [
+          GraphQLField(\\"name\\", type: .nonNull(.scalar(String.self))),
+        ]
+      )
+    ]
+  }
 
   public private(set) var resultMap: ResultMap
 
@@ -1512,10 +1576,12 @@ exports[`Swift code generation #structDeclarationForSelectionSet() should genera
   public struct AsDroid: GraphQLSelectionSet {
     public static let possibleTypes: [String] = [\\"Droid\\"]
 
-    public private(set) static var selections: [GraphQLSelection] = [
-      GraphQLField(\\"name\\", type: .nonNull(.scalar(String.self))),
-      GraphQLField(\\"name\\", type: .nonNull(.scalar(String.self))),
-    ]
+    public static var selections: [GraphQLSelection] {
+      return [
+        GraphQLField(\\"name\\", type: .nonNull(.scalar(String.self))),
+        GraphQLField(\\"name\\", type: .nonNull(.scalar(String.self))),
+      ]
+    }
 
     public private(set) var resultMap: ResultMap
 
@@ -1570,9 +1636,11 @@ exports[`Swift code generation #structDeclarationForSelectionSet() should genera
 "public struct Hero: GraphQLSelectionSet {
   public static let possibleTypes: [String] = [\\"Human\\", \\"Droid\\"]
 
-  public private(set) static var selections: [GraphQLSelection] = [
-    GraphQLField(\\"name\\", type: .nonNull(.scalar(String.self))),
-  ]
+  public static var selections: [GraphQLSelection] {
+    return [
+      GraphQLField(\\"name\\", type: .nonNull(.scalar(String.self))),
+    ]
+  }
 
   public private(set) var resultMap: ResultMap
 
@@ -1604,11 +1672,13 @@ exports[`Swift code generation #structDeclarationForSelectionSet() should genera
 "public struct Hero: GraphQLSelectionSet {
   public static let possibleTypes: [String] = [\\"Human\\", \\"Droid\\"]
 
-  public private(set) static var selections: [GraphQLSelection] = [
-    GraphQLBooleanCondition(variableName: \\"includeName\\", inverted: false, selections: [
-      GraphQLField(\\"name\\", type: .nonNull(.scalar(String.self))),
-    ]),
-  ]
+  public static var selections: [GraphQLSelection] {
+    return [
+      GraphQLBooleanCondition(variableName: \\"includeName\\", inverted: false, selections: [
+        GraphQLField(\\"name\\", type: .nonNull(.scalar(String.self))),
+      ]),
+    ]
+  }
 
   public private(set) var resultMap: ResultMap
 
@@ -1640,10 +1710,12 @@ exports[`Swift code generation #structDeclarationForSelectionSet() should genera
 "public struct Hero: GraphQLSelectionSet {
   public static let possibleTypes: [String] = [\\"Human\\", \\"Droid\\"]
 
-  public private(set) static var selections: [GraphQLSelection] = [
-    GraphQLField(\\"name\\", type: .nonNull(.scalar(String.self))),
-    GraphQLField(\\"name\\", type: .nonNull(.scalar(String.self))),
-  ]
+  public static var selections: [GraphQLSelection] {
+    return [
+      GraphQLField(\\"name\\", type: .nonNull(.scalar(String.self))),
+      GraphQLField(\\"name\\", type: .nonNull(.scalar(String.self))),
+    ]
+  }
 
   public private(set) var resultMap: ResultMap
 
@@ -1701,14 +1773,16 @@ exports[`Swift code generation #structDeclarationForSelectionSet() should genera
 "public struct Hero: GraphQLSelectionSet {
   public static let possibleTypes: [String] = [\\"Human\\", \\"Droid\\"]
 
-  public private(set) static var selections: [GraphQLSelection] = [
-    GraphQLTypeCase(
-      variants: [\\"Droid\\": AsDroid.selections],
-      default: [
-        GraphQLField(\\"name\\", type: .nonNull(.scalar(String.self))),
-      ]
-    )
-  ]
+  public static var selections: [GraphQLSelection] {
+    return [
+      GraphQLTypeCase(
+        variants: [\\"Droid\\": AsDroid.selections],
+        default: [
+          GraphQLField(\\"name\\", type: .nonNull(.scalar(String.self))),
+        ]
+      )
+    ]
+  }
 
   public private(set) var resultMap: ResultMap
 
@@ -1776,10 +1850,12 @@ exports[`Swift code generation #structDeclarationForSelectionSet() should genera
   public struct AsDroid: GraphQLSelectionSet {
     public static let possibleTypes: [String] = [\\"Droid\\"]
 
-    public private(set) static var selections: [GraphQLSelection] = [
-      GraphQLField(\\"name\\", type: .nonNull(.scalar(String.self))),
-      GraphQLField(\\"name\\", type: .nonNull(.scalar(String.self))),
-    ]
+    public static var selections: [GraphQLSelection] {
+      return [
+        GraphQLField(\\"name\\", type: .nonNull(.scalar(String.self))),
+        GraphQLField(\\"name\\", type: .nonNull(.scalar(String.self))),
+      ]
+    }
 
     public private(set) var resultMap: ResultMap
 
@@ -1834,14 +1910,16 @@ exports[`Swift code generation #structDeclarationForSelectionSet() should genera
 "public struct Hero: GraphQLSelectionSet {
   public static let possibleTypes: [String] = [\\"Human\\", \\"Droid\\"]
 
-  public private(set) static var selections: [GraphQLSelection] = [
-    GraphQLTypeCase(
-      variants: [\\"Droid\\": AsDroid.selections],
-      default: [
-        GraphQLField(\\"name\\", type: .nonNull(.scalar(String.self))),
-      ]
-    )
-  ]
+  public static var selections: [GraphQLSelection] {
+    return [
+      GraphQLTypeCase(
+        variants: [\\"Droid\\": AsDroid.selections],
+        default: [
+          GraphQLField(\\"name\\", type: .nonNull(.scalar(String.self))),
+        ]
+      )
+    ]
+  }
 
   public private(set) var resultMap: ResultMap
 
@@ -1881,10 +1959,12 @@ exports[`Swift code generation #structDeclarationForSelectionSet() should genera
   public struct AsDroid: GraphQLSelectionSet {
     public static let possibleTypes: [String] = [\\"Droid\\"]
 
-    public private(set) static var selections: [GraphQLSelection] = [
-      GraphQLField(\\"name\\", type: .nonNull(.scalar(String.self))),
-      GraphQLField(\\"primaryFunction\\", type: .scalar(String.self)),
-    ]
+    public static var selections: [GraphQLSelection] {
+      return [
+        GraphQLField(\\"name\\", type: .nonNull(.scalar(String.self))),
+        GraphQLField(\\"primaryFunction\\", type: .scalar(String.self)),
+      ]
+    }
 
     public private(set) var resultMap: ResultMap
 
@@ -1923,10 +2003,12 @@ exports[`Swift code generation #structDeclarationForSelectionSet() should preser
 "public struct Hero: GraphQLSelectionSet {
   public static let possibleTypes: [String] = [\\"Human\\", \\"Droid\\"]
 
-  public private(set) static var selections: [GraphQLSelection] = [
-    GraphQLField(\\"name\\", alias: \\"_name\\", type: .nonNull(.scalar(String.self))),
-    GraphQLField(\\"id\\", alias: \\"_camel_case_id__\\", type: .nonNull(.scalar(GraphQLID.self))),
-  ]
+  public static var selections: [GraphQLSelection] {
+    return [
+      GraphQLField(\\"name\\", alias: \\"_name\\", type: .nonNull(.scalar(String.self))),
+      GraphQLField(\\"id\\", alias: \\"_camel_case_id__\\", type: .nonNull(.scalar(GraphQLID.self))),
+    ]
+  }
 
   public private(set) var resultMap: ResultMap
 

--- a/packages/apollo-codegen-swift/src/__tests__/__snapshots__/codeGeneration.ts.snap
+++ b/packages/apollo-codegen-swift/src/__tests__/__snapshots__/codeGeneration.ts.snap
@@ -32,7 +32,7 @@ exports[`Swift code generation #classDeclarationForOperation() should correctly 
   public struct Data: GraphQLSelectionSet {
     public static let possibleTypes: [String] = [\\"Mutation\\"]
 
-    public static let selections: [GraphQLSelection] = [
+    public private(set) static var selections: [GraphQLSelection] = [
       GraphQLField(\\"createReview\\", arguments: [\\"episode\\": GraphQLVariable(\\"episode\\"), \\"review\\": [\\"stars\\": 5, \\"commentary\\": \\"Wow!\\\\n I thought\\\\n  This movie ROCKED!\\"]], type: .object(CreateReview.selections)),
     ]
 
@@ -58,7 +58,7 @@ exports[`Swift code generation #classDeclarationForOperation() should correctly 
     public struct CreateReview: GraphQLSelectionSet {
       public static let possibleTypes: [String] = [\\"Review\\"]
 
-      public static let selections: [GraphQLSelection] = [
+      public private(set) static var selections: [GraphQLSelection] = [
         GraphQLField(\\"stars\\", type: .nonNull(.scalar(Int.self))),
         GraphQLField(\\"commentary\\", type: .scalar(String.self)),
       ]
@@ -129,7 +129,7 @@ exports[`Swift code generation #classDeclarationForOperation() should correctly 
   public struct Data: GraphQLSelectionSet {
     public static let possibleTypes: [String] = [\\"Mutation\\"]
 
-    public static let selections: [GraphQLSelection] = [
+    public private(set) static var selections: [GraphQLSelection] = [
       GraphQLField(\\"createReview\\", arguments: [\\"episode\\": GraphQLVariable(\\"episode\\"), \\"review\\": [\\"stars\\": 5, \\"commentary\\": \\"Wow!\\\\n I thought\\\\n  This movie \\\\\\\\ ROCKED!\\"]], type: .object(CreateReview.selections)),
     ]
 
@@ -155,7 +155,7 @@ exports[`Swift code generation #classDeclarationForOperation() should correctly 
     public struct CreateReview: GraphQLSelectionSet {
       public static let possibleTypes: [String] = [\\"Review\\"]
 
-      public static let selections: [GraphQLSelection] = [
+      public private(set) static var selections: [GraphQLSelection] = [
         GraphQLField(\\"stars\\", type: .nonNull(.scalar(Int.self))),
         GraphQLField(\\"commentary\\", type: .scalar(String.self)),
       ]
@@ -222,7 +222,7 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
   public struct Data: GraphQLSelectionSet {
     public static let possibleTypes: [String] = [\\"Mutation\\"]
 
-    public static let selections: [GraphQLSelection] = [
+    public private(set) static var selections: [GraphQLSelection] = [
       GraphQLField(\\"createReview\\", arguments: [\\"episode\\": GraphQLVariable(\\"episode\\"), \\"review\\": [\\"stars\\": 5, \\"commentary\\": \\"Wow!\\"]], type: .object(CreateReview.selections)),
     ]
 
@@ -248,7 +248,7 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
     public struct CreateReview: GraphQLSelectionSet {
       public static let possibleTypes: [String] = [\\"Review\\"]
 
-      public static let selections: [GraphQLSelection] = [
+      public private(set) static var selections: [GraphQLSelection] = [
         GraphQLField(\\"stars\\", type: .nonNull(.scalar(Int.self))),
         GraphQLField(\\"commentary\\", type: .scalar(String.self)),
       ]
@@ -311,7 +311,7 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
   public struct Data: GraphQLSelectionSet {
     public static let possibleTypes: [String] = [\\"Query\\"]
 
-    public static let selections: [GraphQLSelection] = [
+    public private(set) static var selections: [GraphQLSelection] = [
       GraphQLField(\\"hero\\", type: .object(Hero.selections)),
     ]
 
@@ -337,7 +337,7 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
     public struct Hero: GraphQLSelectionSet {
       public static let possibleTypes: [String] = [\\"Human\\", \\"Droid\\"]
 
-      public static let selections: [GraphQLSelection] = [
+      public private(set) static var selections: [GraphQLSelection] = [
         GraphQLTypeCase(
           variants: [\\"Droid\\": AsDroid.selections],
           default: [
@@ -373,7 +373,7 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
       public struct AsDroid: GraphQLSelectionSet {
         public static let possibleTypes: [String] = [\\"Droid\\"]
 
-        public static let selections: [GraphQLSelection] = [
+        public private(set) static var selections: [GraphQLSelection] = [
           GraphQLField(\\"name\\", type: .nonNull(.scalar(String.self))),
         ]
 
@@ -450,7 +450,7 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
   public struct Data: GraphQLSelectionSet {
     public static let possibleTypes: [String] = [\\"Query\\"]
 
-    public static let selections: [GraphQLSelection] = [
+    public private(set) static var selections: [GraphQLSelection] = [
       GraphQLField(\\"hero\\", type: .object(Hero.selections)),
     ]
 
@@ -476,7 +476,7 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
     public struct Hero: GraphQLSelectionSet {
       public static let possibleTypes: [String] = [\\"Human\\", \\"Droid\\"]
 
-      public static let selections: [GraphQLSelection] = [
+      public private(set) static var selections: [GraphQLSelection] = [
         GraphQLTypeCase(
           variants: [\\"Droid\\": AsDroid.selections],
           default: [
@@ -540,7 +540,7 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
       public struct AsDroid: GraphQLSelectionSet {
         public static let possibleTypes: [String] = [\\"Droid\\"]
 
-        public static let selections: [GraphQLSelection] = [
+        public private(set) static var selections: [GraphQLSelection] = [
           GraphQLField(\\"primaryFunction\\", type: .scalar(String.self)),
         ]
 
@@ -617,7 +617,7 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
   public struct Data: GraphQLSelectionSet {
     public static let possibleTypes: [String] = [\\"Query\\"]
 
-    public static let selections: [GraphQLSelection] = [
+    public private(set) static var selections: [GraphQLSelection] = [
       GraphQLField(\\"hero\\", type: .object(Hero.selections)),
     ]
 
@@ -643,7 +643,7 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
     public struct Hero: GraphQLSelectionSet {
       public static let possibleTypes: [String] = [\\"Human\\", \\"Droid\\"]
 
-      public static let selections: [GraphQLSelection] = [
+      public private(set) static var selections: [GraphQLSelection] = [
         GraphQLField(\\"name\\", type: .nonNull(.scalar(String.self))),
       ]
 
@@ -728,7 +728,7 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
   public struct Data: GraphQLSelectionSet {
     public static let possibleTypes: [String] = [\\"Query\\"]
 
-    public static let selections: [GraphQLSelection] = [
+    public private(set) static var selections: [GraphQLSelection] = [
       GraphQLField(\\"hero\\", arguments: [\\"episode\\": GraphQLVariable(\\"episode\\")], type: .object(Hero.selections)),
     ]
 
@@ -754,7 +754,7 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
     public struct Hero: GraphQLSelectionSet {
       public static let possibleTypes: [String] = [\\"Human\\", \\"Droid\\"]
 
-      public static let selections: [GraphQLSelection] = [
+      public private(set) static var selections: [GraphQLSelection] = [
         GraphQLField(\\"name\\", type: .nonNull(.scalar(String.self))),
       ]
 
@@ -810,7 +810,7 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
   public struct Data: GraphQLSelectionSet {
     public static let possibleTypes: [String] = [\\"Query\\"]
 
-    public static let selections: [GraphQLSelection] = [
+    public private(set) static var selections: [GraphQLSelection] = [
       GraphQLField(\\"hero\\", type: .object(Hero.selections)),
     ]
 
@@ -836,7 +836,7 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
     public struct Hero: GraphQLSelectionSet {
       public static let possibleTypes: [String] = [\\"Human\\", \\"Droid\\"]
 
-      public static let selections: [GraphQLSelection] = [
+      public private(set) static var selections: [GraphQLSelection] = [
         GraphQLField(\\"name\\", type: .nonNull(.scalar(String.self))),
       ]
 
@@ -926,7 +926,7 @@ exports[`Swift code generation #structDeclarationForFragment() should generate a
 
   public static let possibleTypes: [String] = [\\"Human\\", \\"Droid\\"]
 
-  public static let selections: [GraphQLSelection] = [
+  public private(set) static var selections: [GraphQLSelection] = [
     GraphQLField(\\"name\\", type: .nonNull(.scalar(String.self))),
     GraphQLField(\\"appearsIn\\", type: .nonNull(.list(.scalar(Episode.self)))),
   ]
@@ -1006,7 +1006,7 @@ exports[`Swift code generation #structDeclarationForFragment() should generate a
 
   public static let possibleTypes: [String] = [\\"Droid\\"]
 
-  public static let selections: [GraphQLSelection] = [
+  public private(set) static var selections: [GraphQLSelection] = [
     GraphQLField(\\"name\\", type: .nonNull(.scalar(String.self))),
     GraphQLField(\\"primaryFunction\\", type: .scalar(String.self)),
   ]
@@ -1058,7 +1058,7 @@ exports[`Swift code generation #structDeclarationForFragment() should generate a
 
   public static let possibleTypes: [String] = [\\"Human\\", \\"Droid\\"]
 
-  public static let selections: [GraphQLSelection] = [
+  public private(set) static var selections: [GraphQLSelection] = [
     GraphQLField(\\"name\\", type: .nonNull(.scalar(String.self))),
     GraphQLField(\\"friends\\", type: .list(.object(Friend.selections))),
   ]
@@ -1100,7 +1100,7 @@ exports[`Swift code generation #structDeclarationForFragment() should generate a
   public struct Friend: GraphQLSelectionSet {
     public static let possibleTypes: [String] = [\\"Human\\", \\"Droid\\"]
 
-    public static let selections: [GraphQLSelection] = [
+    public private(set) static var selections: [GraphQLSelection] = [
       GraphQLField(\\"name\\", type: .nonNull(.scalar(String.self))),
     ]
 
@@ -1144,7 +1144,7 @@ exports[`Swift code generation #structDeclarationForFragment() should generate a
 
   public static let possibleTypes: [String] = [\\"Human\\", \\"Droid\\"]
 
-  public static let selections: [GraphQLSelection] = [
+  public private(set) static var selections: [GraphQLSelection] = [
     GraphQLField(\\"name\\", type: .nonNull(.scalar(String.self))),
     GraphQLField(\\"appearsIn\\", type: .nonNull(.list(.scalar(Episode.self)))),
   ]
@@ -1189,7 +1189,7 @@ exports[`Swift code generation #structDeclarationForSelectionSet() should escape
 "public struct Human: GraphQLSelectionSet {
   public static let possibleTypes: [String] = [\\"Human\\"]
 
-  public static let selections: [GraphQLSelection] = [
+  public private(set) static var selections: [GraphQLSelection] = [
     GraphQLField(\\"friends\\", alias: \\"self\\", type: .list(.object(\`Self\`.selections))),
   ]
 
@@ -1216,7 +1216,7 @@ exports[`Swift code generation #structDeclarationForSelectionSet() should escape
   public struct \`Self\`: GraphQLSelectionSet {
     public static let possibleTypes: [String] = [\\"Human\\", \\"Droid\\"]
 
-    public static let selections: [GraphQLSelection] = [
+    public private(set) static var selections: [GraphQLSelection] = [
       GraphQLField(\\"id\\", type: .nonNull(.scalar(GraphQLID.self))),
     ]
 
@@ -1249,7 +1249,7 @@ exports[`Swift code generation #structDeclarationForSelectionSet() should escape
 public struct Human: GraphQLSelectionSet {
   public static let possibleTypes: [String] = [\\"Human\\"]
 
-  public static let selections: [GraphQLSelection] = [
+  public private(set) static var selections: [GraphQLSelection] = [
     GraphQLField(\\"friends\\", alias: \\"self\\", type: .list(.object(\`Self\`.selections))),
     GraphQLField(\\"name\\", alias: \\"_self\\", type: .nonNull(.scalar(String.self))),
   ]
@@ -1287,7 +1287,7 @@ public struct Human: GraphQLSelectionSet {
   public struct \`Self\`: GraphQLSelectionSet {
     public static let possibleTypes: [String] = [\\"Human\\", \\"Droid\\"]
 
-    public static let selections: [GraphQLSelection] = [
+    public private(set) static var selections: [GraphQLSelection] = [
       GraphQLField(\\"id\\", type: .nonNull(.scalar(GraphQLID.self))),
     ]
 
@@ -1322,7 +1322,7 @@ exports[`Swift code generation #structDeclarationForSelectionSet() should escape
 "public struct Hero: GraphQLSelectionSet {
   public static let possibleTypes: [String] = [\\"Human\\", \\"Droid\\"]
 
-  public static let selections: [GraphQLSelection] = [
+  public private(set) static var selections: [GraphQLSelection] = [
     GraphQLField(\\"name\\", alias: \\"private\\", type: .nonNull(.scalar(String.self))),
     GraphQLField(\\"friends\\", alias: \\"self\\", type: .list(.object(\`Self\`.selections))),
   ]
@@ -1364,7 +1364,7 @@ exports[`Swift code generation #structDeclarationForSelectionSet() should escape
   public struct \`Self\`: GraphQLSelectionSet {
     public static let possibleTypes: [String] = [\\"Human\\", \\"Droid\\"]
 
-    public static let selections: [GraphQLSelection] = [
+    public private(set) static var selections: [GraphQLSelection] = [
       GraphQLField(\\"id\\", type: .nonNull(.scalar(GraphQLID.self))),
     ]
 
@@ -1399,7 +1399,7 @@ exports[`Swift code generation #structDeclarationForSelectionSet() should genera
 "public struct Hero: GraphQLSelectionSet {
   public static let possibleTypes: [String] = [\\"Human\\", \\"Droid\\"]
 
-  public static let selections: [GraphQLSelection] = [
+  public private(set) static var selections: [GraphQLSelection] = [
     GraphQLField(\\"friends\\", type: .list(.object(Friend.selections))),
   ]
 
@@ -1430,7 +1430,7 @@ exports[`Swift code generation #structDeclarationForSelectionSet() should genera
   public struct Friend: GraphQLSelectionSet {
     public static let possibleTypes: [String] = [\\"Human\\", \\"Droid\\"]
 
-    public static let selections: [GraphQLSelection] = [
+    public private(set) static var selections: [GraphQLSelection] = [
       GraphQLField(\\"name\\", type: .nonNull(.scalar(String.self))),
     ]
 
@@ -1465,7 +1465,7 @@ exports[`Swift code generation #structDeclarationForSelectionSet() should genera
 "public struct Hero: GraphQLSelectionSet {
   public static let possibleTypes: [String] = [\\"Human\\", \\"Droid\\"]
 
-  public static let selections: [GraphQLSelection] = [
+  public private(set) static var selections: [GraphQLSelection] = [
     GraphQLTypeCase(
       variants: [\\"Droid\\": AsDroid.selections],
       default: [
@@ -1512,7 +1512,7 @@ exports[`Swift code generation #structDeclarationForSelectionSet() should genera
   public struct AsDroid: GraphQLSelectionSet {
     public static let possibleTypes: [String] = [\\"Droid\\"]
 
-    public static let selections: [GraphQLSelection] = [
+    public private(set) static var selections: [GraphQLSelection] = [
       GraphQLField(\\"name\\", type: .nonNull(.scalar(String.self))),
       GraphQLField(\\"name\\", type: .nonNull(.scalar(String.self))),
     ]
@@ -1570,7 +1570,7 @@ exports[`Swift code generation #structDeclarationForSelectionSet() should genera
 "public struct Hero: GraphQLSelectionSet {
   public static let possibleTypes: [String] = [\\"Human\\", \\"Droid\\"]
 
-  public static let selections: [GraphQLSelection] = [
+  public private(set) static var selections: [GraphQLSelection] = [
     GraphQLField(\\"name\\", type: .nonNull(.scalar(String.self))),
   ]
 
@@ -1604,7 +1604,7 @@ exports[`Swift code generation #structDeclarationForSelectionSet() should genera
 "public struct Hero: GraphQLSelectionSet {
   public static let possibleTypes: [String] = [\\"Human\\", \\"Droid\\"]
 
-  public static let selections: [GraphQLSelection] = [
+  public private(set) static var selections: [GraphQLSelection] = [
     GraphQLBooleanCondition(variableName: \\"includeName\\", inverted: false, selections: [
       GraphQLField(\\"name\\", type: .nonNull(.scalar(String.self))),
     ]),
@@ -1640,7 +1640,7 @@ exports[`Swift code generation #structDeclarationForSelectionSet() should genera
 "public struct Hero: GraphQLSelectionSet {
   public static let possibleTypes: [String] = [\\"Human\\", \\"Droid\\"]
 
-  public static let selections: [GraphQLSelection] = [
+  public private(set) static var selections: [GraphQLSelection] = [
     GraphQLField(\\"name\\", type: .nonNull(.scalar(String.self))),
     GraphQLField(\\"name\\", type: .nonNull(.scalar(String.self))),
   ]
@@ -1701,7 +1701,7 @@ exports[`Swift code generation #structDeclarationForSelectionSet() should genera
 "public struct Hero: GraphQLSelectionSet {
   public static let possibleTypes: [String] = [\\"Human\\", \\"Droid\\"]
 
-  public static let selections: [GraphQLSelection] = [
+  public private(set) static var selections: [GraphQLSelection] = [
     GraphQLTypeCase(
       variants: [\\"Droid\\": AsDroid.selections],
       default: [
@@ -1776,7 +1776,7 @@ exports[`Swift code generation #structDeclarationForSelectionSet() should genera
   public struct AsDroid: GraphQLSelectionSet {
     public static let possibleTypes: [String] = [\\"Droid\\"]
 
-    public static let selections: [GraphQLSelection] = [
+    public private(set) static var selections: [GraphQLSelection] = [
       GraphQLField(\\"name\\", type: .nonNull(.scalar(String.self))),
       GraphQLField(\\"name\\", type: .nonNull(.scalar(String.self))),
     ]
@@ -1834,7 +1834,7 @@ exports[`Swift code generation #structDeclarationForSelectionSet() should genera
 "public struct Hero: GraphQLSelectionSet {
   public static let possibleTypes: [String] = [\\"Human\\", \\"Droid\\"]
 
-  public static let selections: [GraphQLSelection] = [
+  public private(set) static var selections: [GraphQLSelection] = [
     GraphQLTypeCase(
       variants: [\\"Droid\\": AsDroid.selections],
       default: [
@@ -1881,7 +1881,7 @@ exports[`Swift code generation #structDeclarationForSelectionSet() should genera
   public struct AsDroid: GraphQLSelectionSet {
     public static let possibleTypes: [String] = [\\"Droid\\"]
 
-    public static let selections: [GraphQLSelection] = [
+    public private(set) static var selections: [GraphQLSelection] = [
       GraphQLField(\\"name\\", type: .nonNull(.scalar(String.self))),
       GraphQLField(\\"primaryFunction\\", type: .scalar(String.self)),
     ]
@@ -1923,7 +1923,7 @@ exports[`Swift code generation #structDeclarationForSelectionSet() should preser
 "public struct Hero: GraphQLSelectionSet {
   public static let possibleTypes: [String] = [\\"Human\\", \\"Droid\\"]
 
-  public static let selections: [GraphQLSelection] = [
+  public private(set) static var selections: [GraphQLSelection] = [
     GraphQLField(\\"name\\", alias: \\"_name\\", type: .nonNull(.scalar(String.self))),
     GraphQLField(\\"id\\", alias: \\"_camel_case_id__\\", type: .nonNull(.scalar(GraphQLID.self))),
   ]

--- a/packages/apollo-codegen-swift/src/codeGeneration.ts
+++ b/packages/apollo-codegen-swift/src/codeGeneration.ts
@@ -471,14 +471,17 @@ export class SwiftAPIGenerator extends SwiftGenerator<CompilerContext> {
 
         this.printNewlineIfNeeded();
         this.printOnNewline(
-          swift`public private(set) static var selections: [GraphQLSelection] = `
+          swift`public static var selections: [GraphQLSelection] {`
         );
-        if (typeCase) {
-          this.typeCaseInitialization(typeCase);
-        } else {
-          this.selectionSetInitialization(variant);
-        }
-
+        this.withIndent(() => {
+          this.printOnNewline(swift`return `);
+          if (typeCase) {
+            this.typeCaseInitialization(typeCase);
+          } else {
+            this.selectionSetInitialization(variant);
+          }
+        });
+        this.printOnNewline(swift`}`);
         this.printNewlineIfNeeded();
 
         this.printOnNewline(

--- a/packages/apollo-codegen-swift/src/codeGeneration.ts
+++ b/packages/apollo-codegen-swift/src/codeGeneration.ts
@@ -471,7 +471,7 @@ export class SwiftAPIGenerator extends SwiftGenerator<CompilerContext> {
 
         this.printNewlineIfNeeded();
         this.printOnNewline(
-          swift`public static let selections: [GraphQLSelection] = `
+          swift`public private(set) static var selections: [GraphQLSelection] = `
         );
         if (typeCase) {
           this.typeCaseInitialization(typeCase);

--- a/packages/apollo/src/commands/client/__tests__/__snapshots__/generate.test.ts.snap
+++ b/packages/apollo/src/commands/client/__tests__/__snapshots__/generate.test.ts.snap
@@ -249,7 +249,7 @@ public final class SimpleQueryQuery: GraphQLQuery {
   public struct Data: GraphQLSelectionSet {
     public static let possibleTypes: [String] = [\\"Query\\"]
 
-    public static let selections: [GraphQLSelection] = [
+    public private(set) static var selections: [GraphQLSelection] = [
       GraphQLField(\\"hello\\", type: .nonNull(.scalar(String.self))),
     ]
 
@@ -300,7 +300,7 @@ public final class SimpleQueryQuery: GraphQLQuery {
   public struct Data: GraphQLSelectionSet {
     public static let possibleTypes: [String] = [\\"Query\\"]
 
-    public static let selections: [GraphQLSelection] = [
+    public private(set) static var selections: [GraphQLSelection] = [
       GraphQLField(\\"hello\\", type: .nonNull(.scalar(String.self))),
     ]
 

--- a/packages/apollo/src/commands/client/__tests__/__snapshots__/generate.test.ts.snap
+++ b/packages/apollo/src/commands/client/__tests__/__snapshots__/generate.test.ts.snap
@@ -249,9 +249,11 @@ public final class SimpleQueryQuery: GraphQLQuery {
   public struct Data: GraphQLSelectionSet {
     public static let possibleTypes: [String] = [\\"Query\\"]
 
-    public private(set) static var selections: [GraphQLSelection] = [
-      GraphQLField(\\"hello\\", type: .nonNull(.scalar(String.self))),
-    ]
+    public static var selections: [GraphQLSelection] {
+      return [
+        GraphQLField(\\"hello\\", type: .nonNull(.scalar(String.self))),
+      ]
+    }
 
     public private(set) var resultMap: ResultMap
 
@@ -300,9 +302,11 @@ public final class SimpleQueryQuery: GraphQLQuery {
   public struct Data: GraphQLSelectionSet {
     public static let possibleTypes: [String] = [\\"Query\\"]
 
-    public private(set) static var selections: [GraphQLSelection] = [
-      GraphQLField(\\"hello\\", type: .nonNull(.scalar(String.self))),
-    ]
+    public static var selections: [GraphQLSelection] {
+      return [
+        GraphQLField(\\"hello\\", type: .nonNull(.scalar(String.self))),
+      ]
+    }
 
     public private(set) var resultMap: ResultMap
 


### PR DESCRIPTION
A workaround for [iOS #230](https://github.com/apollographql/apollo-ios/issues/230) - the way that Swift allocates `static lets` was basically eating through memory that it shouldn't been. This transitions to using a computed `static var` instead, which should alleviate the problem. 

~I did look into just making it a computed var but there were some...complications... with the formatting that I wasted far too much time on trying to make work, and this achieves the same effect with a more minimal change.~ Got it working as a computed `var` after stepping away from the code for a weekend. 