### PR TITLE
Update sanitizeGitRemote() to safelist bitbucket.org, and to set GitUrl.token to empty string

### DIFF
--- a/packages/apollo-language-server/src/engine/index.ts
+++ b/packages/apollo-language-server/src/engine/index.ts
@@ -262,7 +262,7 @@ export class ApolloEngineClient extends GraphQLDataSource {
       }
     });
 
-    if (!(data && data.service) || errors) {
+    if (!(data && data.service && data.service.schemaTags) || errors) {
       throw new Error(
         errors
           ? errors.map(error => error.message).join("\n")

--- a/packages/apollo-language-server/src/graphqlTypes.ts
+++ b/packages/apollo-language-server/src/graphqlTypes.ts
@@ -540,7 +540,7 @@ export interface SchemaTagsAndFieldStats_service {
    * Get schema tags, with optional filtering to a set of tags. Always sorted by creation
    * date in reverse chronological order.
    */
-  schemaTags: SchemaTagsAndFieldStats_service_schemaTags[];
+  schemaTags: SchemaTagsAndFieldStats_service_schemaTags[] | null;
   stats: SchemaTagsAndFieldStats_service_stats;
 }
 
@@ -1672,6 +1672,7 @@ export enum IntrospectionDirectiveLocation {
   SCHEMA = "SCHEMA",
   SUBSCRIPTION = "SUBSCRIPTION",
   UNION = "UNION",
+  VARIABLE_DEFINITION = "VARIABLE_DEFINITION",
 }
 
 export enum IntrospectionTypeKind {

--- a/packages/apollo/src/__tests__/git.test.ts
+++ b/packages/apollo/src/__tests__/git.test.ts
@@ -25,9 +25,9 @@ describe("strip usernames/passwords from git remotes", () => {
   });
   it("removes username from remote with only a username present", () => {
     let clean = sanitizeGitRemote(
-      "https://un@bitbucket.com/apollographql/test"
+      "https://un@bitbucket.org/apollographql/test"
     );
-    expect(clean).toEqual("https://REDACTED@bitbucket.com/apollographql/test");
+    expect(clean).toEqual("https://REDACTED@bitbucket.org/apollographql/test");
   });
   it("does not mind case", () => {
     let clean = sanitizeGitRemote("https://un@GITHUB.com/apollographql/test");
@@ -44,10 +44,10 @@ describe("strip usernames/passwords from git remotes", () => {
     expect(clean).toEqual("https://REDACTED@github.com/apollographql/test");
 
     let bbClean = sanitizeGitRemote(
-      "https://un:p%40ssw%3Ard@bitbucket.com/apollographql/test"
+      "https://un:p%40ssw%3Ard@bitbucket.org/apollographql/test"
     );
     expect(bbClean).toEqual(
-      "https://REDACTED@bitbucket.com/apollographql/test"
+      "https://REDACTED@bitbucket.org/apollographql/test"
     );
   });
   it("works with non-url remotes from github with git user ONLY", () => {
@@ -65,15 +65,15 @@ describe("strip usernames/passwords from git remotes", () => {
   });
   it("works with non-url remotes from bitbucket with git user ONLY", () => {
     let clean = sanitizeGitRemote(
-      "git@bitbucket.com:apollographql/apollo-tooling.git"
+      "git@bitbucket.org:apollographql/apollo-tooling.git"
     );
-    expect(clean).toEqual("git@bitbucket.com:apollographql/apollo-tooling.git");
+    expect(clean).toEqual("git@bitbucket.org:apollographql/apollo-tooling.git");
 
     let clean2 = sanitizeGitRemote(
-      "bob@bitbucket.com:apollographql/apollo-tooling.git"
+      "bob@bitbucket.org:apollographql/apollo-tooling.git"
     );
     expect(clean2).toEqual(
-      "REDACTED@bitbucket.com:apollographql/apollo-tooling.git"
+      "REDACTED@bitbucket.org:apollographql/apollo-tooling.git"
     );
   });
   it("does not allow non-url remotes from unrecognized providers (not github)", () => {

--- a/packages/apollo/src/git.ts
+++ b/packages/apollo/src/git.ts
@@ -39,11 +39,12 @@ export const sanitizeGitRemote = (remote?: string) => {
 
   // we only support github and bitbucket sources
   const source = info.source.toLowerCase();
-  if (source !== "github.com" && source !== "bitbucket.com") return null;
+  if (source !== "github.com" && source !== "bitbucket.org") return null;
 
   if (info.user !== "" && info.user !== "git") {
     info.user = "REDACTED";
   }
+  info.token = "";
 
   // just to make sure that with an unknown `protocol` that stringify doesn't
   // just print the old, dirty url


### PR DESCRIPTION
This PR updates `sanitizeGitRemote()` to:
- safelist `bitbucket.org` instead of `bitbucket.com`
- set `info.token` to empty string, as it may also appear in HTTP/S remote URLs

TODO:
- [ ] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
