### PR TITLE
Hardcode $COLUMNS when running oclif-dev readme

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6779,6 +6779,58 @@
         "parse-json": "^4.0.0"
       }
     },
+    "cross-env": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.2.tgz",
+      "integrity": "sha512-KZP/bMEOJEDCkDQAyRhu3RL2ZO/SUVrxQVI0G3YEQ+OLbRA3c6zgixe8Mq8a/z7+HKlNEjo8oiLUs8iRijY2Rw==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.1"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+          "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
+          }
+        },
+        "path-key": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+          "dev": true
+        },
+        "shebang-command": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^3.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+          "dev": true
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
+      }
+    },
     "cross-spawn": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "@types/node": "8.10.61",
     "@types/node-fetch": "2.5.7",
     "@types/table": "4.0.7",
+    "cross-env": "^7.0.2",
     "graphql": "14.5.7",
     "heroku-cli-util": "8.0.12",
     "husky": "3.1.0",

--- a/packages/apollo/README.md
+++ b/packages/apollo/README.md
@@ -60,38 +60,52 @@ USAGE
   $ apollo client:check
 
 OPTIONS
-  -c, --config=config                    Path to your Apollo config file
+  -c, --config=config
+      Path to your Apollo config file
 
-  -g, --graph=graph                      The ID for the graph in Apollo Graph Manager to operate client commands with.
-                                         Overrides config file if set.
+  -g, --graph=graph
+      The ID for the graph in Apollo Graph Manager to operate client 
+      commands with. Overrides config file if set.
 
-  -v, --variant=variant                  The variant of the graph in Apollo Graph Manager to associate this client to
+  -v, --variant=variant
+      The variant of the graph in Apollo Graph Manager to associate this 
+      client to
 
-  --clientName=clientName                Name of the client that the queries will be attached to
+  --clientName=clientName
+      Name of the client that the queries will be attached to
 
-  --clientReferenceId=clientReferenceId  Reference id for the client which will match ids from client traces, will use
-                                         clientName if not provided
+  --clientReferenceId=clientReferenceId
+      Reference id for the client which will match ids from client traces, 
+      will use clientName if not provided
 
-  --clientVersion=clientVersion          The version of the client that the queries will be attached to
+  --clientVersion=clientVersion
+      The version of the client that the queries will be attached to
 
-  --endpoint=endpoint                    The URL for the CLI use to introspect your service
+  --endpoint=endpoint
+      The URL for the CLI use to introspect your service
 
-  --excludes=excludes                    Glob of files to exclude for GraphQL operations. Caveat: this doesn't currently
-                                         work in watch mode
+  --excludes=excludes
+      Glob of files to exclude for GraphQL operations. Caveat: this doesn't 
+      currently work in watch mode
 
-  --header=header                        Additional header to send to server for introspectionQuery. May be used
-                                         multiple times to add multiple headers. NOTE: The `--endpoint` flag is REQUIRED
-                                         if using the `--header` flag.
+  --header=header
+      Additional header to send to server for introspectionQuery. May be 
+      used multiple times to add multiple headers. NOTE: The `--endpoint` 
+      flag is REQUIRED if using the `--header` flag.
 
-  --includes=includes                    Glob of files to search for GraphQL operations. This should be used to find
-                                         queries *and* any client schema extensions
+  --includes=includes
+      Glob of files to search for GraphQL operations. This should be used to 
+      find queries *and* any client schema extensions
 
-  --key=key                              The API key to use for authentication to Apollo Graph Manager
+  --key=key
+      The API key to use for authentication to Apollo Graph Manager
 
-  --queries=queries                      Deprecated in favor of the includes flag
+  --queries=queries
+      Deprecated in favor of the includes flag
 
-  --tagName=tagName                      Name of the template literal tag used to identify template literals containing
-                                         GraphQL queries in Javascript/Typescript code
+  --tagName=tagName
+      Name of the template literal tag used to identify template literals 
+      containing GraphQL queries in Javascript/Typescript code
 ```
 
 _See code: [src/commands/client/check.ts](https://github.com/apollographql/apollo-tooling/blob/master/packages/apollo/src/commands/client/check.ts)_
@@ -107,99 +121,136 @@ USAGE
 ARGUMENTS
   OUTPUT
       Directory to which generated files will be written.
-      - For TypeScript/Flow generators, this specifies a directory relative to each source file by default.
-      - For TypeScript/Flow generators with the "outputFlat" flag is set, and for the Swift generator, this specifies a 
-      file or directory (absolute or relative to the current working directory) to which:
-         - a file will be written for each query (if "output" is a directory)
+      - For TypeScript/Flow generators, this specifies a directory relative 
+      to each source file by default.
+      - For TypeScript/Flow generators with the "outputFlat" flag is set, 
+      and for the Swift generator, this specifies a file or directory 
+      (absolute or relative to the current working directory) to which:
+         - a file will be written for each query (if "output" is a 
+      directory)
          - all generated types will be written
-      - For all other types, this defines a file (absolute or relative to the current working directory) to which all 
-      generated types are written.
+      - For all other types, this defines a file (absolute or relative to 
+      the current working directory) to which all generated types are 
+      written.
 
 OPTIONS
-  -c, --config=config                        Path to your Apollo config file
+  -c, --config=config
+      Path to your Apollo config file
 
-  -g, --graph=graph                          The ID for the graph in Apollo Graph Manager to operate client commands
-                                             with. Overrides config file if set.
+  -g, --graph=graph
+      The ID for the graph in Apollo Graph Manager to operate client 
+      commands with. Overrides config file if set.
 
-  -v, --variant=variant                      The variant of the graph in Apollo Graph Manager to associate this client
-                                             to
+  -v, --variant=variant
+      The variant of the graph in Apollo Graph Manager to associate this 
+      client to
 
-  --[no-]addTypename                         [default: true] Automatically add __typename to your queries, can be unset
-                                             with --no-addTypename
+  --[no-]addTypename
+      [default: true] Automatically add __typename to your queries, can be 
+      unset with --no-addTypename
 
-  --clientName=clientName                    Name of the client that the queries will be attached to
+  --clientName=clientName
+      Name of the client that the queries will be attached to
 
-  --clientReferenceId=clientReferenceId      Reference id for the client which will match ids from client traces, will
-                                             use clientName if not provided
+  --clientReferenceId=clientReferenceId
+      Reference id for the client which will match ids from client traces, 
+      will use clientName if not provided
 
-  --clientVersion=clientVersion              The version of the client that the queries will be attached to
+  --clientVersion=clientVersion
+      The version of the client that the queries will be attached to
 
-  --customScalarsPrefix=customScalarsPrefix  Include a prefix when using provided types for custom scalars
+  --customScalarsPrefix=customScalarsPrefix
+      Include a prefix when using provided types for custom scalars
 
-  --endpoint=endpoint                        The URL for the CLI use to introspect your service
+  --endpoint=endpoint
+      The URL for the CLI use to introspect your service
 
-  --excludes=excludes                        Glob of files to exclude for GraphQL operations. Caveat: this doesn't
-                                             currently work in watch mode
+  --excludes=excludes
+      Glob of files to exclude for GraphQL operations. Caveat: this doesn't 
+      currently work in watch mode
 
-  --globalTypesFile=globalTypesFile          By default, TypeScript will put a file named "globalTypes.ts" inside the
-                                             "output" directory. Set "globalTypesFile" to specify a different path.
-                                             Alternatively, set "tsFileExtension" to modify the extension of the file,
-                                             for example "d.ts" will output "globalTypes.d.ts"
+  --globalTypesFile=globalTypesFile
+      By default, TypeScript will put a file named "globalTypes.ts" inside 
+      the "output" directory. Set "globalTypesFile" to specify a different 
+      path. Alternatively, set "tsFileExtension" to modify the extension of 
+      the file, for example "d.ts" will output "globalTypes.d.ts"
 
-  --header=header                            Additional header to send to server for introspectionQuery. May be used
-                                             multiple times to add multiple headers. NOTE: The `--endpoint` flag is
-                                             REQUIRED if using the `--header` flag.
+  --header=header
+      Additional header to send to server for introspectionQuery. May be 
+      used multiple times to add multiple headers. NOTE: The `--endpoint` 
+      flag is REQUIRED if using the `--header` flag.
 
-  --includes=includes                        Glob of files to search for GraphQL operations. This should be used to find
-                                             queries *and* any client schema extensions
+  --includes=includes
+      Glob of files to search for GraphQL operations. This should be used to 
+      find queries *and* any client schema extensions
 
-  --key=key                                  The API key to use for authentication to Apollo Graph Manager
+  --key=key
+      The API key to use for authentication to Apollo Graph Manager
 
-  --localSchemaFile=localSchemaFile          Path to one or more local GraphQL schema file(s), as introspection result
-                                             or SDL. Supports comma-separated list of paths (ex.
-                                             `--localSchemaFile=schema.graphql,extensions.graphql`)
+  --localSchemaFile=localSchemaFile
+      Path to one or more local GraphQL schema file(s), as introspection 
+      result or SDL. Supports comma-separated list of paths (ex. 
+      `--localSchemaFile=schema.graphql,extensions.graphql`)
 
-  --mergeInFieldsFromFragmentSpreads         Merge fragment fields onto its enclosing type
+  --mergeInFieldsFromFragmentSpreads
+      Merge fragment fields onto its enclosing type
 
-  --namespace=namespace                      The namespace to emit generated code into.
+  --namespace=namespace
+      The namespace to emit generated code into.
 
-  --omitDeprecatedEnumCases                  Omit deprecated enum cases from generated code [Swift only]
+  --omitDeprecatedEnumCases
+      Omit deprecated enum cases from generated code [Swift only]
 
-  --only=only                                Parse all input files, but only output generated code for the specified
-                                             file [Swift only]
+  --only=only
+      Parse all input files, but only output generated code for the 
+      specified file [Swift only]
 
-  --operationIdsPath=operationIdsPath        Path to an operation id JSON map file. If specified, also stores the
-                                             operation ids (hashes) as properties on operation types [currently
-                                             Swift-only]
+  --operationIdsPath=operationIdsPath
+      Path to an operation id JSON map file. If specified, also stores the 
+      operation ids (hashes) as properties on operation types [currently 
+      Swift-only]
 
-  --outputFlat                               By default, TypeScript/Flow will put each generated file in a directory
-                                             next to its source file using the value of the "output" as the directory
-                                             name. Set "outputFlat" to put all generated files in the directory relative
-                                             to the current working directory defined by "output".
+  --outputFlat
+      By default, TypeScript/Flow will put each generated file in a 
+      directory next to its source file using the value of the "output" as 
+      the directory name. Set "outputFlat" to put all generated files in the 
+      directory relative to the current working directory defined by 
+      "output".
 
-  --passthroughCustomScalars                 Use your own types for custom scalars
+  --passthroughCustomScalars
+      Use your own types for custom scalars
 
-  --queries=queries                          Deprecated in favor of the includes flag
+  --queries=queries
+      Deprecated in favor of the includes flag
 
-  --suppressSwiftMultilineStringLiterals     Prevents operations from being rendered as multiline strings [Swift only]
+  --suppressSwiftMultilineStringLiterals
+      Prevents operations from being rendered as multiline strings [Swift 
+      only]
 
-  --tagName=tagName                          Name of the template literal tag used to identify template literals
-                                             containing GraphQL queries in Javascript/Typescript code
+  --tagName=tagName
+      Name of the template literal tag used to identify template literals 
+      containing GraphQL queries in Javascript/Typescript code
 
-  --target=target                            (required) Type of code generator to use (swift | typescript | flow | scala
-                                             | json | json-modern (exposes raw json types))
+  --target=target
+      (required) Type of code generator to use (swift | typescript | flow | 
+      scala | json | json-modern (exposes raw json types))
 
-  --tsFileExtension=tsFileExtension          By default, TypeScript will output "ts" files. Set "tsFileExtension" to
-                                             specify a different file extension, for example "d.ts"
+  --tsFileExtension=tsFileExtension
+      By default, TypeScript will output "ts" files. Set "tsFileExtension" 
+      to specify a different file extension, for example "d.ts"
 
-  --useFlowExactObjects                      Use Flow exact objects for generated types [flow only]
+  --useFlowExactObjects
+      Use Flow exact objects for generated types [flow only]
 
-  --useFlowReadOnlyTypes                     Use read only types for generated types [flow only]. **Deprecated in favor
-                                             of `useReadOnlyTypes`.**
+  --useFlowReadOnlyTypes
+      Use read only types for generated types [flow only]. **Deprecated in 
+      favor of `useReadOnlyTypes`.**
 
-  --useReadOnlyTypes                         Use read only types for generated types [flow | typescript]
+  --useReadOnlyTypes
+      Use read only types for generated types [flow | typescript]
 
-  --watch                                    Watch for file changes and reload codegen
+  --watch
+      Watch for file changes and reload codegen
 
 ALIASES
   $ apollo codegen:generate
@@ -216,42 +267,56 @@ USAGE
   $ apollo client:download-schema OUTPUT
 
 ARGUMENTS
-  OUTPUT  [default: schema.json] Path to write the introspection result to. Can be `.graphql`, `.gql`, `.graphqls`, or
-          `.json`
+  OUTPUT  [default: schema.json] Path to write the introspection result
+          to. Can be `.graphql`, `.gql`, `.graphqls`, or `.json`
 
 OPTIONS
-  -c, --config=config                    Path to your Apollo config file
+  -c, --config=config
+      Path to your Apollo config file
 
-  -g, --graph=graph                      The ID for the graph in Apollo Graph Manager to operate client commands with.
-                                         Overrides config file if set.
+  -g, --graph=graph
+      The ID for the graph in Apollo Graph Manager to operate client 
+      commands with. Overrides config file if set.
 
-  -v, --variant=variant                  The variant of the graph in Apollo Graph Manager to associate this client to
+  -v, --variant=variant
+      The variant of the graph in Apollo Graph Manager to associate this 
+      client to
 
-  --clientName=clientName                Name of the client that the queries will be attached to
+  --clientName=clientName
+      Name of the client that the queries will be attached to
 
-  --clientReferenceId=clientReferenceId  Reference id for the client which will match ids from client traces, will use
-                                         clientName if not provided
+  --clientReferenceId=clientReferenceId
+      Reference id for the client which will match ids from client traces, 
+      will use clientName if not provided
 
-  --clientVersion=clientVersion          The version of the client that the queries will be attached to
+  --clientVersion=clientVersion
+      The version of the client that the queries will be attached to
 
-  --endpoint=endpoint                    The URL for the CLI use to introspect your service
+  --endpoint=endpoint
+      The URL for the CLI use to introspect your service
 
-  --excludes=excludes                    Glob of files to exclude for GraphQL operations. Caveat: this doesn't currently
-                                         work in watch mode
+  --excludes=excludes
+      Glob of files to exclude for GraphQL operations. Caveat: this doesn't 
+      currently work in watch mode
 
-  --header=header                        Additional header to send to server for introspectionQuery. May be used
-                                         multiple times to add multiple headers. NOTE: The `--endpoint` flag is REQUIRED
-                                         if using the `--header` flag.
+  --header=header
+      Additional header to send to server for introspectionQuery. May be 
+      used multiple times to add multiple headers. NOTE: The `--endpoint` 
+      flag is REQUIRED if using the `--header` flag.
 
-  --includes=includes                    Glob of files to search for GraphQL operations. This should be used to find
-                                         queries *and* any client schema extensions
+  --includes=includes
+      Glob of files to search for GraphQL operations. This should be used to 
+      find queries *and* any client schema extensions
 
-  --key=key                              The API key to use for authentication to Apollo Graph Manager
+  --key=key
+      The API key to use for authentication to Apollo Graph Manager
 
-  --queries=queries                      Deprecated in favor of the includes flag
+  --queries=queries
+      Deprecated in favor of the includes flag
 
-  --tagName=tagName                      Name of the template literal tag used to identify template literals containing
-                                         GraphQL queries in Javascript/Typescript code
+  --tagName=tagName
+      Name of the template literal tag used to identify template literals 
+      containing GraphQL queries in Javascript/Typescript code
 ```
 
 _See code: [src/commands/client/download-schema.ts](https://github.com/apollographql/apollo-tooling/blob/master/packages/apollo/src/commands/client/download-schema.ts)_
@@ -268,44 +333,60 @@ ARGUMENTS
   OUTPUT  [default: manifest.json] Path to write the extracted queries to
 
 OPTIONS
-  -c, --config=config                    Path to your Apollo config file
+  -c, --config=config
+      Path to your Apollo config file
 
-  -g, --graph=graph                      The ID for the graph in Apollo Graph Manager to operate client commands with.
-                                         Overrides config file if set.
+  -g, --graph=graph
+      The ID for the graph in Apollo Graph Manager to operate client 
+      commands with. Overrides config file if set.
 
-  -v, --variant=variant                  The variant of the graph in Apollo Graph Manager to associate this client to
+  -v, --variant=variant
+      The variant of the graph in Apollo Graph Manager to associate this 
+      client to
 
-  --clientName=clientName                Name of the client that the queries will be attached to
+  --clientName=clientName
+      Name of the client that the queries will be attached to
 
-  --clientReferenceId=clientReferenceId  Reference id for the client which will match ids from client traces, will use
-                                         clientName if not provided
+  --clientReferenceId=clientReferenceId
+      Reference id for the client which will match ids from client traces, 
+      will use clientName if not provided
 
-  --clientVersion=clientVersion          The version of the client that the queries will be attached to
+  --clientVersion=clientVersion
+      The version of the client that the queries will be attached to
 
-  --endpoint=endpoint                    The URL for the CLI use to introspect your service
+  --endpoint=endpoint
+      The URL for the CLI use to introspect your service
 
-  --excludes=excludes                    Glob of files to exclude for GraphQL operations. Caveat: this doesn't currently
-                                         work in watch mode
+  --excludes=excludes
+      Glob of files to exclude for GraphQL operations. Caveat: this doesn't 
+      currently work in watch mode
 
-  --header=header                        Additional header to send to server for introspectionQuery. May be used
-                                         multiple times to add multiple headers. NOTE: The `--endpoint` flag is REQUIRED
-                                         if using the `--header` flag.
+  --header=header
+      Additional header to send to server for introspectionQuery. May be 
+      used multiple times to add multiple headers. NOTE: The `--endpoint` 
+      flag is REQUIRED if using the `--header` flag.
 
-  --includes=includes                    Glob of files to search for GraphQL operations. This should be used to find
-                                         queries *and* any client schema extensions
+  --includes=includes
+      Glob of files to search for GraphQL operations. This should be used to 
+      find queries *and* any client schema extensions
 
-  --key=key                              The API key to use for authentication to Apollo Graph Manager
+  --key=key
+      The API key to use for authentication to Apollo Graph Manager
 
-  --preserveStringAndNumericLiterals     Disable redaction of string and numerical literals.  Without this flag, these
-                                         values will be replaced with empty strings (`''`) and zeroes (`0`)
-                                         respectively.  This redaction is intended to avoid  inadvertently outputting
-                                         potentially personally identifiable information (e.g. embedded passwords  or
-                                         API keys) into operation manifests
+  --preserveStringAndNumericLiterals
+      Disable redaction of string and numerical literals.  Without this 
+      flag, these values will be replaced with empty strings (`''`) and 
+      zeroes (`0`) respectively.  This redaction is intended to avoid  
+      inadvertently outputting potentially personally identifiable 
+      information (e.g. embedded passwords  or API keys) into operation 
+      manifests
 
-  --queries=queries                      Deprecated in favor of the includes flag
+  --queries=queries
+      Deprecated in favor of the includes flag
 
-  --tagName=tagName                      Name of the template literal tag used to identify template literals containing
-                                         GraphQL queries in Javascript/Typescript code
+  --tagName=tagName
+      Name of the template literal tag used to identify template literals 
+      containing GraphQL queries in Javascript/Typescript code
 ```
 
 _See code: [src/commands/client/extract.ts](https://github.com/apollographql/apollo-tooling/blob/master/packages/apollo/src/commands/client/extract.ts)_
@@ -319,38 +400,52 @@ USAGE
   $ apollo client:push
 
 OPTIONS
-  -c, --config=config                    Path to your Apollo config file
+  -c, --config=config
+      Path to your Apollo config file
 
-  -g, --graph=graph                      The ID for the graph in Apollo Graph Manager to operate client commands with.
-                                         Overrides config file if set.
+  -g, --graph=graph
+      The ID for the graph in Apollo Graph Manager to operate client 
+      commands with. Overrides config file if set.
 
-  -v, --variant=variant                  The variant of the graph in Apollo Graph Manager to associate this client to
+  -v, --variant=variant
+      The variant of the graph in Apollo Graph Manager to associate this 
+      client to
 
-  --clientName=clientName                Name of the client that the queries will be attached to
+  --clientName=clientName
+      Name of the client that the queries will be attached to
 
-  --clientReferenceId=clientReferenceId  Reference id for the client which will match ids from client traces, will use
-                                         clientName if not provided
+  --clientReferenceId=clientReferenceId
+      Reference id for the client which will match ids from client traces, 
+      will use clientName if not provided
 
-  --clientVersion=clientVersion          The version of the client that the queries will be attached to
+  --clientVersion=clientVersion
+      The version of the client that the queries will be attached to
 
-  --endpoint=endpoint                    The URL for the CLI use to introspect your service
+  --endpoint=endpoint
+      The URL for the CLI use to introspect your service
 
-  --excludes=excludes                    Glob of files to exclude for GraphQL operations. Caveat: this doesn't currently
-                                         work in watch mode
+  --excludes=excludes
+      Glob of files to exclude for GraphQL operations. Caveat: this doesn't 
+      currently work in watch mode
 
-  --header=header                        Additional header to send to server for introspectionQuery. May be used
-                                         multiple times to add multiple headers. NOTE: The `--endpoint` flag is REQUIRED
-                                         if using the `--header` flag.
+  --header=header
+      Additional header to send to server for introspectionQuery. May be 
+      used multiple times to add multiple headers. NOTE: The `--endpoint` 
+      flag is REQUIRED if using the `--header` flag.
 
-  --includes=includes                    Glob of files to search for GraphQL operations. This should be used to find
-                                         queries *and* any client schema extensions
+  --includes=includes
+      Glob of files to search for GraphQL operations. This should be used to 
+      find queries *and* any client schema extensions
 
-  --key=key                              The API key to use for authentication to Apollo Graph Manager
+  --key=key
+      The API key to use for authentication to Apollo Graph Manager
 
-  --queries=queries                      Deprecated in favor of the includes flag
+  --queries=queries
+      Deprecated in favor of the includes flag
 
-  --tagName=tagName                      Name of the template literal tag used to identify template literals containing
-                                         GraphQL queries in Javascript/Typescript code
+  --tagName=tagName
+      Name of the template literal tag used to identify template literals 
+      containing GraphQL queries in Javascript/Typescript code
 ```
 
 _See code: [src/commands/client/push.ts](https://github.com/apollographql/apollo-tooling/blob/master/packages/apollo/src/commands/client/push.ts)_
@@ -410,9 +505,11 @@ DESCRIPTION
 
   Installation of a user-installed plugin will override a core plugin.
 
-  e.g. If you have a core plugin that has a 'hello' command, installing a user-installed plugin with a 'hello' command 
-  will override the core plugin implementation. This is useful if a user needs to update core plugin functionality in 
-  the CLI without the need to patch and update the whole CLI.
+  e.g. If you have a core plugin that has a 'hello' command, installing a 
+  user-installed plugin with a 'hello' command will override the core 
+  plugin implementation. This is useful if a user needs to update core 
+  plugin functionality in the CLI without the need to patch and update the 
+  whole CLI.
 
 ALIASES
   $ apollo plugins:add
@@ -441,10 +538,13 @@ OPTIONS
   -v, --verbose
 
 DESCRIPTION
-  Installation of a linked plugin will override a user-installed or core plugin.
+  Installation of a linked plugin will override a user-installed or core 
+  plugin.
 
-  e.g. If you have a user-installed or core plugin that has a 'hello' command, installing a linked plugin with a 'hello' 
-  command will override the user-installed or core plugin implementation. This is useful for development work.
+  e.g. If you have a user-installed or core plugin that has a 'hello' 
+  command, installing a linked plugin with a 'hello' command will override 
+  the user-installed or core plugin implementation. This is useful for 
+  development work.
 
 EXAMPLE
   $ apollo plugins:link myplugin
@@ -498,53 +598,61 @@ USAGE
   $ apollo service:check
 
 OPTIONS
-  -c, --config=config                                            Path to your Apollo config file
+  -c, --config=config
+      Path to your Apollo config file
 
-  -g, --graph=graph                                              The ID of the graph in Apollo Graph Manager to check
-                                                                 your proposed schema changes against. Overrides config
-                                                                 file if set.
+  -g, --graph=graph
+      The ID of the graph in Apollo Graph Manager to check your proposed 
+      schema changes against. Overrides config file if set.
 
-  -v, --variant=variant                                          The variant to check the proposed schema against
+  -v, --variant=variant
+      The variant to check the proposed schema against
 
-  --endpoint=endpoint                                            The URL for the CLI use to introspect your service
+  --endpoint=endpoint
+      The URL for the CLI use to introspect your service
 
-  --header=header                                                Additional header to send to server for
-                                                                 introspectionQuery. May be used multiple times to add
-                                                                 multiple headers. NOTE: The `--endpoint` flag is
-                                                                 REQUIRED if using the `--header` flag.
+  --header=header
+      Additional header to send to server for introspectionQuery. May be 
+      used multiple times to add multiple headers. NOTE: The `--endpoint` 
+      flag is REQUIRED if using the `--header` flag.
 
-  --ignoreFailures                                               Exit with status 0 when the check completes, even if
-                                                                 errors are found
+  --ignoreFailures
+      Exit with status 0 when the check completes, even if errors are found
 
-  --json                                                         Output result in json, which can then be parsed by CLI
-                                                                 tools such as jq.
+  --json
+      Output result in json, which can then be parsed by CLI tools such as 
+      jq.
 
-  --key=key                                                      The API key to use for authentication to Apollo Graph
-                                                                 Manager
+  --key=key
+      The API key to use for authentication to Apollo Graph Manager
 
-  --localSchemaFile=localSchemaFile                              Path to one or more local GraphQL schema file(s), as
-                                                                 introspection result or SDL. Supports comma-separated
-                                                                 list of paths (ex.
-                                                                 `--localSchemaFile=schema.graphql,extensions.graphql`)
+  --localSchemaFile=localSchemaFile
+      Path to one or more local GraphQL schema file(s), as introspection 
+      result or SDL. Supports comma-separated list of paths (ex. 
+      `--localSchemaFile=schema.graphql,extensions.graphql`)
 
-  --markdown                                                     Output result in markdown.
+  --markdown
+      Output result in markdown.
 
-  --queryCountThreshold=queryCountThreshold                      Minimum number of requests within the requested time
-                                                                 window for a query to be considered.
+  --queryCountThreshold=queryCountThreshold
+      Minimum number of requests within the requested time window for a 
+      query to be considered.
 
-  --queryCountThresholdPercentage=queryCountThresholdPercentage  Number of requests within the requested time window for
-                                                                 a query to be considered, relative to total request
-                                                                 count. Expected values are between 0 and 0.05 (minimum
-                                                                 5% of total request volume)
+  --queryCountThresholdPercentage=queryCountThresholdPercentage
+      Number of requests within the requested time window for a query to be 
+      considered, relative to total request count. Expected values are 
+      between 0 and 0.05 (minimum 5% of total request volume)
 
-  --serviceName=serviceName                                      Provides the name of the implementing service for a
-                                                                 federated graph. This flag will indicate that the
-                                                                 schema is a partial schema from a federated service
+  --serviceName=serviceName
+      Provides the name of the implementing service for a federated graph. 
+      This flag will indicate that the schema is a partial schema from a 
+      federated service
 
-  --validationPeriod=validationPeriod                            The size of the time window with which to validate the
-                                                                 schema against. You may provide a number (in seconds),
-                                                                 or an ISO8601 format duration for more granularity
-                                                                 (see: https://en.wikipedia.org/wiki/ISO_8601#Durations)
+  --validationPeriod=validationPeriod
+      The size of the time window with which to validate the schema against. 
+      You may provide a number (in seconds), or an ISO8601 format duration 
+      for more granularity (see: 
+      https://en.wikipedia.org/wiki/ISO_8601#Durations)
 
 ALIASES
   $ apollo schema:check
@@ -563,21 +671,29 @@ USAGE
 OPTIONS
   -c, --config=config        Path to your Apollo config file
 
-  -g, --graph=graph          The ID of the graph in Apollo Graph Manager for which to delete an implementing service.
+  -g, --graph=graph          The ID of the graph in Apollo Graph Manager
+                             for which to delete an implementing service.
                              Overrides config file if set.
 
-  -v, --variant=variant      The variant to delete the implementing service from
+  -v, --variant=variant      The variant to delete the implementing
+                             service from
 
   -y, --yes                  Bypass confirmation when deleting a service
 
-  --endpoint=endpoint        The URL for the CLI use to introspect your service
+  --endpoint=endpoint        The URL for the CLI use to introspect your
+                             service
 
-  --header=header            Additional header to send to server for introspectionQuery. May be used multiple times to
-                             add multiple headers. NOTE: The `--endpoint` flag is REQUIRED if using the `--header` flag.
+  --header=header            Additional header to send to server for
+                             introspectionQuery. May be used multiple
+                             times to add multiple headers. NOTE: The
+                             `--endpoint` flag is REQUIRED if using the
+                             `--header` flag.
 
-  --key=key                  The API key to use for authentication to Apollo Graph Manager
+  --key=key                  The API key to use for authentication to
+                             Apollo Graph Manager
 
-  --serviceName=serviceName  (required) Provides the name of the implementing service for a federated graph
+  --serviceName=serviceName  (required) Provides the name of the
+                             implementing service for a federated graph
 ```
 
 _See code: [src/commands/service/delete.ts](https://github.com/apollographql/apollo-tooling/blob/master/packages/apollo/src/commands/service/delete.ts)_
@@ -591,24 +707,30 @@ USAGE
   $ apollo service:download OUTPUT
 
 ARGUMENTS
-  OUTPUT  [default: schema.json] Path to write the introspection result to. Supports .json output only.
+  OUTPUT  [default: schema.json] Path to write the introspection result
+          to. Supports .json output only.
 
 OPTIONS
   -c, --config=config      Path to your Apollo config file
 
-  -g, --graph=graph        The ID of the graph in Apollo Graph Manager for which to download the schema for. Overrides
+  -g, --graph=graph        The ID of the graph in Apollo Graph Manager for
+                           which to download the schema for. Overrides
                            config file if provided.
 
   -k, --skipSSLValidation  Allow connections to an SSL site without certs
 
   -v, --variant=variant    The variant to download the schema of
 
-  --endpoint=endpoint      The URL for the CLI use to introspect your service
+  --endpoint=endpoint      The URL for the CLI use to introspect your
+                           service
 
-  --header=header          Additional header to send to server for introspectionQuery. May be used multiple times to add
-                           multiple headers. NOTE: The `--endpoint` flag is REQUIRED if using the `--header` flag.
+  --header=header          Additional header to send to server for
+                           introspectionQuery. May be used multiple times
+                           to add multiple headers. NOTE: The `--endpoint`
+                           flag is REQUIRED if using the `--header` flag.
 
-  --key=key                The API key to use for authentication to Apollo Graph Manager
+  --key=key                The API key to use for authentication to Apollo
+                           Graph Manager
 
 ALIASES
   $ apollo schema:download
@@ -627,17 +749,22 @@ USAGE
 OPTIONS
   -c, --config=config    Path to your Apollo config file
 
-  -g, --graph=graph      The ID of the graph in Apollo Graph Manager for which to list implementing services. Overrides
+  -g, --graph=graph      The ID of the graph in Apollo Graph Manager for
+                         which to list implementing services. Overrides
                          config file if set.
 
   -v, --variant=variant  The variant to list implementing services for
 
-  --endpoint=endpoint    The URL for the CLI use to introspect your service
+  --endpoint=endpoint    The URL for the CLI use to introspect your
+                         service
 
-  --header=header        Additional header to send to server for introspectionQuery. May be used multiple times to add
-                         multiple headers. NOTE: The `--endpoint` flag is REQUIRED if using the `--header` flag.
+  --header=header        Additional header to send to server for
+                         introspectionQuery. May be used multiple times to
+                         add multiple headers. NOTE: The `--endpoint` flag
+                         is REQUIRED if using the `--header` flag.
 
-  --key=key              The API key to use for authentication to Apollo Graph Manager
+  --key=key              The API key to use for authentication to Apollo
+                         Graph Manager
 ```
 
 _See code: [src/commands/service/list.ts](https://github.com/apollographql/apollo-tooling/blob/master/packages/apollo/src/commands/service/list.ts)_
@@ -651,31 +778,42 @@ USAGE
   $ apollo service:push
 
 OPTIONS
-  -c, --config=config                Path to your Apollo config file
+  -c, --config=config
+      Path to your Apollo config file
 
-  -g, --graph=graph                  The ID of the graph in Apollo Graph Manager to publish your service to. Overrides
-                                     config file if set.
+  -g, --graph=graph
+      The ID of the graph in Apollo Graph Manager to publish your service 
+      to. Overrides config file if set.
 
-  -v, --variant=variant              The variant to publish your service to in Apollo Graph Manager
+  -v, --variant=variant
+      The variant to publish your service to in Apollo Graph Manager
 
-  --endpoint=endpoint                The URL for the CLI use to introspect your service
+  --endpoint=endpoint
+      The URL for the CLI use to introspect your service
 
-  --header=header                    Additional header to send to server for introspectionQuery. May be used multiple
-                                     times to add multiple headers. NOTE: The `--endpoint` flag is REQUIRED if using the
-                                     `--header` flag.
+  --header=header
+      Additional header to send to server for introspectionQuery. May be 
+      used multiple times to add multiple headers. NOTE: The `--endpoint` 
+      flag is REQUIRED if using the `--header` flag.
 
-  --key=key                          The API key to use for authentication to Apollo Graph Manager
+  --key=key
+      The API key to use for authentication to Apollo Graph Manager
 
-  --localSchemaFile=localSchemaFile  Path to one or more local GraphQL schema file(s), as introspection result or SDL.
-                                     Supports comma-separated list of paths (ex.
-                                     `--localSchemaFile=schema.graphql,extensions.graphql`)
+  --localSchemaFile=localSchemaFile
+      Path to one or more local GraphQL schema file(s), as introspection 
+      result or SDL. Supports comma-separated list of paths (ex. 
+      `--localSchemaFile=schema.graphql,extensions.graphql`)
 
-  --serviceName=serviceName          Provides the name of the implementing service for a federated graph
+  --serviceName=serviceName
+      Provides the name of the implementing service for a federated graph
 
-  --serviceRevision=serviceRevision  Provides a unique revision identifier for a change to an implementing service on a
-                                     federated service push. The default of this is a git sha
+  --serviceRevision=serviceRevision
+      Provides a unique revision identifier for a change to an implementing 
+      service on a federated service push. The default of this is a git sha
 
-  --serviceURL=serviceURL            Provides the url to the location of the implementing service for a federated graph
+  --serviceURL=serviceURL
+      Provides the url to the location of the implementing service for a 
+      federated graph
 
 ALIASES
   $ apollo schema:publish

--- a/packages/apollo/README.md
+++ b/packages/apollo/README.md
@@ -62,48 +62,36 @@ USAGE
 OPTIONS
   -c, --config=config                    Path to your Apollo config file
 
-  -g, --graph=graph                      The ID for the graph in Apollo Graph Manager
-                                         to operate client commands with. Overrides
-                                         config file if set.
+  -g, --graph=graph                      The ID for the graph in Apollo Graph Manager to operate client commands with.
+                                         Overrides config file if set.
 
-  -v, --variant=variant                  The variant of the graph in Apollo Graph
-                                         Manager to associate this client to
+  -v, --variant=variant                  The variant of the graph in Apollo Graph Manager to associate this client to
 
-  --clientName=clientName                Name of the client that the queries will be
-                                         attached to
+  --clientName=clientName                Name of the client that the queries will be attached to
 
-  --clientReferenceId=clientReferenceId  Reference id for the client which will match
-                                         ids from client traces, will use clientName
-                                         if not provided
+  --clientReferenceId=clientReferenceId  Reference id for the client which will match ids from client traces, will use
+                                         clientName if not provided
 
-  --clientVersion=clientVersion          The version of the client that the queries
-                                         will be attached to
+  --clientVersion=clientVersion          The version of the client that the queries will be attached to
 
-  --endpoint=endpoint                    The URL for the CLI use to introspect your
-                                         service
+  --endpoint=endpoint                    The URL for the CLI use to introspect your service
 
-  --excludes=excludes                    Glob of files to exclude for GraphQL
-                                         operations. Caveat: this doesn't currently
+  --excludes=excludes                    Glob of files to exclude for GraphQL operations. Caveat: this doesn't currently
                                          work in watch mode
 
-  --header=header                        Additional header to send to server for
-                                         introspectionQuery. May be used multiple
-                                         times to add multiple headers. NOTE: The
-                                         `--endpoint` flag is REQUIRED if using the
-                                         `--header` flag.
+  --header=header                        Additional header to send to server for introspectionQuery. May be used
+                                         multiple times to add multiple headers. NOTE: The `--endpoint` flag is REQUIRED
+                                         if using the `--header` flag.
 
-  --includes=includes                    Glob of files to search for GraphQL
-                                         operations. This should be used to find
+  --includes=includes                    Glob of files to search for GraphQL operations. This should be used to find
                                          queries *and* any client schema extensions
 
-  --key=key                              The API key to use for authentication to
-                                         Apollo Graph Manager
+  --key=key                              The API key to use for authentication to Apollo Graph Manager
 
   --queries=queries                      Deprecated in favor of the includes flag
 
-  --tagName=tagName                      Name of the template literal tag used to
-                                         identify template literals containing GraphQL
-                                         queries in Javascript/Typescript code
+  --tagName=tagName                      Name of the template literal tag used to identify template literals containing
+                                         GraphQL queries in Javascript/Typescript code
 ```
 
 _See code: [src/commands/client/check.ts](https://github.com/apollographql/apollo-tooling/blob/master/packages/apollo/src/commands/client/check.ts)_
@@ -119,130 +107,99 @@ USAGE
 ARGUMENTS
   OUTPUT
       Directory to which generated files will be written.
-      - For TypeScript/Flow generators, this specifies a directory relative to each 
-      source file by default.
-      - For TypeScript/Flow generators with the "outputFlat" flag is set, and for the 
-      Swift generator, this specifies a file or directory (absolute or relative to the 
-      current working directory) to which:
+      - For TypeScript/Flow generators, this specifies a directory relative to each source file by default.
+      - For TypeScript/Flow generators with the "outputFlat" flag is set, and for the Swift generator, this specifies a 
+      file or directory (absolute or relative to the current working directory) to which:
          - a file will be written for each query (if "output" is a directory)
          - all generated types will be written
-      - For all other types, this defines a file (absolute or relative to the current 
-      working directory) to which all generated types are written.
+      - For all other types, this defines a file (absolute or relative to the current working directory) to which all 
+      generated types are written.
 
 OPTIONS
-  -c, --config=config
-      Path to your Apollo config file
+  -c, --config=config                        Path to your Apollo config file
 
-  -g, --graph=graph
-      The ID for the graph in Apollo Graph Manager to operate client commands with. 
-      Overrides config file if set.
+  -g, --graph=graph                          The ID for the graph in Apollo Graph Manager to operate client commands
+                                             with. Overrides config file if set.
 
-  -v, --variant=variant
-      The variant of the graph in Apollo Graph Manager to associate this client to
+  -v, --variant=variant                      The variant of the graph in Apollo Graph Manager to associate this client
+                                             to
 
-  --[no-]addTypename
-      [default: true] Automatically add __typename to your queries, can be unset with 
-      --no-addTypename
+  --[no-]addTypename                         [default: true] Automatically add __typename to your queries, can be unset
+                                             with --no-addTypename
 
-  --clientName=clientName
-      Name of the client that the queries will be attached to
+  --clientName=clientName                    Name of the client that the queries will be attached to
 
-  --clientReferenceId=clientReferenceId
-      Reference id for the client which will match ids from client traces, will use 
-      clientName if not provided
+  --clientReferenceId=clientReferenceId      Reference id for the client which will match ids from client traces, will
+                                             use clientName if not provided
 
-  --clientVersion=clientVersion
-      The version of the client that the queries will be attached to
+  --clientVersion=clientVersion              The version of the client that the queries will be attached to
 
-  --customScalarsPrefix=customScalarsPrefix
-      Include a prefix when using provided types for custom scalars
+  --customScalarsPrefix=customScalarsPrefix  Include a prefix when using provided types for custom scalars
 
-  --endpoint=endpoint
-      The URL for the CLI use to introspect your service
+  --endpoint=endpoint                        The URL for the CLI use to introspect your service
 
-  --excludes=excludes
-      Glob of files to exclude for GraphQL operations. Caveat: this doesn't currently 
-      work in watch mode
+  --excludes=excludes                        Glob of files to exclude for GraphQL operations. Caveat: this doesn't
+                                             currently work in watch mode
 
-  --globalTypesFile=globalTypesFile
-      By default, TypeScript will put a file named "globalTypes.ts" inside the "output" 
-      directory. Set "globalTypesFile" to specify a different path. Alternatively, set 
-      "tsFileExtension" to modify the extension of the file, for example "d.ts" will 
-      output "globalTypes.d.ts"
+  --globalTypesFile=globalTypesFile          By default, TypeScript will put a file named "globalTypes.ts" inside the
+                                             "output" directory. Set "globalTypesFile" to specify a different path.
+                                             Alternatively, set "tsFileExtension" to modify the extension of the file,
+                                             for example "d.ts" will output "globalTypes.d.ts"
 
-  --header=header
-      Additional header to send to server for introspectionQuery. May be used multiple 
-      times to add multiple headers. NOTE: The `--endpoint` flag is REQUIRED if using 
-      the `--header` flag.
+  --header=header                            Additional header to send to server for introspectionQuery. May be used
+                                             multiple times to add multiple headers. NOTE: The `--endpoint` flag is
+                                             REQUIRED if using the `--header` flag.
 
-  --includes=includes
-      Glob of files to search for GraphQL operations. This should be used to find 
-      queries *and* any client schema extensions
+  --includes=includes                        Glob of files to search for GraphQL operations. This should be used to find
+                                             queries *and* any client schema extensions
 
-  --key=key
-      The API key to use for authentication to Apollo Graph Manager
+  --key=key                                  The API key to use for authentication to Apollo Graph Manager
 
-  --localSchemaFile=localSchemaFile
-      Path to one or more local GraphQL schema file(s), as introspection result or SDL. 
-      Supports comma-separated list of paths (ex. 
-      `--localSchemaFile=schema.graphql,extensions.graphql`)
+  --localSchemaFile=localSchemaFile          Path to one or more local GraphQL schema file(s), as introspection result
+                                             or SDL. Supports comma-separated list of paths (ex.
+                                             `--localSchemaFile=schema.graphql,extensions.graphql`)
 
-  --mergeInFieldsFromFragmentSpreads
-      Merge fragment fields onto its enclosing type
+  --mergeInFieldsFromFragmentSpreads         Merge fragment fields onto its enclosing type
 
-  --namespace=namespace
-      The namespace to emit generated code into.
+  --namespace=namespace                      The namespace to emit generated code into.
 
-  --omitDeprecatedEnumCases
-      Omit deprecated enum cases from generated code [Swift only]
+  --omitDeprecatedEnumCases                  Omit deprecated enum cases from generated code [Swift only]
 
-  --only=only
-      Parse all input files, but only output generated code for the specified file 
-      [Swift only]
+  --only=only                                Parse all input files, but only output generated code for the specified
+                                             file [Swift only]
 
-  --operationIdsPath=operationIdsPath
-      Path to an operation id JSON map file. If specified, also stores the operation ids 
-      (hashes) as properties on operation types [currently Swift-only]
+  --operationIdsPath=operationIdsPath        Path to an operation id JSON map file. If specified, also stores the
+                                             operation ids (hashes) as properties on operation types [currently
+                                             Swift-only]
 
-  --outputFlat
-      By default, TypeScript/Flow will put each generated file in a directory next to 
-      its source file using the value of the "output" as the directory name. Set 
-      "outputFlat" to put all generated files in the directory relative to the current 
-      working directory defined by "output".
+  --outputFlat                               By default, TypeScript/Flow will put each generated file in a directory
+                                             next to its source file using the value of the "output" as the directory
+                                             name. Set "outputFlat" to put all generated files in the directory relative
+                                             to the current working directory defined by "output".
 
-  --passthroughCustomScalars
-      Use your own types for custom scalars
+  --passthroughCustomScalars                 Use your own types for custom scalars
 
-  --queries=queries
-      Deprecated in favor of the includes flag
+  --queries=queries                          Deprecated in favor of the includes flag
 
-  --suppressSwiftMultilineStringLiterals
-      Prevents operations from being rendered as multiline strings [Swift only]
+  --suppressSwiftMultilineStringLiterals     Prevents operations from being rendered as multiline strings [Swift only]
 
-  --tagName=tagName
-      Name of the template literal tag used to identify template literals containing 
-      GraphQL queries in Javascript/Typescript code
+  --tagName=tagName                          Name of the template literal tag used to identify template literals
+                                             containing GraphQL queries in Javascript/Typescript code
 
-  --target=target
-      (required) Type of code generator to use (swift | typescript | flow | scala | json 
-      | json-modern (exposes raw json types))
+  --target=target                            (required) Type of code generator to use (swift | typescript | flow | scala
+                                             | json | json-modern (exposes raw json types))
 
-  --tsFileExtension=tsFileExtension
-      By default, TypeScript will output "ts" files. Set "tsFileExtension" to specify a 
-      different file extension, for example "d.ts"
+  --tsFileExtension=tsFileExtension          By default, TypeScript will output "ts" files. Set "tsFileExtension" to
+                                             specify a different file extension, for example "d.ts"
 
-  --useFlowExactObjects
-      Use Flow exact objects for generated types [flow only]
+  --useFlowExactObjects                      Use Flow exact objects for generated types [flow only]
 
-  --useFlowReadOnlyTypes
-      Use read only types for generated types [flow only]. **Deprecated in favor of 
-      `useReadOnlyTypes`.**
+  --useFlowReadOnlyTypes                     Use read only types for generated types [flow only]. **Deprecated in favor
+                                             of `useReadOnlyTypes`.**
 
-  --useReadOnlyTypes
-      Use read only types for generated types [flow | typescript]
+  --useReadOnlyTypes                         Use read only types for generated types [flow | typescript]
 
-  --watch
-      Watch for file changes and reload codegen
+  --watch                                    Watch for file changes and reload codegen
 
 ALIASES
   $ apollo codegen:generate
@@ -259,54 +216,42 @@ USAGE
   $ apollo client:download-schema OUTPUT
 
 ARGUMENTS
-  OUTPUT  [default: schema.json] Path to write the introspection result to. Can be
-          `.graphql`, `.gql`, `.graphqls`, or `.json`
+  OUTPUT  [default: schema.json] Path to write the introspection result to. Can be `.graphql`, `.gql`, `.graphqls`, or
+          `.json`
 
 OPTIONS
   -c, --config=config                    Path to your Apollo config file
 
-  -g, --graph=graph                      The ID for the graph in Apollo Graph Manager
-                                         to operate client commands with. Overrides
-                                         config file if set.
+  -g, --graph=graph                      The ID for the graph in Apollo Graph Manager to operate client commands with.
+                                         Overrides config file if set.
 
-  -v, --variant=variant                  The variant of the graph in Apollo Graph
-                                         Manager to associate this client to
+  -v, --variant=variant                  The variant of the graph in Apollo Graph Manager to associate this client to
 
-  --clientName=clientName                Name of the client that the queries will be
-                                         attached to
+  --clientName=clientName                Name of the client that the queries will be attached to
 
-  --clientReferenceId=clientReferenceId  Reference id for the client which will match
-                                         ids from client traces, will use clientName
-                                         if not provided
+  --clientReferenceId=clientReferenceId  Reference id for the client which will match ids from client traces, will use
+                                         clientName if not provided
 
-  --clientVersion=clientVersion          The version of the client that the queries
-                                         will be attached to
+  --clientVersion=clientVersion          The version of the client that the queries will be attached to
 
-  --endpoint=endpoint                    The URL for the CLI use to introspect your
-                                         service
+  --endpoint=endpoint                    The URL for the CLI use to introspect your service
 
-  --excludes=excludes                    Glob of files to exclude for GraphQL
-                                         operations. Caveat: this doesn't currently
+  --excludes=excludes                    Glob of files to exclude for GraphQL operations. Caveat: this doesn't currently
                                          work in watch mode
 
-  --header=header                        Additional header to send to server for
-                                         introspectionQuery. May be used multiple
-                                         times to add multiple headers. NOTE: The
-                                         `--endpoint` flag is REQUIRED if using the
-                                         `--header` flag.
+  --header=header                        Additional header to send to server for introspectionQuery. May be used
+                                         multiple times to add multiple headers. NOTE: The `--endpoint` flag is REQUIRED
+                                         if using the `--header` flag.
 
-  --includes=includes                    Glob of files to search for GraphQL
-                                         operations. This should be used to find
+  --includes=includes                    Glob of files to search for GraphQL operations. This should be used to find
                                          queries *and* any client schema extensions
 
-  --key=key                              The API key to use for authentication to
-                                         Apollo Graph Manager
+  --key=key                              The API key to use for authentication to Apollo Graph Manager
 
   --queries=queries                      Deprecated in favor of the includes flag
 
-  --tagName=tagName                      Name of the template literal tag used to
-                                         identify template literals containing GraphQL
-                                         queries in Javascript/Typescript code
+  --tagName=tagName                      Name of the template literal tag used to identify template literals containing
+                                         GraphQL queries in Javascript/Typescript code
 ```
 
 _See code: [src/commands/client/download-schema.ts](https://github.com/apollographql/apollo-tooling/blob/master/packages/apollo/src/commands/client/download-schema.ts)_
@@ -323,58 +268,44 @@ ARGUMENTS
   OUTPUT  [default: manifest.json] Path to write the extracted queries to
 
 OPTIONS
-  -c, --config=config
-      Path to your Apollo config file
+  -c, --config=config                    Path to your Apollo config file
 
-  -g, --graph=graph
-      The ID for the graph in Apollo Graph Manager to operate client commands with. 
-      Overrides config file if set.
+  -g, --graph=graph                      The ID for the graph in Apollo Graph Manager to operate client commands with.
+                                         Overrides config file if set.
 
-  -v, --variant=variant
-      The variant of the graph in Apollo Graph Manager to associate this client to
+  -v, --variant=variant                  The variant of the graph in Apollo Graph Manager to associate this client to
 
-  --clientName=clientName
-      Name of the client that the queries will be attached to
+  --clientName=clientName                Name of the client that the queries will be attached to
 
-  --clientReferenceId=clientReferenceId
-      Reference id for the client which will match ids from client traces, will use 
-      clientName if not provided
+  --clientReferenceId=clientReferenceId  Reference id for the client which will match ids from client traces, will use
+                                         clientName if not provided
 
-  --clientVersion=clientVersion
-      The version of the client that the queries will be attached to
+  --clientVersion=clientVersion          The version of the client that the queries will be attached to
 
-  --endpoint=endpoint
-      The URL for the CLI use to introspect your service
+  --endpoint=endpoint                    The URL for the CLI use to introspect your service
 
-  --excludes=excludes
-      Glob of files to exclude for GraphQL operations. Caveat: this doesn't currently 
-      work in watch mode
+  --excludes=excludes                    Glob of files to exclude for GraphQL operations. Caveat: this doesn't currently
+                                         work in watch mode
 
-  --header=header
-      Additional header to send to server for introspectionQuery. May be used multiple 
-      times to add multiple headers. NOTE: The `--endpoint` flag is REQUIRED if using 
-      the `--header` flag.
+  --header=header                        Additional header to send to server for introspectionQuery. May be used
+                                         multiple times to add multiple headers. NOTE: The `--endpoint` flag is REQUIRED
+                                         if using the `--header` flag.
 
-  --includes=includes
-      Glob of files to search for GraphQL operations. This should be used to find 
-      queries *and* any client schema extensions
+  --includes=includes                    Glob of files to search for GraphQL operations. This should be used to find
+                                         queries *and* any client schema extensions
 
-  --key=key
-      The API key to use for authentication to Apollo Graph Manager
+  --key=key                              The API key to use for authentication to Apollo Graph Manager
 
-  --preserveStringAndNumericLiterals
-      Disable redaction of string and numerical literals.  Without this flag, these 
-      values will be replaced with empty strings (`''`) and zeroes (`0`) respectively.  
-      This redaction is intended to avoid  inadvertently outputting potentially 
-      personally identifiable information (e.g. embedded passwords  or API keys) into 
-      operation manifests
+  --preserveStringAndNumericLiterals     Disable redaction of string and numerical literals.  Without this flag, these
+                                         values will be replaced with empty strings (`''`) and zeroes (`0`)
+                                         respectively.  This redaction is intended to avoid  inadvertently outputting
+                                         potentially personally identifiable information (e.g. embedded passwords  or
+                                         API keys) into operation manifests
 
-  --queries=queries
-      Deprecated in favor of the includes flag
+  --queries=queries                      Deprecated in favor of the includes flag
 
-  --tagName=tagName
-      Name of the template literal tag used to identify template literals containing 
-      GraphQL queries in Javascript/Typescript code
+  --tagName=tagName                      Name of the template literal tag used to identify template literals containing
+                                         GraphQL queries in Javascript/Typescript code
 ```
 
 _See code: [src/commands/client/extract.ts](https://github.com/apollographql/apollo-tooling/blob/master/packages/apollo/src/commands/client/extract.ts)_
@@ -390,48 +321,36 @@ USAGE
 OPTIONS
   -c, --config=config                    Path to your Apollo config file
 
-  -g, --graph=graph                      The ID for the graph in Apollo Graph Manager
-                                         to operate client commands with. Overrides
-                                         config file if set.
+  -g, --graph=graph                      The ID for the graph in Apollo Graph Manager to operate client commands with.
+                                         Overrides config file if set.
 
-  -v, --variant=variant                  The variant of the graph in Apollo Graph
-                                         Manager to associate this client to
+  -v, --variant=variant                  The variant of the graph in Apollo Graph Manager to associate this client to
 
-  --clientName=clientName                Name of the client that the queries will be
-                                         attached to
+  --clientName=clientName                Name of the client that the queries will be attached to
 
-  --clientReferenceId=clientReferenceId  Reference id for the client which will match
-                                         ids from client traces, will use clientName
-                                         if not provided
+  --clientReferenceId=clientReferenceId  Reference id for the client which will match ids from client traces, will use
+                                         clientName if not provided
 
-  --clientVersion=clientVersion          The version of the client that the queries
-                                         will be attached to
+  --clientVersion=clientVersion          The version of the client that the queries will be attached to
 
-  --endpoint=endpoint                    The URL for the CLI use to introspect your
-                                         service
+  --endpoint=endpoint                    The URL for the CLI use to introspect your service
 
-  --excludes=excludes                    Glob of files to exclude for GraphQL
-                                         operations. Caveat: this doesn't currently
+  --excludes=excludes                    Glob of files to exclude for GraphQL operations. Caveat: this doesn't currently
                                          work in watch mode
 
-  --header=header                        Additional header to send to server for
-                                         introspectionQuery. May be used multiple
-                                         times to add multiple headers. NOTE: The
-                                         `--endpoint` flag is REQUIRED if using the
-                                         `--header` flag.
+  --header=header                        Additional header to send to server for introspectionQuery. May be used
+                                         multiple times to add multiple headers. NOTE: The `--endpoint` flag is REQUIRED
+                                         if using the `--header` flag.
 
-  --includes=includes                    Glob of files to search for GraphQL
-                                         operations. This should be used to find
+  --includes=includes                    Glob of files to search for GraphQL operations. This should be used to find
                                          queries *and* any client schema extensions
 
-  --key=key                              The API key to use for authentication to
-                                         Apollo Graph Manager
+  --key=key                              The API key to use for authentication to Apollo Graph Manager
 
   --queries=queries                      Deprecated in favor of the includes flag
 
-  --tagName=tagName                      Name of the template literal tag used to
-                                         identify template literals containing GraphQL
-                                         queries in Javascript/Typescript code
+  --tagName=tagName                      Name of the template literal tag used to identify template literals containing
+                                         GraphQL queries in Javascript/Typescript code
 ```
 
 _See code: [src/commands/client/push.ts](https://github.com/apollographql/apollo-tooling/blob/master/packages/apollo/src/commands/client/push.ts)_
@@ -491,10 +410,9 @@ DESCRIPTION
 
   Installation of a user-installed plugin will override a core plugin.
 
-  e.g. If you have a core plugin that has a 'hello' command, installing a 
-  user-installed plugin with a 'hello' command will override the core plugin 
-  implementation. This is useful if a user needs to update core plugin functionality 
-  in the CLI without the need to patch and update the whole CLI.
+  e.g. If you have a core plugin that has a 'hello' command, installing a user-installed plugin with a 'hello' command 
+  will override the core plugin implementation. This is useful if a user needs to update core plugin functionality in 
+  the CLI without the need to patch and update the whole CLI.
 
 ALIASES
   $ apollo plugins:add
@@ -525,9 +443,8 @@ OPTIONS
 DESCRIPTION
   Installation of a linked plugin will override a user-installed or core plugin.
 
-  e.g. If you have a user-installed or core plugin that has a 'hello' command, 
-  installing a linked plugin with a 'hello' command will override the user-installed 
-  or core plugin implementation. This is useful for development work.
+  e.g. If you have a user-installed or core plugin that has a 'hello' command, installing a linked plugin with a 'hello' 
+  command will override the user-installed or core plugin implementation. This is useful for development work.
 
 EXAMPLE
   $ apollo plugins:link myplugin
@@ -581,58 +498,53 @@ USAGE
   $ apollo service:check
 
 OPTIONS
-  -c, --config=config
-      Path to your Apollo config file
+  -c, --config=config                                            Path to your Apollo config file
 
-  -g, --graph=graph
-      The ID of the graph in Apollo Graph Manager to check your proposed schema changes 
-      against. Overrides config file if set.
+  -g, --graph=graph                                              The ID of the graph in Apollo Graph Manager to check
+                                                                 your proposed schema changes against. Overrides config
+                                                                 file if set.
 
-  -v, --variant=variant
-      The variant to check the proposed schema against
+  -v, --variant=variant                                          The variant to check the proposed schema against
 
-  --endpoint=endpoint
-      The URL for the CLI use to introspect your service
+  --endpoint=endpoint                                            The URL for the CLI use to introspect your service
 
-  --header=header
-      Additional header to send to server for introspectionQuery. May be used multiple 
-      times to add multiple headers. NOTE: The `--endpoint` flag is REQUIRED if using 
-      the `--header` flag.
+  --header=header                                                Additional header to send to server for
+                                                                 introspectionQuery. May be used multiple times to add
+                                                                 multiple headers. NOTE: The `--endpoint` flag is
+                                                                 REQUIRED if using the `--header` flag.
 
-  --ignoreFailures
-      Exit with status 0 when the check completes, even if errors are found
+  --ignoreFailures                                               Exit with status 0 when the check completes, even if
+                                                                 errors are found
 
-  --json
-      Output result in json, which can then be parsed by CLI tools such as jq.
+  --json                                                         Output result in json, which can then be parsed by CLI
+                                                                 tools such as jq.
 
-  --key=key
-      The API key to use for authentication to Apollo Graph Manager
+  --key=key                                                      The API key to use for authentication to Apollo Graph
+                                                                 Manager
 
-  --localSchemaFile=localSchemaFile
-      Path to one or more local GraphQL schema file(s), as introspection result or SDL. 
-      Supports comma-separated list of paths (ex. 
-      `--localSchemaFile=schema.graphql,extensions.graphql`)
+  --localSchemaFile=localSchemaFile                              Path to one or more local GraphQL schema file(s), as
+                                                                 introspection result or SDL. Supports comma-separated
+                                                                 list of paths (ex.
+                                                                 `--localSchemaFile=schema.graphql,extensions.graphql`)
 
-  --markdown
-      Output result in markdown.
+  --markdown                                                     Output result in markdown.
 
-  --queryCountThreshold=queryCountThreshold
-      Minimum number of requests within the requested time window for a query to be 
-      considered.
+  --queryCountThreshold=queryCountThreshold                      Minimum number of requests within the requested time
+                                                                 window for a query to be considered.
 
-  --queryCountThresholdPercentage=queryCountThresholdPercentage
-      Number of requests within the requested time window for a query to be considered, 
-      relative to total request count. Expected values are between 0 and 0.05 (minimum 
-      5% of total request volume)
+  --queryCountThresholdPercentage=queryCountThresholdPercentage  Number of requests within the requested time window for
+                                                                 a query to be considered, relative to total request
+                                                                 count. Expected values are between 0 and 0.05 (minimum
+                                                                 5% of total request volume)
 
-  --serviceName=serviceName
-      Provides the name of the implementing service for a federated graph. This flag 
-      will indicate that the schema is a partial schema from a federated service
+  --serviceName=serviceName                                      Provides the name of the implementing service for a
+                                                                 federated graph. This flag will indicate that the
+                                                                 schema is a partial schema from a federated service
 
-  --validationPeriod=validationPeriod
-      The size of the time window with which to validate the schema against. You may 
-      provide a number (in seconds), or an ISO8601 format duration for more granularity 
-      (see: https://en.wikipedia.org/wiki/ISO_8601#Durations)
+  --validationPeriod=validationPeriod                            The size of the time window with which to validate the
+                                                                 schema against. You may provide a number (in seconds),
+                                                                 or an ISO8601 format duration for more granularity
+                                                                 (see: https://en.wikipedia.org/wiki/ISO_8601#Durations)
 
 ALIASES
   $ apollo schema:check
@@ -651,9 +563,8 @@ USAGE
 OPTIONS
   -c, --config=config        Path to your Apollo config file
 
-  -g, --graph=graph          The ID of the graph in Apollo Graph Manager for which to
-                             delete an implementing service. Overrides config file if
-                             set.
+  -g, --graph=graph          The ID of the graph in Apollo Graph Manager for which to delete an implementing service.
+                             Overrides config file if set.
 
   -v, --variant=variant      The variant to delete the implementing service from
 
@@ -661,16 +572,12 @@ OPTIONS
 
   --endpoint=endpoint        The URL for the CLI use to introspect your service
 
-  --header=header            Additional header to send to server for
-                             introspectionQuery. May be used multiple times to add
-                             multiple headers. NOTE: The `--endpoint` flag is REQUIRED
-                             if using the `--header` flag.
+  --header=header            Additional header to send to server for introspectionQuery. May be used multiple times to
+                             add multiple headers. NOTE: The `--endpoint` flag is REQUIRED if using the `--header` flag.
 
-  --key=key                  The API key to use for authentication to Apollo Graph
-                             Manager
+  --key=key                  The API key to use for authentication to Apollo Graph Manager
 
-  --serviceName=serviceName  (required) Provides the name of the implementing service
-                             for a federated graph
+  --serviceName=serviceName  (required) Provides the name of the implementing service for a federated graph
 ```
 
 _See code: [src/commands/service/delete.ts](https://github.com/apollographql/apollo-tooling/blob/master/packages/apollo/src/commands/service/delete.ts)_
@@ -684,14 +591,13 @@ USAGE
   $ apollo service:download OUTPUT
 
 ARGUMENTS
-  OUTPUT  [default: schema.json] Path to write the introspection result to. Supports
-          .json output only.
+  OUTPUT  [default: schema.json] Path to write the introspection result to. Supports .json output only.
 
 OPTIONS
   -c, --config=config      Path to your Apollo config file
 
-  -g, --graph=graph        The ID of the graph in Apollo Graph Manager for which to
-                           download the schema for. Overrides config file if provided.
+  -g, --graph=graph        The ID of the graph in Apollo Graph Manager for which to download the schema for. Overrides
+                           config file if provided.
 
   -k, --skipSSLValidation  Allow connections to an SSL site without certs
 
@@ -699,13 +605,10 @@ OPTIONS
 
   --endpoint=endpoint      The URL for the CLI use to introspect your service
 
-  --header=header          Additional header to send to server for introspectionQuery.
-                           May be used multiple times to add multiple headers. NOTE:
-                           The `--endpoint` flag is REQUIRED if using the `--header`
-                           flag.
+  --header=header          Additional header to send to server for introspectionQuery. May be used multiple times to add
+                           multiple headers. NOTE: The `--endpoint` flag is REQUIRED if using the `--header` flag.
 
-  --key=key                The API key to use for authentication to Apollo Graph
-                           Manager
+  --key=key                The API key to use for authentication to Apollo Graph Manager
 
 ALIASES
   $ apollo schema:download
@@ -724,16 +627,15 @@ USAGE
 OPTIONS
   -c, --config=config    Path to your Apollo config file
 
-  -g, --graph=graph      The ID of the graph in Apollo Graph Manager for which to list
-                         implementing services. Overrides config file if set.
+  -g, --graph=graph      The ID of the graph in Apollo Graph Manager for which to list implementing services. Overrides
+                         config file if set.
 
   -v, --variant=variant  The variant to list implementing services for
 
   --endpoint=endpoint    The URL for the CLI use to introspect your service
 
-  --header=header        Additional header to send to server for introspectionQuery.
-                         May be used multiple times to add multiple headers. NOTE: The
-                         `--endpoint` flag is REQUIRED if using the `--header` flag.
+  --header=header        Additional header to send to server for introspectionQuery. May be used multiple times to add
+                         multiple headers. NOTE: The `--endpoint` flag is REQUIRED if using the `--header` flag.
 
   --key=key              The API key to use for authentication to Apollo Graph Manager
 ```
@@ -751,39 +653,29 @@ USAGE
 OPTIONS
   -c, --config=config                Path to your Apollo config file
 
-  -g, --graph=graph                  The ID of the graph in Apollo Graph Manager to
-                                     publish your service to. Overrides config file if
-                                     set.
+  -g, --graph=graph                  The ID of the graph in Apollo Graph Manager to publish your service to. Overrides
+                                     config file if set.
 
-  -v, --variant=variant              The variant to publish your service to in Apollo
-                                     Graph Manager
+  -v, --variant=variant              The variant to publish your service to in Apollo Graph Manager
 
-  --endpoint=endpoint                The URL for the CLI use to introspect your
-                                     service
+  --endpoint=endpoint                The URL for the CLI use to introspect your service
 
-  --header=header                    Additional header to send to server for
-                                     introspectionQuery. May be used multiple times to
-                                     add multiple headers. NOTE: The `--endpoint` flag
-                                     is REQUIRED if using the `--header` flag.
+  --header=header                    Additional header to send to server for introspectionQuery. May be used multiple
+                                     times to add multiple headers. NOTE: The `--endpoint` flag is REQUIRED if using the
+                                     `--header` flag.
 
-  --key=key                          The API key to use for authentication to Apollo
-                                     Graph Manager
+  --key=key                          The API key to use for authentication to Apollo Graph Manager
 
-  --localSchemaFile=localSchemaFile  Path to one or more local GraphQL schema file(s),
-                                     as introspection result or SDL. Supports
-                                     comma-separated list of paths (ex.
-                                     `--localSchemaFile=schema.graphql,extensions.grap
-                                     hql`)
+  --localSchemaFile=localSchemaFile  Path to one or more local GraphQL schema file(s), as introspection result or SDL.
+                                     Supports comma-separated list of paths (ex.
+                                     `--localSchemaFile=schema.graphql,extensions.graphql`)
 
-  --serviceName=serviceName          Provides the name of the implementing service for
-                                     a federated graph
+  --serviceName=serviceName          Provides the name of the implementing service for a federated graph
 
-  --serviceRevision=serviceRevision  Provides a unique revision identifier for a
-                                     change to an implementing service on a federated
-                                     service push. The default of this is a git sha
+  --serviceRevision=serviceRevision  Provides a unique revision identifier for a change to an implementing service on a
+                                     federated service push. The default of this is a git sha
 
-  --serviceURL=serviceURL            Provides the url to the location of the
-                                     implementing service for a federated graph
+  --serviceURL=serviceURL            Provides the url to the location of the implementing service for a federated graph
 
 ALIASES
   $ apollo schema:publish

--- a/packages/apollo/package.json
+++ b/packages/apollo/package.json
@@ -24,7 +24,7 @@
   "scripts": {
     "prepack": "oclif-dev manifest && oclif-dev readme",
     "postpack": "rm -f oclif.manifest.json",
-    "version": "COLUMNS=120 oclif-dev readme && git add README.md"
+    "version": "COLUMNS=74 oclif-dev readme && git add README.md"
   },
   "engines": {
     "node": ">=8",

--- a/packages/apollo/package.json
+++ b/packages/apollo/package.json
@@ -24,7 +24,7 @@
   "scripts": {
     "prepack": "oclif-dev manifest && oclif-dev readme",
     "postpack": "rm -f oclif.manifest.json",
-    "version": "oclif-dev readme && git add README.md"
+    "version": "COLUMNS=120 oclif-dev readme && git add README.md"
   },
   "engines": {
     "node": ">=8",

--- a/packages/apollo/package.json
+++ b/packages/apollo/package.json
@@ -24,7 +24,7 @@
   "scripts": {
     "prepack": "oclif-dev manifest && oclif-dev readme",
     "postpack": "rm -f oclif.manifest.json",
-    "version": "COLUMNS=74 oclif-dev readme && git add README.md"
+    "version": "cross-env COLUMNS=74 oclif-dev readme && git add README.md"
   },
   "engines": {
     "node": ">=8",


### PR DESCRIPTION
The default value of $COLUMNS in `oclif-dev readme` is 120, so we hardcode this
so that we don't reformat the whole README whenever a developer does a release
from a narrower shell.

This reverts the reformatting done in the previous release, which implies that 120 was the correct value to choose.