### PR TITLE
apollo-graphql: Rename defaultEngineReportingSignature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 - `apollo-env`
   - <First `apollo-env` related entry goes here>
 - `apollo-graphql`
-  - <First `apollo-graphql` related entry goes here>
+  - Rename `defaultEngineReportingSignature` to `defaultUsageReportingSignature`; the old name continues to be exported as well.
 - `apollo-language-server`
   - <First `apollo-language-server` related entry goes here>
 - `apollo-tools`

--- a/packages/apollo-graphql/src/__tests__/__snapshots__/operationId.test.ts.snap
+++ b/packages/apollo-graphql/src/__tests__/__snapshots__/operationId.test.ts.snap
@@ -1,20 +1,20 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`defaultEngineReportingSignature basic test 1`] = `"{user{name}}"`;
+exports[`defaultUsageReportingSignature basic test 1`] = `"{user{name}}"`;
 
-exports[`defaultEngineReportingSignature basic test with query 1`] = `"{user{name}}"`;
+exports[`defaultUsageReportingSignature basic test with query 1`] = `"{user{name}}"`;
 
-exports[`defaultEngineReportingSignature basic with operation name 1`] = `"query OpName{user{name}}"`;
+exports[`defaultUsageReportingSignature basic with operation name 1`] = `"query OpName{user{name}}"`;
 
-exports[`defaultEngineReportingSignature fragment 1`] = `"fragment Bar on User{asd}{user{name...Bar}}"`;
+exports[`defaultUsageReportingSignature fragment 1`] = `"fragment Bar on User{asd}{user{name...Bar}}"`;
 
-exports[`defaultEngineReportingSignature fragments in various order 1`] = `"fragment Bar on User{asd}{user{name...Bar}}"`;
+exports[`defaultUsageReportingSignature fragments in various order 1`] = `"fragment Bar on User{asd}{user{name...Bar}}"`;
 
-exports[`defaultEngineReportingSignature full test 1`] = `"fragment Bar on User{age@skip(if:$a)...Nested}fragment Nested on User{blah}query Foo($a:Boolean,$b:Int){user(age:0,name:\\"\\"){name tz...Bar...on User{bee hello}}}"`;
+exports[`defaultUsageReportingSignature full test 1`] = `"fragment Bar on User{age@skip(if:$a)...Nested}fragment Nested on User{blah}query Foo($a:Boolean,$b:Int){user(age:0,name:\\"\\"){name tz...Bar...on User{bee hello}}}"`;
 
-exports[`defaultEngineReportingSignature with various argument types 1`] = `"query OpName($a:[[Boolean!]!],$b:EnumType,$c:Int!){user{name(apple:$a,bag:$b,cat:$c)}}"`;
+exports[`defaultUsageReportingSignature with various argument types 1`] = `"query OpName($a:[[Boolean!]!],$b:EnumType,$c:Int!){user{name(apple:$a,bag:$b,cat:$c)}}"`;
 
-exports[`defaultEngineReportingSignature with various inline types 1`] = `"query OpName{user{name(apple:[],bag:{},cat:ENUM_VALUE)}}"`;
+exports[`defaultUsageReportingSignature with various inline types 1`] = `"query OpName{user{name(apple:[],bag:{},cat:ENUM_VALUE)}}"`;
 
 exports[`operationRegistrySignature basic test 1`] = `"{user{name}}"`;
 

--- a/packages/apollo-graphql/src/__tests__/operationId.test.ts
+++ b/packages/apollo-graphql/src/__tests__/operationId.test.ts
@@ -1,6 +1,6 @@
 import { default as gql, disableFragmentWarnings } from "graphql-tag";
 import {
-  defaultEngineReportingSignature,
+  defaultUsageReportingSignature,
   operationRegistrySignature
 } from "../operationId";
 
