### PR TITLE
Support scalars in modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
 - `apollo-language-server`
   - <First `apollo-language-server` related entry goes here>
 - `apollo-tools`
-  - <First `apollo-tools` related entry goes here>
+  - Support scalars when using modules [#2068](https://github.com/apollographql/apollo-tooling/issues/2068)
 - `vscode-apollo`
   - <First `vscode-apollo` related entry goes here>
 

--- a/packages/apollo-tools/src/__tests__/buildServiceDefinition.test.ts
+++ b/packages/apollo-tools/src/__tests__/buildServiceDefinition.test.ts
@@ -1,11 +1,6 @@
 import gql from "graphql-tag";
 import { buildServiceDefinition } from "../buildServiceDefinition";
-import {
-  GraphQLObjectType,
-  GraphQLScalarType,
-  GraphQLInt,
-  IntValueNode
-} from "graphql";
+import { GraphQLObjectType, GraphQLScalarType } from "graphql";
 
 describe("buildServiceDefinition", () => {
   describe(`type definitions`, () => {


### PR DESCRIPTION
This fixes #2068 by adding members of the scalar resolver to the type.

Its very similar to how this [other implementation](https://github.com/ardatan/graphql-tools/blob/ae7c968deb2e6f51024a385abfc6455c0db5a5df/packages/schema/src/addResolversToSchema.ts#L143) works.

Related to #2067