### PR TITLE
Re-throw instances of ExitError

### DIFF
--- a/packages/apollo/src/Command.ts
+++ b/packages/apollo/src/Command.ts
@@ -1,4 +1,5 @@
 import Command, { flags } from "@oclif/command";
+import { ExitError } from "@oclif/errors";
 import Listr, { ListrTask } from "listr";
 import { parse, resolve } from "path";
 
@@ -273,6 +274,9 @@ export abstract class ProjectCommand extends Command {
   }
   async catch(err) {
     // handle any error from the command
+    if (err instanceof ExitError) {
+      throw err;
+    }
     this.error(err);
   }
   async finally(err) {


### PR DESCRIPTION
Catching error and calling Command.error changes the original exit code used in the ExitError to 2. Re-throwing the error will result in the correct exit code.

TODO:

- [ ] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [ ] Make sure all of the significant new logic is covered by tests
- [ ] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests and linter rules pass

\*Make sure changelog entries note which project(s) has been affected. See older entries for examples on what this looks like.
