### PR TITLE
Support resolveType for unions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
 - `apollo-language-server`
   - <First `apollo-language-server` related entry goes here>
 - `apollo-tools`
-  - <First `apollo-tools` related entry goes here>
+  - Adds support for `resolveType` on unions [#890](https://github.com/apollographql/apollo-tooling/issues/890)
 - `vscode-apollo`
   - <First `vscode-apollo` related entry goes here>
 

--- a/packages/apollo-tools/src/buildServiceDefinition.ts
+++ b/packages/apollo-tools/src/buildServiceDefinition.ts
@@ -11,10 +11,10 @@ import {
   Kind,
   extendSchema,
   isObjectType,
+  isUnionType,
   SchemaDefinitionNode,
   OperationTypeNode,
-  SchemaExtensionNode,
-  isUnionType
+  SchemaExtensionNode
 } from "graphql";
 import { isNode, isDocumentNode } from "./utilities/graphql";
 import { GraphQLResolverMap } from "./schema/resolverMap";

--- a/packages/apollo-tools/src/buildServiceDefinition.ts
+++ b/packages/apollo-tools/src/buildServiceDefinition.ts
@@ -13,7 +13,8 @@ import {
   isObjectType,
   SchemaDefinitionNode,
   OperationTypeNode,
-  SchemaExtensionNode
+  SchemaExtensionNode,
+  isUnionType
 } from "graphql";
 import { isNode, isDocumentNode } from "./utilities/graphql";
 import { GraphQLResolverMap } from "./schema/resolverMap";
@@ -213,27 +214,34 @@ function addResolversToSchema(
 ) {
   for (const [typeName, fieldConfigs] of Object.entries(resolvers)) {
     const type = schema.getType(typeName);
-    if (!isObjectType(type)) continue;
+    if (isObjectType(type)) {
+      const fieldMap = type.getFields();
 
-    const fieldMap = type.getFields();
-
-    for (const [fieldName, fieldConfig] of Object.entries(fieldConfigs)) {
-      if (fieldName.startsWith("__")) {
-        (type as any)[fieldName.substring(2)] = fieldConfig;
-        continue;
-      }
-
-      const field = fieldMap[fieldName];
-      if (!field) continue;
-
-      if (typeof fieldConfig === "function") {
-        field.resolve = fieldConfig;
-      } else {
-        if (fieldConfig.resolve) {
-          field.resolve = fieldConfig.resolve;
+      for (const [fieldName, fieldConfig] of Object.entries(fieldConfigs)) {
+        if (fieldName.startsWith("__")) {
+          (type as any)[fieldName.substring(2)] = fieldConfig;
+          continue;
         }
-        if (fieldConfig.subscribe) {
-          field.subscribe = fieldConfig.subscribe;
+
+        const field = fieldMap[fieldName];
+        if (!field) continue;
+
+        if (typeof fieldConfig === "function") {
+          field.resolve = fieldConfig;
+        } else {
+          if (fieldConfig.resolve) {
+            field.resolve = fieldConfig.resolve;
+          }
+          if (fieldConfig.subscribe) {
+            field.subscribe = fieldConfig.subscribe;
+          }
+        }
+      }
+    } else if (isUnionType(type)) {
+      for (const [fieldName, fieldConfig] of Object.entries(fieldConfigs)) {
+        if (fieldName.startsWith("__")) {
+          (type as any)[fieldName.substring(2)] = fieldConfig;
+          continue;
         }
       }
     }


### PR DESCRIPTION
This fixes issue #890 

Union types are not considered object types therefore when building their schema the function `__resolveType` is not added properly even though it should be supported for union types.

The associated bug was closed but it was not actually fixed previously, this change actually fixes it. 