### PR TITLE
Export useful sanitizing functions: printWithReducedWhitespace, hideStringAndNumericLiterals and hideLiterals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 > **Note:** Apollo's GraphQL VSCode extension is no longer housed in this repository. It is now maintained separately in [this repo](https://github.com/apollographql/vscode-graphql).
 
+## vNEXT
+
+- `apollo-graphql`
+  - Export useful operation sanitization transforms [PR #2057](https://github.com/apollographql/apollo-tooling/pull/2057)
+
 ## `apollo@2.33.7`
 
 - `apollo-graphql@0.9.4`

--- a/packages/apollo-graphql/src/index.ts
+++ b/packages/apollo-graphql/src/index.ts
@@ -7,3 +7,8 @@ export {
   defaultUsageReportingSignature as defaultEngineReportingSignature
 } from "./operationId";
 export * from "./schema";
+export {
+  printWithReducedWhitespace,
+  hideStringAndNumericLiterals,
+  hideLiterals
+} from "./transforms";


### PR DESCRIPTION
GraphQL execution requests can include PII. At Indeed we have need of a mechanism to sanitize requests of PII in order to maintain GDPR and CCPA requirements. I'm certain many other companies have this need, and expect this to also be useful for companies requiring HIPPA compliance.

The existing hideStringAndNumericLiterals and hideLiterals functions look to be well suited for this purpose. Here I've exported these functions, along with printWithReducedWhitespace which is a nice companion to both. I've updated the existing test for `hideLiterals` to cover more scenarios and added a test for `hideStringAndNumericLiterals`.

- [x] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass

