### PR TITLE
vscode-apollo: Fix 'Apollo: Show Status' command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
 - `apollo-tools`
   - <First `apollo-tools` related entry goes here>
 - `vscode-apollo`
-  - <First `vscode-apollo` related entry goes here>
+  - Fix 'Apollo: Show Status' command.
 
 ## `apollo@2.28.3`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
 - `apollo-tools`
   - <First `apollo-tools` related entry goes here>
 - `vscode-apollo`
-  - Fix 'Apollo: Show Status' command.
+  - Fix 'Apollo: Show Status' command. [#2004](https://github.com/apollographql/apollo-tooling/pull/2004)
 
 ## `apollo@2.28.3`
 

--- a/packages/vscode-apollo/package.json
+++ b/packages/vscode-apollo/package.json
@@ -157,7 +157,7 @@
         "category": "Apollo"
       },
       {
-        "command": "apollographql/showStatus",
+        "command": "apollographql/showStats",
         "title": "Show Status",
         "category": "Apollo"
       }


### PR DESCRIPTION
It was registered under the wrong name since its introduction in #840.
