### PR TITLE
If there is no global type used, the globalTypes file is not created

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Upcoming
 
 - `apollo`
-  - <First `apollo` related entry goes here>
+  - If there is no global type used, the globalTypes file is not created when doing codegen for typescript [#1179](https://github.com/apollographql/apollo-tooling/issues/1179)
 - `apollo-codegen-flow`
   - <First `apollo-codegen-flow` related entry goes here>
 - `apollo-codegen-scala`

--- a/packages/apollo/src/generate.ts
+++ b/packages/apollo/src/generate.ts
@@ -157,9 +157,11 @@ export default function generate(
       (fs.existsSync(outputPath) && fs.statSync(outputPath).isDirectory())
     ) {
       if (options.globalTypesFile) {
-        const globalTypesDir = path.dirname(options.globalTypesFile);
-        if (!fs.existsSync(globalTypesDir)) {
-          fs.mkdirSync(globalTypesDir);
+        if (context.typesUsed.length > 0) {
+          const globalTypesDir = path.dirname(options.globalTypesFile);
+          if (!fs.existsSync(globalTypesDir)) {
+            fs.mkdirSync(globalTypesDir);
+          }
         }
       } else if (nextToSources && !fs.existsSync(outputPath)) {
         fs.mkdirSync(outputPath);
@@ -172,9 +174,12 @@ export default function generate(
           `globalTypes.${options.tsFileExtension ||
             TYPESCRIPT_DEFAULT_FILE_EXTENSION}`
         );
-      outFiles[globalSourcePath] = {
-        output: generatedGlobalFile.fileContents
-      };
+
+      if (context.typesUsed.length > 0) {
+        outFiles[globalSourcePath] = {
+          output: generatedGlobalFile.fileContents
+        };
+      }
 
       generatedFiles.forEach(({ sourcePath, fileName, content }) => {
         let dir = outputPath;


### PR DESCRIPTION
This commit adds logic to prevent the creation of the file if globalType is not used in any query or fragment. This is because, when using the Create React App, it is necessary to take additional measures due to the globalType file. In fact, I thought that this file should not be created if it is not used.

Question. How can I test it on my project as well?

TODO:

- [x] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
