### PR TITLE
Add missing graphql dependency

### DIFF
--- a/packages/apollo-tools/package.json
+++ b/packages/apollo-tools/package.json
@@ -18,6 +18,9 @@
   "dependencies": {
     "apollo-env": "file:../apollo-env"
   },
+  "peerDependencies": {
+    "graphql": "^14.2.1 || ^15.0.0"
+  },
   "jest": {
     "preset": "ts-jest",
     "testEnvironment": "node",


### PR DESCRIPTION
Because the dependency is currently not declared, users will see the following error in a yarn2/PnP installation:

```shell
(node:4310) [MODULE_NOT_FOUND] Error: @apollographql/apollo-tools tried to access graphql, but it isn't declared in its dependencies; this makes the require call ambiguous and unsound.
```

As the error indicates, the module code does import code from `graphql`, but the module manifest does not declare the dependency. This change fixes that.