### PR TITLE
[apollo-codegen-swift] Skip generating Types.graphql.swift if there are no type definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - `apollo-codegen-scala`
   - <First `apollo-codegen-scala` related entry goes here>
 - `apollo-codegen-swift`
-   - <First `apollo-codegen-swift` related entry goes here>
+   - When outputting multiple files, skip generating `Types.graphql.swift` if there are no type definitions
 - `apollo-codegen-typescript`
   - <First `apollo-codegen-typescript` related entry goes here>
 - `apollo-codegen-core`

--- a/packages/apollo-codegen-swift/src/codeGeneration.ts
+++ b/packages/apollo-codegen-swift/src/codeGeneration.ts
@@ -68,15 +68,17 @@ export function generateSource(
   const generator = new SwiftAPIGenerator(context);
 
   if (outputIndividualFiles) {
-    generator.withinFile(`Types.graphql.swift`, () => {
-      generator.fileHeader();
+    if (context.typesUsed.length > 0) {
+      generator.withinFile(`Types.graphql.swift`, () => {
+        generator.fileHeader();
 
-      generator.namespaceDeclaration(context.options.namespace, () => {
-        context.typesUsed.forEach(type => {
-          generator.typeDeclarationForGraphQLType(type, true);
+        generator.namespaceDeclaration(context.options.namespace, () => {
+          context.typesUsed.forEach(type => {
+            generator.typeDeclarationForGraphQLType(type, true);
+          });
         });
       });
-    });
+    }
 
     const inputFilePaths = new Set<string>();
 


### PR DESCRIPTION
- [ ] Update CHANGELOG.md with your change (include reference to issue & this PR)
- [ ] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass

I'm working on a project that uses Apollo-iOS (and thus apollo-codegen-swift). Thank you for the great project!
We're co-locating our GraphQL files near the library that uses them, and generating separate output files for each library (by running apollo-codegen-swift once for each library).
We have several small libraries that are executing very simple GraphQL queries which have no enum or struct types. 

Unfortunately, in these libraries, an empty Types.graphql.swift file is generated, which only contains imports:
```
// @generated
//  This file was automatically generated and should not be edited.

import Apollo
import Foundation
``` 

This PR modifies `generateSource()` to skip generating a `Types.graphql.swift` file if there are no types to define!

For testing, I wasn't really sure how to proceed.. it looks like codeGeneration.ts tests are only testing SwiftAPIGenerator, not `generateSource()`. If there is a non-invasive way to test file generation, I'd love some advice!