### PR TITLE
Prevent cli from sending git credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Upcoming
 
 - `apollo`
-  - <First `apollo` related entry goes here>
+  - Prevent cli from sending some git credentials [#1988](https://github.com/apollographql/apollo-tooling/pull/1988)
 - `apollo-codegen-flow`
   - <First `apollo-codegen-flow` related entry goes here>
 - `apollo-codegen-scala`

--- a/package-lock.json
+++ b/package-lock.json
@@ -4190,6 +4190,7 @@
         "gaze": "1.1.3",
         "git-parse": "1.0.4",
         "git-rev-sync": "2.0.0",
+        "git-url-parse": "^11.1.2",
         "glob": "7.1.5",
         "graphql": "14.0.2 - 14.2.0 || ^14.3.1",
         "graphql-tag": "2.10.3",
@@ -8883,7 +8884,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/git-up/-/git-up-4.0.1.tgz",
       "integrity": "sha512-LFTZZrBlrCrGCG07/dm1aCjjpL1z9L3+5aEeI9SBhAqSc+kiA9Or1bgZhQFNppJX6h/f5McrvJt1mQXTFm6Qrw==",
-      "dev": true,
       "requires": {
         "is-ssh": "^1.3.0",
         "parse-url": "^5.0.0"
@@ -8893,7 +8893,6 @@
       "version": "11.1.2",
       "resolved": "https://registry.npmjs.org/git-url-parse/-/git-url-parse-11.1.2.tgz",
       "integrity": "sha512-gZeLVGY8QVKMIkckncX+iCq2/L8PlwncvDFKiWkBn9EtCfYDbliRTTp6qzyQ1VMdITUfq7293zDzfpjdiGASSQ==",
-      "dev": true,
       "requires": {
         "git-up": "^4.0.0"
       }
@@ -9857,7 +9856,6 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/is-ssh/-/is-ssh-1.3.1.tgz",
       "integrity": "sha512-0eRIASHZt1E68/ixClI8bp2YK2wmBPVWEismTs6M+M099jKgrzl/3E976zIbImSIob48N2/XGe9y7ZiYdImSlg==",
-      "dev": true,
       "requires": {
         "protocols": "^1.1.0"
       }
@@ -15697,7 +15695,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/parse-path/-/parse-path-4.0.1.tgz",
       "integrity": "sha512-d7yhga0Oc+PwNXDvQ0Jv1BuWkLVPXcAoQ/WREgd6vNNoKYaW52KI+RdOFjI63wjkmps9yUE8VS4veP+AgpQ/hA==",
-      "dev": true,
       "requires": {
         "is-ssh": "^1.3.0",
         "protocols": "^1.4.0"
@@ -15716,7 +15713,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/parse-url/-/parse-url-5.0.1.tgz",
       "integrity": "sha512-flNUPP27r3vJpROi0/R3/2efgKkyXqnXwyP1KQ2U0SfFRgdizOdWfvrrvJg1LuOoxs7GQhmxJlq23IpQ/BkByg==",
-      "dev": true,
       "requires": {
         "is-ssh": "^1.3.0",
         "normalize-url": "^3.3.0",
@@ -15727,8 +15723,7 @@
         "normalize-url": {
           "version": "3.3.0",
           "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-3.3.0.tgz",
-          "integrity": "sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg==",
-          "dev": true
+          "integrity": "sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg=="
         }
       }
     },
@@ -16109,8 +16104,7 @@
     "protocols": {
       "version": "1.4.7",
       "resolved": "https://registry.npmjs.org/protocols/-/protocols-1.4.7.tgz",
-      "integrity": "sha512-Fx65lf9/YDn3hUX08XUc0J8rSux36rEsyiv21ZGUC1mOyeM3lTRpZLcrm8aAolzS4itwVfm7TAPyxC2E5zd6xg==",
-      "dev": true
+      "integrity": "sha512-Fx65lf9/YDn3hUX08XUc0J8rSux36rEsyiv21ZGUC1mOyeM3lTRpZLcrm8aAolzS4itwVfm7TAPyxC2E5zd6xg=="
     },
     "protoduck": {
       "version": "5.0.1",

--- a/packages/apollo/package.json
+++ b/packages/apollo/package.json
@@ -54,6 +54,7 @@
     "gaze": "1.1.3",
     "git-parse": "1.0.4",
     "git-rev-sync": "2.0.0",
+    "git-url-parse": "^11.1.2",
     "glob": "7.1.5",
     "graphql": "14.0.2 - 14.2.0 || ^14.3.1",
     "graphql-tag": "2.10.3",


### PR DESCRIPTION
This PR aims to fix a security issue where the CLI would send some users' git credentials to Apollo Graph Manager (AGM).

> It's important to note that although this security risk was identified, **we do not believe that any personal data was ever leaked through this**. This issue was identified internally and has been fully dealt with on the backend before this change. 

Few users were affected by this issue, and if your account was affected by this, you will also receive an email informing you.

Once the changed in this PR is released, we recommend all users upgrade to the newest version of the CLI to prevent sending any unnecessary sensitive information.

### Issue description

Apollo Graph Manager attempts to link back to a PR or a repository on GitHub or BitBucket from the Graph Manager's history page. This url comes from the CLI, who reports the git remote url. This was coming from running the equivalent of `git ls-remote --get-url` with the [git-rev-sync](https://www.npmjs.com/package/git-rev-sync) package. 

We realized that this git remote can in certain circumstances (mostly BitBucket setups using a `gitlab-ci-token` user) contain a git user and/or password.

Prior to realizing this, we weren't taking any effort on the CLI or backend services to sanitize these urls properly, and we were unintentionally storing this information.

### The fix for the CLI

This PR aims to sanitize all git urls on the CLI before being sent to the backend. We now replace git usernames/passwords that are found with `REDACTED` prior to reporting. In addition to that, any URLs with sources that are unsupported by Graph Manager (i.e. not GitHub or BitBucket) are just removed and not reported. These changes have been accompanied by a test suite.

### The fix in Apollo Graph Manager

Before releasing this PR publicly, **we have already changed** the Graph Manager servers to perform the same sanitization on its input, and we have (conservatively) removed all git URLs from our databases and database backups that were sent to us before this server change was deployed. This means that users on older versions of the CLI may still send us git credentials but we will not save them persistently.
<!--
  Thanks for filing a pull request on Apollo Tooling!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [ ] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [ ] Make sure all of the significant new logic is covered by tests
- [ ] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests and linter rules pass

\*Make sure changelog entries note which project(s) has been affected. See older entries for examples on what this looks like.
