### PR TITLE
Fix definition navigation for vscode using localSchemaFile (missing file url)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 - `apollo-graphql`
   - <First `apollo-graphql` related entry goes here>
 - `apollo-language-server`
-  - <First `apollo-language-server` related entry goes here>
+  - Fix definition navigation for vscode using localSchemaFile [#1996](https://github.com/apollographql/apollo-tooling/pull/1996)
 - `apollo-tools`
   - <First `apollo-tools` related entry goes here>
 - `vscode-apollo`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
 - `apollo-tools`
   - <First `apollo-tools` related entry goes here>
 - `vscode-apollo`
-  - <First `vscode-apollo` related entry goes here>
+  - Fix definition navigation for vscode using localSchemaFile [#1996](https://github.com/apollographql/apollo-tooling/pull/1996)
 
 ## `apollo@2.28.2`
 

--- a/packages/apollo-language-server/src/providers/schema/file.ts
+++ b/packages/apollo-language-server/src/providers/schema/file.ts
@@ -19,6 +19,7 @@ import {
   composeServices,
   printSchema as printFederatedSchema
 } from "@apollo/federation";
+import URI from "vscode-uri";
 // import federationDirectives from "@apollo/federation/src/directives";
 
 export interface FileSchemaProviderConfig {
@@ -82,7 +83,8 @@ export class FileSchemaProvider implements GraphQLSchemaProvider {
       const schema = buildClientSchema({ __schema });
       return parse(printSchema(schema));
     } else if (ext === ".graphql" || ext === ".graphqls" || ext === ".gql") {
-      return parse(result);
+      const uri = URI.file(resolve(path)).toString();
+      return parse(new Source(result, uri));
     }
     throw new Error(
       "File Type not supported for schema loading. Must be a .json, .graphql, .gql, or .graphqls file"


### PR DESCRIPTION
Fixes #1995 

- [x] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
