### PR TITLE
[AR-1691] The CLI does not need to know the frontend URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Upcoming
 
 - `apollo`
-  - <First `apollo` related entry goes here>
+  - Don't send a user-specified frontend URL to Apollo's servers; fetch one when needed. Drop `--frontend` flag. [#1990](https://github.com/apollographql/apollo-tooling/pull/1990)
 - `apollo-codegen-flow`
   - <First `apollo-codegen-flow` related entry goes here>
 - `apollo-codegen-scala`
@@ -19,7 +19,7 @@
 - `apollo-graphql`
   - <First `apollo-graphql` related entry goes here>
 - `apollo-language-server`
-  - <First `apollo-language-server` related entry goes here>
+  - Don't send a user-specified frontend URL to Apollo's servers; fetch one when needed. [#1990](https://github.com/apollographql/apollo-tooling/pull/1990)
 - `apollo-tools`
   - <First `apollo-tools` related entry goes here>
 - `vscode-apollo`

--- a/apollo.config.js
+++ b/apollo.config.js
@@ -6,7 +6,6 @@ module.exports = {
     excludes: ["**/*.test.ts", "**/__tests__/*"]
   },
   engine: {
-    frontend: "https://engine-staging.apollographql.com",
     endpoint: "https://engine-staging-graphql.apollographql.com/api/graphql"
   }
 };

--- a/packages/apollo-language-server/src/config/__tests__/config.ts
+++ b/packages/apollo-language-server/src/config/__tests__/config.ts
@@ -78,8 +78,7 @@ describe("ApolloConfig", () => {
       const config = new ApolloConfig({});
       const overrides = {
         engine: {
-          endpoint: "https://test.apollographql.com/api/graphql",
-          frontend: "https://test.apollographql.com"
+          endpoint: "https://test.apollographql.com/api/graphql"
         }
       };
       config.setDefaults(overrides);

--- a/packages/apollo-language-server/src/config/__tests__/loadConfig.ts
+++ b/packages/apollo-language-server/src/config/__tests__/loadConfig.ts
@@ -111,7 +111,6 @@ describe("loadConfig", () => {
           },
           "engine": Object {
             "endpoint": "https://engine-graphql.apollographql.com/api/graphql",
-            "frontend": "https://engine.apollographql.com",
           },
         }
       `);
@@ -136,7 +135,6 @@ describe("loadConfig", () => {
         Object {
           "engine": Object {
             "endpoint": "https://engine-graphql.apollographql.com/api/graphql",
-            "frontend": "https://engine.apollographql.com",
           },
           "service": Object {
             "endpoint": Object {

--- a/packages/apollo-language-server/src/config/config.ts
+++ b/packages/apollo-language-server/src/config/config.ts
@@ -33,13 +33,11 @@ export interface LocalServiceConfig {
 
 export interface EngineConfig {
   endpoint?: EndpointURI;
-  frontend?: EndpointURI;
   readonly apiKey?: string;
 }
 
 export const DefaultEngineConfig = {
-  endpoint: "https://engine-graphql.apollographql.com/api/graphql",
-  frontend: "https://engine.apollographql.com"
+  endpoint: "https://engine-graphql.apollographql.com/api/graphql"
 };
 
 export const DefaultConfigBase = {

--- a/packages/apollo-language-server/src/engine/index.ts
+++ b/packages/apollo-language-server/src/engine/index.ts
@@ -98,7 +98,7 @@ export class ApolloEngineClient extends GraphQLDataSource {
       if (!(data && data.service)) {
         throw new Error("Error in request from Apollo Graph Manager");
       }
-      return data.service;
+      return data;
     });
   }
 

--- a/packages/apollo-language-server/src/engine/operations/checkPartialSchema.ts
+++ b/packages/apollo-language-server/src/engine/operations/checkPartialSchema.ts
@@ -8,7 +8,6 @@ export const CHECK_PARTIAL_SCHEMA = gql`
     $partialSchema: PartialSchemaInput!
     $gitContext: GitContextInput
     $historicParameters: HistoricQueryParameters
-    $frontend: String
   ) {
     service(id: $id) {
       checkPartialSchema(
@@ -17,7 +16,6 @@ export const CHECK_PARTIAL_SCHEMA = gql`
         partialSchema: $partialSchema
         gitContext: $gitContext
         historicParameters: $historicParameters
-        frontend: $frontend
       ) {
         compositionValidationResult {
           compositionValidationDetails {

--- a/packages/apollo-language-server/src/engine/operations/checkSchema.ts
+++ b/packages/apollo-language-server/src/engine/operations/checkSchema.ts
@@ -8,7 +8,6 @@ export const CHECK_SCHEMA = gql`
     $tag: String
     $gitContext: GitContextInput
     $historicParameters: HistoricQueryParameters
-    $frontend: String
   ) {
     service(id: $id) {
       checkSchema(
@@ -17,7 +16,6 @@ export const CHECK_SCHEMA = gql`
         baseSchemaTag: $tag
         gitContext: $gitContext
         historicParameters: $historicParameters
-        frontend: $frontend
       ) {
         targetUrl
         diffToPrevious {

--- a/packages/apollo-language-server/src/engine/operations/listServices.ts
+++ b/packages/apollo-language-server/src/engine/operations/listServices.ts
@@ -2,6 +2,7 @@ import gql from "graphql-tag";
 
 export const LIST_SERVICES = gql`
   query ListServices($id: ID!, $graphVariant: String!) {
+    frontendUrlRoot
     service(id: $id) {
       implementingServices(graphVariant: $graphVariant) {
         __typename

--- a/packages/apollo-language-server/src/graphqlTypes.ts
+++ b/packages/apollo-language-server/src/graphqlTypes.ts
@@ -166,7 +166,6 @@ export interface CheckPartialSchemaVariables {
   partialSchema: PartialSchemaInput;
   gitContext?: GitContextInput | null;
   historicParameters?: HistoricQueryParameters | null;
-  frontend?: string | null;
 }
 
 /* tslint:disable */
@@ -296,7 +295,6 @@ export interface CheckSchemaVariables {
   tag?: string | null;
   gitContext?: GitContextInput | null;
   historicParameters?: HistoricQueryParameters | null;
-  frontend?: string | null;
 }
 
 /* tslint:disable */
@@ -355,6 +353,7 @@ export interface ListServices_service {
 }
 
 export interface ListServices {
+  frontendUrlRoot: string;
   /**
    * Service by ID
    */

--- a/packages/apollo/src/Command.ts
+++ b/packages/apollo/src/Command.ts
@@ -35,7 +35,6 @@ export interface Flags {
   localSchemaFile?: string;
   key?: string;
   engine?: string;
-  frontend?: string;
   tag?: string;
   variant?: string;
   graph?: string;
@@ -88,10 +87,6 @@ export abstract class ProjectCommand extends Command {
     }),
     engine: flags.string({
       description: "URL for a custom Apollo Graph Manager deployment",
-      hidden: true
-    }),
-    frontend: flags.string({
-      description: "URL for a custom Apollo Graph Manager frontend",
       hidden: true
     })
   };
@@ -161,8 +156,7 @@ export abstract class ProjectCommand extends Command {
     config.setDefaults({
       engine: {
         apiKey: flags.key,
-        endpoint: flags.engine,
-        frontend: flags.frontend
+        endpoint: flags.engine
       }
     });
 

--- a/packages/apollo/src/commands/service/__tests__/list.test.ts
+++ b/packages/apollo/src/commands/service/__tests__/list.test.ts
@@ -102,6 +102,7 @@ function mockServiceListFederated() {
     )
     .reply(200, {
       data: {
+        frontendUrlRoot: "https://engine-staging.apollographql.com",
         service: {
           implementingServices: {
             services: [
@@ -158,6 +159,7 @@ function mockServiceListNonFederated() {
     )
     .reply(200, {
       data: {
+        frontendUrlRoot: "https://engine-staging.apollographql.com",
         service: {
           implementingServices: {
             services: [],

--- a/packages/apollo/src/commands/service/check.ts
+++ b/packages/apollo/src/commands/service/check.ts
@@ -374,7 +374,6 @@ export default class ServiceCheck extends ProjectCommand {
                   partialSchema: {
                     sdl
                   },
-                  frontend: flags.frontend || config.engine.frontend,
                   ...(historicParameters && { historicParameters }),
                   gitContext: await gitInfo(this.log)
                 });
@@ -468,7 +467,6 @@ export default class ServiceCheck extends ProjectCommand {
                   id: graphID!,
                   tag: config.variant,
                   gitContext: await gitInfo(this.log),
-                  frontend: flags.frontend || config.engine.frontend,
                   ...(historicParameters && { historicParameters }),
                   ...schemaCheckSchemaVariables
                 };

--- a/packages/apollo/src/commands/service/list.ts
+++ b/packages/apollo/src/commands/service/list.ts
@@ -14,6 +14,7 @@ import { graphUndefinedError } from "../../utils/sharedMessages";
 interface TasksOutput {
   config: ApolloConfig;
   implementingServices: ListServices_service_implementingServices | null;
+  frontendUrlRoot: string;
 }
 
 const formatImplementingService = (
@@ -32,11 +33,11 @@ const formatImplementingService = (
 function formatHumanReadable({
   implementingServices,
   graphName,
-  frontendUrl
+  frontendUrlRoot
 }: {
   implementingServices: ListServices_service_implementingServices | null;
   graphName: string | undefined;
-  frontendUrl: string | undefined;
+  frontendUrlRoot: string;
 }): string {
   let result = "";
   if (
@@ -76,7 +77,7 @@ function formatHumanReadable({
     );
 
     const serviceListUrlEnding = `/graph/${graphName}/service-list`;
-    const targetUrl = `${frontendUrl}${serviceListUrlEnding}`;
+    const targetUrl = `${frontendUrlRoot}${serviceListUrlEnding}`;
     result += `\nView full details at: ${chalk.cyan(targetUrl)}\n`;
   }
   return result;
@@ -134,13 +135,16 @@ export default class ServiceList extends ProjectCommand {
             )}`,
             task: async (ctx: TasksOutput, task) => {
               const {
-                implementingServices
+                frontendUrlRoot,
+                service
               } = await project.engine.listServices({
                 id: graphID!,
                 graphVariant: graphVariant!
               });
+              const { implementingServices } = service!;
               const newContext: typeof ctx = {
                 implementingServices,
+                frontendUrlRoot,
                 config
               };
 
@@ -162,8 +166,7 @@ export default class ServiceList extends ProjectCommand {
       formatHumanReadable({
         implementingServices: taskOutput.implementingServices,
         graphName: taskOutput.config.graph,
-        frontendUrl:
-          taskOutput.config.engine.frontend || DefaultEngineConfig.frontend
+        frontendUrlRoot: taskOutput.frontendUrlRoot
       })
     );
   }


### PR DESCRIPTION
Currently the CLI has configuration (via `engine.frontend` in a config file or
the --frontend flag to a few commands) to control what Engine frontend the user
is using. This is primarily set by Apollo employees using staging servers. This
is in addition to setting `engine.endpoint` to control which GraphQL server it
talks to.

This is used for two things:
- passing arguments to a couple ServiceMutation fields
- printing links in `services:list`

As of recently, this no longer is needed:
- those ServiceMutation fields now ignore the `frontend` argument and just use
  the correct frontend for the server processing them
- we expose a Query.frontendUrlRoot field that `services:list` can use

So this change completely removes recognition of this config field as well as
the flag. (Note that it is not an error to have unrecognized fields in your
config file, though it is to pass an unknown flag.) While this is technically
backwards-incompatible, we don't expect that this undocumented feature is used
much other than by Apollo employees.

<!--
  Thanks for filing a pull request on Apollo Tooling!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [ ] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [ ] Make sure all of the significant new logic is covered by tests
- [ ] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests and linter rules pass

\*Make sure changelog entries note which project(s) has been affected. See older entries for examples on what this looks like.
