### PR TITLE
Support Union types in the exported IR typesUsed property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,16 +3,16 @@
 ## Upcoming
 
 - `apollo`
-  - Fix CLI crashing when trying to open a directory that is named like a file [#1948](https://github.com/apollographql/apollo-tooling/pull/1948).
+  - <First `apollo` related entry goes here>
 - `apollo-codegen-flow`
   - <First `apollo-codegen-flow` related entry goes here>
 - `apollo-codegen-scala`
   - <First `apollo-codegen-scala` related entry goes here>
 - `apollo-codegen-swift`
-  - Change selection sets to computed vars to remove unnecessary  memory use [#1950](https://github.com/apollographql/apollo-tooling/pull/1950)
 - `apollo-codegen-typescript`
   - <First `apollo-codegen-typescript` related entry goes here>
 - `apollo-codegen-core`
+  - Add Union types to the `typesUsed` property of the IR exported when using the `json-modern` target [#1969](https://github.com/apollographql/apollo-tooling/pull/1969).
   - <First `apollo-codegen-core` related entry goes here>
 - `apollo-env`
   - <First `apollo-env` related entry goes here>
@@ -24,6 +24,13 @@
   - <First `apollo-tools` related entry goes here>
 - `vscode-apollo`
   - <First `vscode-apollo` related entry goes here>
+
+## `apollo@2.28.0`
+
+- `apollo`
+  - Fix CLI crashing when trying to open a directory that is named like a file [#1948](https://github.com/apollographql/apollo-tooling/pull/1948).
+- `apollo-codegen-swift`
+  - Change selection sets to computed vars to remove unnecessary  memory use [#1950](https://github.com/apollographql/apollo-tooling/pull/1950)
 
 ## `apollo@2.27.3`
 

--- a/packages/apollo-codegen-core/src/__tests__/__snapshots__/jsonOutput.ts.snap
+++ b/packages/apollo-codegen-core/src/__tests__/__snapshots__/jsonOutput.ts.snap
@@ -154,6 +154,159 @@ exports[`JSON output should generate JSON output for a mutation with an enum and
 }"
 `;
 
+exports[`JSON output should generate JSON output for a query involving a union 1`] = `
+"{
+	\\"operations\\": [
+		{
+			\\"filePath\\": \\"GraphQL request\\",
+			\\"operationName\\": \\"Search\\",
+			\\"operationType\\": \\"query\\",
+			\\"rootType\\": \\"Query\\",
+			\\"variables\\": [],
+			\\"source\\": \\"query Search {\\\\n  search(text: \\\\\\"an\\\\\\") {\\\\n    __typename\\\\n    ... on Human {\\\\n      name\\\\n      height\\\\n    }\\\\n    ... on Droid {\\\\n      name\\\\n      primaryFunction\\\\n    }\\\\n    ... on Starship {\\\\n      name\\\\n      length\\\\n    }\\\\n  }\\\\n}\\",
+			\\"fields\\": [
+				{
+					\\"responseName\\": \\"search\\",
+					\\"fieldName\\": \\"search\\",
+					\\"type\\": \\"[SearchResult]\\",
+					\\"args\\": [
+						{
+							\\"name\\": \\"text\\",
+							\\"value\\": \\"an\\",
+							\\"type\\": \\"String\\"
+						}
+					],
+					\\"isConditional\\": false,
+					\\"isDeprecated\\": false,
+					\\"fields\\": [
+						{
+							\\"responseName\\": \\"__typename\\",
+							\\"fieldName\\": \\"__typename\\",
+							\\"type\\": \\"String!\\",
+							\\"isConditional\\": false
+						}
+					],
+					\\"fragmentSpreads\\": [],
+					\\"inlineFragments\\": [
+						{
+							\\"typeCondition\\": \\"Human\\",
+							\\"possibleTypes\\": [
+								\\"Human\\"
+							],
+							\\"fields\\": [
+								{
+									\\"responseName\\": \\"__typename\\",
+									\\"fieldName\\": \\"__typename\\",
+									\\"type\\": \\"String!\\",
+									\\"isConditional\\": false
+								},
+								{
+									\\"responseName\\": \\"name\\",
+									\\"fieldName\\": \\"name\\",
+									\\"type\\": \\"String!\\",
+									\\"isConditional\\": false,
+									\\"description\\": \\"What this human calls themselves\\",
+									\\"isDeprecated\\": false
+								},
+								{
+									\\"responseName\\": \\"height\\",
+									\\"fieldName\\": \\"height\\",
+									\\"type\\": \\"Float\\",
+									\\"isConditional\\": false,
+									\\"description\\": \\"Height in the preferred unit, default is meters\\",
+									\\"isDeprecated\\": false
+								}
+							],
+							\\"fragmentSpreads\\": []
+						},
+						{
+							\\"typeCondition\\": \\"Droid\\",
+							\\"possibleTypes\\": [
+								\\"Droid\\"
+							],
+							\\"fields\\": [
+								{
+									\\"responseName\\": \\"__typename\\",
+									\\"fieldName\\": \\"__typename\\",
+									\\"type\\": \\"String!\\",
+									\\"isConditional\\": false
+								},
+								{
+									\\"responseName\\": \\"name\\",
+									\\"fieldName\\": \\"name\\",
+									\\"type\\": \\"String!\\",
+									\\"isConditional\\": false,
+									\\"description\\": \\"What others call this droid\\",
+									\\"isDeprecated\\": false
+								},
+								{
+									\\"responseName\\": \\"primaryFunction\\",
+									\\"fieldName\\": \\"primaryFunction\\",
+									\\"type\\": \\"String\\",
+									\\"isConditional\\": false,
+									\\"description\\": \\"This droid's primary function\\",
+									\\"isDeprecated\\": false
+								}
+							],
+							\\"fragmentSpreads\\": []
+						},
+						{
+							\\"typeCondition\\": \\"Starship\\",
+							\\"possibleTypes\\": [
+								\\"Starship\\"
+							],
+							\\"fields\\": [
+								{
+									\\"responseName\\": \\"__typename\\",
+									\\"fieldName\\": \\"__typename\\",
+									\\"type\\": \\"String!\\",
+									\\"isConditional\\": false
+								},
+								{
+									\\"responseName\\": \\"name\\",
+									\\"fieldName\\": \\"name\\",
+									\\"type\\": \\"String!\\",
+									\\"isConditional\\": false,
+									\\"description\\": \\"The name of the starship\\",
+									\\"isDeprecated\\": false
+								},
+								{
+									\\"responseName\\": \\"length\\",
+									\\"fieldName\\": \\"length\\",
+									\\"type\\": \\"Float\\",
+									\\"isConditional\\": false,
+									\\"description\\": \\"Length of the starship, along the longest axis\\",
+									\\"isDeprecated\\": false
+								}
+							],
+							\\"fragmentSpreads\\": []
+						}
+					]
+				}
+			],
+			\\"fragmentSpreads\\": [],
+			\\"inlineFragments\\": [],
+			\\"fragmentsReferenced\\": [],
+			\\"sourceWithFragments\\": \\"query Search {\\\\n  search(text: \\\\\\"an\\\\\\") {\\\\n    __typename\\\\n    ... on Human {\\\\n      name\\\\n      height\\\\n    }\\\\n    ... on Droid {\\\\n      name\\\\n      primaryFunction\\\\n    }\\\\n    ... on Starship {\\\\n      name\\\\n      length\\\\n    }\\\\n  }\\\\n}\\",
+			\\"operationId\\": \\"9887ff0652e14d678a66769b853c41293d4afb1d1338bbbdb9f84e66979605dd\\"
+		}
+	],
+	\\"fragments\\": [],
+	\\"typesUsed\\": [
+		{
+			\\"kind\\": \\"UnionType\\",
+			\\"name\\": \\"SearchResult\\",
+			\\"description\\": \\"\\",
+			\\"types\\": [
+				\\"Human\\",
+				\\"Droid\\",
+				\\"Starship\\"
+			]
+		}
+	]
+}"
+`;
+
 exports[`JSON output should generate JSON output for a query with a fragment spread and nested inline fragments 1`] = `
 "{
 	\\"operations\\": [

--- a/packages/apollo-codegen-core/src/compiler/__tests__/legacyIR.ts
+++ b/packages/apollo-codegen-core/src/compiler/__tests__/legacyIR.ts
@@ -58,7 +58,7 @@ describe("Compiling query documents to the legacy IR", () => {
     ]);
   });
 
-  it(`should keep track of enums and input object types used in variables`, () => {
+  it(`should keep track of enums, union types, and input object types used in variables`, () => {
     const document = parse(`
       query HeroName($episode: Episode) {
         hero(episode: $episode) {
@@ -86,7 +86,12 @@ describe("Compiling query documents to the legacy IR", () => {
       compileToLegacyIR(schema, document)
     );
 
-    expect(typesUsed).toEqual(["Episode", "ReviewInput", "ColorInput"]);
+    expect(typesUsed).toEqual([
+      "Episode",
+      "SearchResult",
+      "ReviewInput",
+      "ColorInput"
+    ]);
   });
 
   it(`should keep track of enums used in fields`, () => {

--- a/packages/apollo-codegen-core/src/compiler/index.ts
+++ b/packages/apollo-codegen-core/src/compiler/index.ts
@@ -23,6 +23,7 @@ import {
   isEnumType,
   isInputObjectType,
   isScalarType,
+  isUnionType,
   NamedTypeNode,
   ListTypeNode,
   TypeNode,
@@ -225,11 +226,11 @@ class Compiler {
 
   addTypeUsed(type: GraphQLType) {
     if (this.typesUsedSet.has(type)) return;
-
     if (
       isEnumType(type) ||
       isInputObjectType(type) ||
-      (isScalarType(type) && !isSpecifiedScalarType(type))
+      (isScalarType(type) && !isSpecifiedScalarType(type)) ||
+      isUnionType(type)
     ) {
       this.typesUsedSet.add(type);
     }

--- a/packages/apollo-codegen-core/src/serializeToJSON.ts
+++ b/packages/apollo-codegen-core/src/serializeToJSON.ts
@@ -4,9 +4,11 @@ import {
   GraphQLScalarType,
   GraphQLEnumType,
   GraphQLInputObjectType,
+  GraphQLUnionType,
   isEnumType,
   isInputObjectType,
   isScalarType,
+  isUnionType,
   parseType
 } from "graphql";
 
@@ -25,7 +27,7 @@ interface serializeOptions {
 
 export default function serializeToJSON(
   context: LegacyCompilerContext | CompilerContext,
-  options: serializeOptions
+  options?: serializeOptions
 ) {
   return serializeAST(
     {
@@ -51,13 +53,15 @@ export function serializeAST(ast: any, space?: string) {
   );
 }
 
-function serializeType(type: GraphQLType, options: serializeOptions) {
+function serializeType(type: GraphQLType, options?: serializeOptions) {
   if (isEnumType(type)) {
     return serializeEnumType(type);
   } else if (isInputObjectType(type)) {
     return serializeInputObjectType(type, options);
   } else if (isScalarType(type)) {
     return serializeScalarType(type);
+  } else if (isUnionType(type)) {
+    return serializeUnionType(type);
   } else {
     throw new Error(`Unexpected GraphQL type: ${type}`);
   }
@@ -111,5 +115,16 @@ function serializeScalarType(type: GraphQLScalarType) {
     kind: "ScalarType",
     name,
     description
+  };
+}
+
+function serializeUnionType(type: GraphQLUnionType) {
+  const { name, description } = type;
+
+  return {
+    kind: "UnionType",
+    name,
+    description,
+    types: type.getTypes()
   };
 }


### PR DESCRIPTION
When using `codegen`'s `json-modern` export target, Union types will now show in the exported IR `typesUsed` property. E.g.

```json
"typesUsed": [
  {
    "kind": "UnionType",
    "name": "SearchResult",
    "types": [
      "Human",
      "Droid",
      "Starship"
    ]
  }
]
```