@@ -8,7 +8,7 @@ import {
 // breaks if you turn it off in tests.
 disableFragmentWarnings();
 
-describe("defaultEngineReportingSignature", () => {
+describe("defaultUsageReportingSignature", () => {
   const cases = [
     // Test cases borrowed from optics-agent-js.
     {
@@ -140,7 +140,7 @@ describe("defaultEngineReportingSignature", () => {
   cases.forEach(({ name, operationName, input }) => {
     test(name, () => {
       expect(
-        defaultEngineReportingSignature(input, operationName)
+        defaultUsageReportingSignature(input, operationName)
       ).toMatchSnapshot();
     });
   });

--- a/packages/apollo-graphql/src/index.ts
+++ b/packages/apollo-graphql/src/index.ts
@@ -1,7 +1,9 @@
 export {
-  defaultEngineReportingSignature,
   defaultOperationRegistrySignature,
+  defaultUsageReportingSignature,
   operationRegistrySignature,
-  operationHash
+  operationHash,
+  // deprecated name for this function:
+  defaultUsageReportingSignature as defaultEngineReportingSignature
 } from "./operationId";
 export * from "./schema";

--- a/packages/apollo-graphql/src/operationId.ts
+++ b/packages/apollo-graphql/src/operationId.ts
@@ -1,18 +1,20 @@
-// In Engine, we want to group requests making the same query together, and
-// treat different queries distinctly. But what does it mean for two queries to
-// be "the same"?  And what if you don't want to send the full text of the query
-// to Apollo Engine's servers, either because it contains sensitive data or
-// because it contains extraneous operations or fragments?
+// In Apollo Studio, we want to group requests making the same query together,
+// and treat different queries distinctly. But what does it mean for two queries
+// to be "the same"?  And what if you don't want to send the full text of the
+// query to Apollo's servers, either because it contains sensitive data
+// or because it contains extraneous operations or fragments?
 //
-// To solve these problems, EngineReportingAgent has the concept of
+// To solve these problems, ApolloServerPluginUsageReporting has the concept of
 // "signatures". We don't (by default) send the full query string of queries to
-// the Engine servers. Instead, each trace has its query string's "signature".
+// Apollo's servers. Instead, each trace has its query string's "signature".
 //
-// You can specify any function mapping a GraphQL query AST (DocumentNode) to
-// string as your signature algorithm by providing it as the 'signature' option
-// to the EngineReportingAgent constructor. Ideally, your signature should be a
-// valid GraphQL query, though as of now the Engine servers do not re-parse your
-// signature and do not expect it to match the execution tree in the trace.
+// You can technically specify any function mapping a GraphQL query AST
+// (DocumentNode) to string as your signature algorithm by providing it as the
+// 'calculateSignature' option to ApolloServerPluginUsageReporting. (This option
+// is not recommended, because Apollo's servers make some assumptions about the
+// semantics of your operation based on the signature.) This file defines the
+// default function used for this purpose: defaultUsageReportingSignature
+// (formerly known as defaultEngineReportingSignature).
 //
 // This module utilizes several AST transformations from the adjacent
 // 'transforms' module (which are also for writing your own signature method).
@@ -27,22 +29,29 @@
 // - printWithReducedWhitespace, a variant on graphql-js's 'print'
 //   which gets rid of unneeded whitespace
 //
-// defaultEngineReportingSignature consists of applying all of these building blocks.
+// defaultUsageReportingSignature consists of applying all of these building
+// blocks.
 //
 // Historical note: the default signature algorithm of the Go engineproxy
-// performed all of the above operations, and the Engine servers then re-ran a
+// performed all of the above operations, and Apollo's servers then re-ran a
 // mostly identical signature implementation on received traces. This was
 // primarily to deal with edge cases where some users used literal interpolation
 // instead of GraphQL variables, included randomized alias names, etc. In
 // addition, the servers relied on the fact that dropUnusedDefinitions had been
 // called in order (and that the signature could be parsed as GraphQL) to
 // extract the name of the operation for display. This caused confusion, as the
-// query document shown in the Engine UI wasn't the same as the one actually
-// sent. apollo-engine-reporting uses a new reporting API which requires it to
-// explicitly include the operation name with each signature; this means that
-// the server no longer needs to parse the signature or run its own signature
-// algorithm on it, and the details of the signature algorithm are now up to the
-// reporting agent.
+// query document shown in the Studio UI wasn't the same as the one actually
+// sent. ApolloServerPluginUsageReporting (previously apollo-engine-reporting)
+// uses a reporting API which requires it to explicitly include the operation
+// name with each signature; this means that the server no longer needs to parse
+// the signature or run its own signature algorithm on it, and the details of
+// the signature algorithm are now up to the reporting agent. That said, not all
+// Studio features will work properly if your signature function changes the
+// signature in unexpected ways.
+//
+// This file also exports operationRegistrySignature and
+// defaultOperationRegistrySignature, which are slightly different normalization
+// functions used in other contextes.
 import { DocumentNode } from "graphql";
 import { createHash } from "apollo-env";
 import {
@@ -54,10 +63,10 @@ import {
   hideLiterals
 } from "./transforms";
 
-// The engine reporting signature function consists of removing extra whitespace,
+// The usage reporting signature function consists of removing extra whitespace,
 // sorting the AST in a deterministic manner, hiding literals, and removing
 // unused definitions.
-export function defaultEngineReportingSignature(
+export function defaultUsageReportingSignature(
   ast: DocumentNode,
   operationName: string
 ): string {
@@ -71,7 +80,7 @@ export function defaultEngineReportingSignature(
 // The operation registry signature function consists of removing extra whitespace,
 // sorting the AST in a deterministic manner, potentially hiding string and numeric
 // literals, and removing unused definitions. This is a less aggressive transform
-// than its engine reporting signature counterpart.
+// than its usage reporting signature counterpart.
 export function operationRegistrySignature(
   ast: DocumentNode,
   operationName: string,

--- a/packages/apollo-graphql/src/transforms.ts
+++ b/packages/apollo-graphql/src/transforms.ts
@@ -26,7 +26,7 @@ import sortBy from "lodash.sortby";
 // values. Leaves enums alone (since there's no consistent "zero" enum). This
 // can help combine similar queries if you substitute values directly into
 // queries rather than use GraphQL variables, and can hide sensitive data in
-// your query (say, a hardcoded API key) from Engine servers, but in general
+// your query (say, a hardcoded API key) from Apollo's servers, but in general
 // avoiding those situations is better than working around them.
 export function hideLiterals(ast: DocumentNode): DocumentNode {
   return visit(ast, {


### PR DESCRIPTION
Rename `defaultEngineReportingSignature` to `defaultUsageReportingSignature`;
the old name continues to be exported as well.

This is part of the effort to remove the name Engine from our APIs. See
https://github.com/apollographql/apollo-server/pull/4453
