### PR TITLE
fix(apollo-tools): add undeclared peer dependency graphql

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 > **Note:** Apollo's GraphQL VSCode extension is no longer housed in this repository. It is now maintained separately in [this repo](https://github.com/apollographql/vscode-graphql).
 
+## vNEXT
+
+- `apollo-tools`
+  - Add undeclared peer dependency `graphql` [#2049](https://github.com/apollographql/apollo-tooling/pull/2049)
+
 ## `apollo@2.33.9`
 
 - `apollo-language-server@1.26.7` / `apollo-codegen-core@0.40.7`

--- a/package-lock.json
+++ b/package-lock.json
@@ -20413,7 +20413,7 @@
         "npm": ">=6"
       },
       "peerDependencies": {
-        "graphql": "^14.2.1 || ^15.0.0"
+        "graphql": "^14.2.1 || ^15.0.0 || ^16.0.0"
       }
     },
     "packages/apollo/node_modules/glob": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -20411,6 +20411,9 @@
       "engines": {
         "node": ">=8",
         "npm": ">=6"
+      },
+      "peerDependencies": {
+        "graphql": "^14.2.1 || ^15.0.0"
       }
     },
     "packages/apollo/node_modules/glob": {
@@ -20511,7 +20514,8 @@
       }
     },
     "@apollographql/apollo-tools": {
-      "version": "file:packages/apollo-tools"
+      "version": "file:packages/apollo-tools",
+      "requires": {}
     },
     "@apollographql/graphql-language-service-interface": {
       "version": "2.0.2",

--- a/packages/apollo-tools/package.json
+++ b/packages/apollo-tools/package.json
@@ -15,9 +15,6 @@
     "node": ">=8",
     "npm": ">=6"
   },
-  "dependencies": {
-    "apollo-env": "file:../apollo-env"
-  },
   "peerDependencies": {
     "graphql": "^14.2.1 || ^15.0.0"
   },

--- a/packages/apollo-tools/package.json
+++ b/packages/apollo-tools/package.json
@@ -16,7 +16,7 @@
     "npm": ">=6"
   },
   "peerDependencies": {
-    "graphql": "^14.2.1 || ^15.0.0"
+    "graphql": "^14.2.1 || ^15.0.0 || ^16.0.0"
   },
   "jest": {
     "preset": "ts-jest",

--- a/packages/apollo-tools/package.json
+++ b/packages/apollo-tools/package.json
@@ -15,6 +15,12 @@
     "node": ">=8",
     "npm": ">=6"
   },
+  "dependencies": {
+    "apollo-env": "file:../apollo-env"
+  },
+  "peerDependencies": {
+    "graphql": "^14.2.1 || ^15.0.0"
+  },
   "jest": {
     "preset": "ts-jest",
     "testEnvironment": "node",


### PR DESCRIPTION
`@apollographql/apollo-tools` is using `graphql` without declaring it as a dependency, this causes issues under strict dependency environments (Yarn PnP) and causes it to rely on hoisting to hopefully place it in a accessible location which is not guaranteed.

Fixes https://github.com/apollographql/apollo-tooling/issues/1680

TODO:

- [x] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
