### PR TITLE
Support flags for branch and author in s/check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Upcoming
 
 - `apollo`
-  - <First `apollo` related entry goes here>
+  - Allow flags for `--branch` and `--author` in service:check command. This will permit users to group changes using the `--branch` flag and indicate an author, via a string value using the `--author` flag.
 - `apollo-codegen-flow`
   - <First `apollo-codegen-flow` related entry goes here>
 - `apollo-codegen-scala`

--- a/apollo.config.js
+++ b/apollo.config.js
@@ -1,7 +1,7 @@
 module.exports = {
   client: {
     name: "Apollo CLI",
-    service: "engine@main",
+    service: "engine@prod",
     includes: ["./packages/apollo-language-server/**/*.ts"],
     excludes: ["**/*.test.ts", "**/__tests__/*"]
   },

--- a/apollo.config.js
+++ b/apollo.config.js
@@ -1,7 +1,7 @@
 module.exports = {
   client: {
     name: "Apollo CLI",
-    service: "engine@prod",
+    service: "engine@main",
     includes: ["./packages/apollo-language-server/**/*.ts"],
     excludes: ["**/*.test.ts", "**/__tests__/*"]
   },

--- a/packages/apollo-language-server/src/graphqlTypes.ts
+++ b/packages/apollo-language-server/src/graphqlTypes.ts
@@ -1711,7 +1711,7 @@ export interface ClientInfoFilter {
  */
 export interface GitContextInput {
   remoteUrl?: string | null;
-  commit: string;
+  commit?: string | null;
   committer?: string | null;
   message?: string | null;
   branch?: string | null;

--- a/packages/apollo-language-server/src/graphqlTypes.ts
+++ b/packages/apollo-language-server/src/graphqlTypes.ts
@@ -1711,7 +1711,7 @@ export interface ClientInfoFilter {
  */
 export interface GitContextInput {
   remoteUrl?: string | null;
-  commit?: string;
+  commit: string;
   committer?: string | null;
   message?: string | null;
   branch?: string | null;
@@ -1722,7 +1722,7 @@ export interface HistoricQueryParameters {
   to?: any | null;
   queryCountThreshold?: number | null;
   queryCountThresholdPercentage?: number | null;
-  excludedOperationIDs?: string[] | null;
+  ignoredOperations?: string[] | null;
   excludedClients?: ClientInfoFilter[] | null;
   includedVariants?: string[] | null;
 }

--- a/packages/apollo-language-server/src/graphqlTypes.ts
+++ b/packages/apollo-language-server/src/graphqlTypes.ts
@@ -1711,7 +1711,7 @@ export interface ClientInfoFilter {
  */
 export interface GitContextInput {
   remoteUrl?: string | null;
-  commit: string;
+  commit?: string;
   committer?: string | null;
   message?: string | null;
   branch?: string | null;

--- a/packages/apollo/src/git.ts
+++ b/packages/apollo/src/git.ts
@@ -60,7 +60,7 @@ export interface Commit {
 
 export interface GitContext {
   committer?: string;
-  commit: string;
+  commit?: string;
   message?: string;
   remoteUrl?: string;
   branch?: string;


### PR DESCRIPTION
This will allow users to pass in a --branch or --author to a call of
service:check, which will provide a means to group changes in the UI for
schema checks

<!--
  Thanks for filing a pull request on Apollo Tooling!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [x] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests and linter rules pass

\*Make sure changelog entries note which project(s) has been affected. See older entries for examples on what this looks like.
