### PR TITLE
Add `unionTypes` and `interfaceTypes` to the `json-modern` IR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 - `apollo-codegen-typescript`
   - <First `apollo-codegen-typescript` related entry goes here>
 - `apollo-codegen-core`
-  - <First `apollo-codegen-core` related entry goes here>
+  - Add new `unionTypes` and `interfaceTypes` properties to the exported IR JSON (when using the `json-modern` target), that list all unions and their types, as well as all interfaces and their implementing types [#2050](https://github.com/apollographql/apollo-tooling/pull/2050).
 - `apollo-env`
   - <First `apollo-env` related entry goes here>
 - `apollo-graphql`

--- a/packages/apollo-codegen-core/src/__tests__/__snapshots__/jsonOutput.ts.snap
+++ b/packages/apollo-codegen-core/src/__tests__/__snapshots__/jsonOutput.ts.snap
@@ -151,7 +151,9 @@ exports[`JSON output should generate JSON output for a mutation with an enum and
 				}
 			]
 		}
-	]
+	],
+	\\"unionTypes\\": [],
+	\\"interfaceTypes\\": []
 }"
 `;
 
@@ -300,7 +302,17 @@ exports[`JSON output should generate JSON output for a query with a fragment spr
 			]
 		}
 	],
-	\\"typesUsed\\": []
+	\\"typesUsed\\": [],
+	\\"unionTypes\\": [],
+	\\"interfaceTypes\\": [
+		{
+			\\"name\\": \\"Character\\",
+			\\"types\\": [
+				\\"Human\\",
+				\\"Droid\\"
+			]
+		}
+	]
 }"
 `;
 
@@ -377,7 +389,17 @@ exports[`JSON output should generate JSON output for a query with a nested selec
 		}
 	],
 	\\"fragments\\": [],
-	\\"typesUsed\\": []
+	\\"typesUsed\\": [],
+	\\"unionTypes\\": [],
+	\\"interfaceTypes\\": [
+		{
+			\\"name\\": \\"Character\\",
+			\\"types\\": [
+				\\"Human\\",
+				\\"Droid\\"
+			]
+		}
+	]
 }"
 `;
 
@@ -468,6 +490,16 @@ exports[`JSON output should generate JSON output for a query with an enum variab
 				}
 			]
 		}
+	],
+	\\"unionTypes\\": [],
+	\\"interfaceTypes\\": [
+		{
+			\\"name\\": \\"Character\\",
+			\\"types\\": [
+				\\"Human\\",
+				\\"Droid\\"
+			]
+		}
 	]
 }"
 `;
@@ -538,7 +570,9 @@ exports[`JSON output should generate JSON output for a subscription 1`] = `
 		}
 	],
 	\\"fragments\\": [],
-	\\"typesUsed\\": []
+	\\"typesUsed\\": [],
+	\\"unionTypes\\": [],
+	\\"interfaceTypes\\": []
 }"
 `;
 
@@ -658,6 +692,265 @@ exports[`JSON output should generate JSON output for an input object type with d
 				}
 			]
 		}
+	],
+	\\"unionTypes\\": [],
+	\\"interfaceTypes\\": []
+}"
+`;
+
+exports[`JSON output should list all interfaces and their implementing types under a \`interfaceTypes\` property 1`] = `
+"{
+	\\"operations\\": [
+		{
+			\\"filePath\\": \\"GraphQL request\\",
+			\\"operationName\\": \\"HeroForEpisode\\",
+			\\"operationType\\": \\"query\\",
+			\\"rootType\\": \\"Query\\",
+			\\"variables\\": [],
+			\\"source\\": \\"query HeroForEpisode {\\\\n  hero(episode: JEDI) {\\\\n    __typename\\\\n    name\\\\n    ... on Droid {\\\\n      primaryFunction\\\\n    }\\\\n  }\\\\n}\\",
+			\\"fields\\": [
+				{
+					\\"responseName\\": \\"hero\\",
+					\\"fieldName\\": \\"hero\\",
+					\\"type\\": \\"Character\\",
+					\\"args\\": [
+						{
+							\\"name\\": \\"episode\\",
+							\\"value\\": \\"JEDI\\",
+							\\"type\\": \\"Episode\\"
+						}
+					],
+					\\"isConditional\\": false,
+					\\"isDeprecated\\": false,
+					\\"fields\\": [
+						{
+							\\"responseName\\": \\"__typename\\",
+							\\"fieldName\\": \\"__typename\\",
+							\\"type\\": \\"String!\\",
+							\\"isConditional\\": false,
+							\\"isDeprecated\\": false
+						},
+						{
+							\\"responseName\\": \\"name\\",
+							\\"fieldName\\": \\"name\\",
+							\\"type\\": \\"String!\\",
+							\\"isConditional\\": false,
+							\\"description\\": \\"The name of the character\\",
+							\\"isDeprecated\\": false
+						}
+					],
+					\\"fragmentSpreads\\": [],
+					\\"inlineFragments\\": [
+						{
+							\\"typeCondition\\": \\"Droid\\",
+							\\"possibleTypes\\": [
+								\\"Droid\\"
+							],
+							\\"fields\\": [
+								{
+									\\"responseName\\": \\"__typename\\",
+									\\"fieldName\\": \\"__typename\\",
+									\\"type\\": \\"String!\\",
+									\\"isConditional\\": false,
+									\\"isDeprecated\\": false
+								},
+								{
+									\\"responseName\\": \\"name\\",
+									\\"fieldName\\": \\"name\\",
+									\\"type\\": \\"String!\\",
+									\\"isConditional\\": false,
+									\\"description\\": \\"What others call this droid\\",
+									\\"isDeprecated\\": false
+								},
+								{
+									\\"responseName\\": \\"primaryFunction\\",
+									\\"fieldName\\": \\"primaryFunction\\",
+									\\"type\\": \\"String\\",
+									\\"isConditional\\": false,
+									\\"description\\": \\"This droid's primary function\\",
+									\\"isDeprecated\\": false
+								}
+							],
+							\\"fragmentSpreads\\": []
+						}
+					]
+				}
+			],
+			\\"fragmentSpreads\\": [],
+			\\"inlineFragments\\": [],
+			\\"fragmentsReferenced\\": [],
+			\\"sourceWithFragments\\": \\"query HeroForEpisode {\\\\n  hero(episode: JEDI) {\\\\n    __typename\\\\n    name\\\\n    ... on Droid {\\\\n      primaryFunction\\\\n    }\\\\n  }\\\\n}\\",
+			\\"operationId\\": \\"173a7ebf41abd014f3fc54ddd007f6182fca738bd44a1e2d1bb75503c8bf79f6\\"
+		}
+	],
+	\\"fragments\\": [],
+	\\"typesUsed\\": [],
+	\\"unionTypes\\": [],
+	\\"interfaceTypes\\": [
+		{
+			\\"name\\": \\"Character\\",
+			\\"types\\": [
+				\\"Human\\",
+				\\"Droid\\"
+			]
+		}
 	]
+}"
+`;
+
+exports[`JSON output should list all unions and their types under a \`unionTypes\` property 1`] = `
+"{
+	\\"operations\\": [
+		{
+			\\"filePath\\": \\"GraphQL request\\",
+			\\"operationName\\": \\"Search\\",
+			\\"operationType\\": \\"query\\",
+			\\"rootType\\": \\"Query\\",
+			\\"variables\\": [],
+			\\"source\\": \\"query Search {\\\\n  search(text: \\\\\\"an\\\\\\") {\\\\n    __typename\\\\n    ... on Human {\\\\n      name\\\\n      height\\\\n    }\\\\n    ... on Droid {\\\\n      name\\\\n      primaryFunction\\\\n    }\\\\n    ... on Starship {\\\\n      name\\\\n      length\\\\n    }\\\\n  }\\\\n}\\",
+			\\"fields\\": [
+				{
+					\\"responseName\\": \\"search\\",
+					\\"fieldName\\": \\"search\\",
+					\\"type\\": \\"[SearchResult]\\",
+					\\"args\\": [
+						{
+							\\"name\\": \\"text\\",
+							\\"value\\": \\"an\\",
+							\\"type\\": \\"String\\"
+						}
+					],
+					\\"isConditional\\": false,
+					\\"isDeprecated\\": false,
+					\\"fields\\": [
+						{
+							\\"responseName\\": \\"__typename\\",
+							\\"fieldName\\": \\"__typename\\",
+							\\"type\\": \\"String!\\",
+							\\"isConditional\\": false,
+							\\"isDeprecated\\": false
+						}
+					],
+					\\"fragmentSpreads\\": [],
+					\\"inlineFragments\\": [
+						{
+							\\"typeCondition\\": \\"Human\\",
+							\\"possibleTypes\\": [
+								\\"Human\\"
+							],
+							\\"fields\\": [
+								{
+									\\"responseName\\": \\"__typename\\",
+									\\"fieldName\\": \\"__typename\\",
+									\\"type\\": \\"String!\\",
+									\\"isConditional\\": false,
+									\\"isDeprecated\\": false
+								},
+								{
+									\\"responseName\\": \\"name\\",
+									\\"fieldName\\": \\"name\\",
+									\\"type\\": \\"String!\\",
+									\\"isConditional\\": false,
+									\\"description\\": \\"What this human calls themselves\\",
+									\\"isDeprecated\\": false
+								},
+								{
+									\\"responseName\\": \\"height\\",
+									\\"fieldName\\": \\"height\\",
+									\\"type\\": \\"Float\\",
+									\\"isConditional\\": false,
+									\\"description\\": \\"Height in the preferred unit, default is meters\\",
+									\\"isDeprecated\\": false
+								}
+							],
+							\\"fragmentSpreads\\": []
+						},
+						{
+							\\"typeCondition\\": \\"Droid\\",
+							\\"possibleTypes\\": [
+								\\"Droid\\"
+							],
+							\\"fields\\": [
+								{
+									\\"responseName\\": \\"__typename\\",
+									\\"fieldName\\": \\"__typename\\",
+									\\"type\\": \\"String!\\",
+									\\"isConditional\\": false,
+									\\"isDeprecated\\": false
+								},
+								{
+									\\"responseName\\": \\"name\\",
+									\\"fieldName\\": \\"name\\",
+									\\"type\\": \\"String!\\",
+									\\"isConditional\\": false,
+									\\"description\\": \\"What others call this droid\\",
+									\\"isDeprecated\\": false
+								},
+								{
+									\\"responseName\\": \\"primaryFunction\\",
+									\\"fieldName\\": \\"primaryFunction\\",
+									\\"type\\": \\"String\\",
+									\\"isConditional\\": false,
+									\\"description\\": \\"This droid's primary function\\",
+									\\"isDeprecated\\": false
+								}
+							],
+							\\"fragmentSpreads\\": []
+						},
+						{
+							\\"typeCondition\\": \\"Starship\\",
+							\\"possibleTypes\\": [
+								\\"Starship\\"
+							],
+							\\"fields\\": [
+								{
+									\\"responseName\\": \\"__typename\\",
+									\\"fieldName\\": \\"__typename\\",
+									\\"type\\": \\"String!\\",
+									\\"isConditional\\": false,
+									\\"isDeprecated\\": false
+								},
+								{
+									\\"responseName\\": \\"name\\",
+									\\"fieldName\\": \\"name\\",
+									\\"type\\": \\"String!\\",
+									\\"isConditional\\": false,
+									\\"description\\": \\"The name of the starship\\",
+									\\"isDeprecated\\": false
+								},
+								{
+									\\"responseName\\": \\"length\\",
+									\\"fieldName\\": \\"length\\",
+									\\"type\\": \\"Float\\",
+									\\"isConditional\\": false,
+									\\"description\\": \\"Length of the starship, along the longest axis\\",
+									\\"isDeprecated\\": false
+								}
+							],
+							\\"fragmentSpreads\\": []
+						}
+					]
+				}
+			],
+			\\"fragmentSpreads\\": [],
+			\\"inlineFragments\\": [],
+			\\"fragmentsReferenced\\": [],
+			\\"sourceWithFragments\\": \\"query Search {\\\\n  search(text: \\\\\\"an\\\\\\") {\\\\n    __typename\\\\n    ... on Human {\\\\n      name\\\\n      height\\\\n    }\\\\n    ... on Droid {\\\\n      name\\\\n      primaryFunction\\\\n    }\\\\n    ... on Starship {\\\\n      name\\\\n      length\\\\n    }\\\\n  }\\\\n}\\",
+			\\"operationId\\": \\"9887ff0652e14d678a66769b853c41293d4afb1d1338bbbdb9f84e66979605dd\\"
+		}
+	],
+	\\"fragments\\": [],
+	\\"typesUsed\\": [],
+	\\"unionTypes\\": [
+		{
+			\\"name\\": \\"SearchResult\\",
+			\\"types\\": [
+				\\"Human\\",
+				\\"Droid\\",
+				\\"Starship\\"
+			]
+		}
+	],
+	\\"interfaceTypes\\": []
 }"
 `;

--- a/packages/apollo-codegen-core/src/compiler/legacyIR.ts
+++ b/packages/apollo-codegen-core/src/compiler/legacyIR.ts
@@ -4,6 +4,8 @@ import {
   GraphQLObjectType,
   GraphQLCompositeType,
   GraphQLInputType,
+  GraphQLUnionType,
+  GraphQLInterfaceType,
   DocumentNode,
   TypeNode
 } from "graphql";
@@ -39,6 +41,11 @@ export interface LegacyCompilerContext {
   fragments: { [fragmentName: string]: LegacyFragment };
   typesUsed: GraphQLType[];
   options: CompilerOptions;
+  unionTypes: GraphQLUnionType[];
+  interfaceTypes: Map<
+    GraphQLInterfaceType,
+    (GraphQLObjectType | GraphQLInterfaceType)[]
+  >;
 }
 
 export interface LegacyOperation {
@@ -185,7 +192,9 @@ class LegacyIRTransformer {
       operations,
       fragments,
       typesUsed: this.context.typesUsed,
-      options: this.options
+      options: this.options,
+      unionTypes: this.context.unionTypes,
+      interfaceTypes: this.context.interfaceTypes
     };
 
     return legacyContext;

--- a/packages/apollo/src/commands/client/__tests__/__snapshots__/generate.test.ts.snap
+++ b/packages/apollo/src/commands/client/__tests__/__snapshots__/generate.test.ts.snap
@@ -96,6 +96,7 @@ export type SimpleQuery = {
 exports[`client:codegen writes json operations 1`] = `
 Object {
   "fragments": Array [],
+  "interfaceTypes": Array [],
   "operations": Array [
     Object {
       "fields": Array [
@@ -125,12 +126,14 @@ Object {
     },
   ],
   "typesUsed": Array [],
+  "unionTypes": Array [],
 }
 `;
 
 exports[`client:codegen writes json operations with typeNode (json-modern) 1`] = `
 Object {
   "fragments": Array [],
+  "interfaceTypes": Array [],
   "operations": Array [
     Object {
       "fields": Array [
@@ -170,6 +173,7 @@ Object {
     },
   ],
   "typesUsed": Array [],
+  "unionTypes": Array [],
 }
 `;
 


### PR DESCRIPTION
This commit adds new top level properties called `unionTypes` and `interfaceTypes`, to the `json-modern` exported IR. These properties list all unions and their types, as well as all interfaces and their implementing types.