### PR TITLE
Inputs with defaultValue should be option in generated type

### DIFF
--- a/packages/apollo-codegen-typescript/src/__tests__/__snapshots__/codeGeneration.ts.snap
+++ b/packages/apollo-codegen-typescript/src/__tests__/__snapshots__/codeGeneration.ts.snap
@@ -664,6 +664,89 @@ export interface HeroNameVariables {
 }
 `;
 
+exports[`Typescript codeGeneration local / global default value in mutation argument 1`] = `
+Object {
+  "common": "/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+//==============================================================
+// START Enums and Input Objects
+//==============================================================
+
+/**
+ * The episodes in the Star Wars trilogy
+ */
+export enum Episode {
+  EMPIRE = \\"EMPIRE\\",
+  JEDI = \\"JEDI\\",
+  NEWHOPE = \\"NEWHOPE\\",
+}
+
+/**
+ * The input object sent when passing in a color
+ */
+export interface ColorInput {
+  red: number;
+  green: number;
+  blue: number;
+}
+
+/**
+ * The input object sent when someone is creating a new review
+ */
+export interface ReviewInput {
+  stars: number;
+  commentary?: string | null;
+  favorite_color?: ColorInput | null;
+}
+
+//==============================================================
+// END Enums and Input Objects
+//==============================================================
+",
+  "generatedFiles": Array [
+    Object {
+      "content": TypescriptGeneratedFile {
+        "fileContents": "/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL mutation operation: ReviewMovie
+// ====================================================
+
+export interface ReviewMovie_createReview {
+  __typename: \\"Review\\";
+  /**
+   * The number of stars this review gave, 1-5
+   */
+  stars: number;
+  /**
+   * Comment about the movie
+   */
+  commentary: string | null;
+}
+
+export interface ReviewMovie {
+  createReview: ReviewMovie_createReview | null;
+}
+
+export interface ReviewMovieVariables {
+  episode?: Episode;
+  review: ReviewInput;
+}
+",
+      },
+      "fileName": "ReviewMovie.ts",
+      "sourcePath": "GraphQL request",
+    },
+  ],
+}
+`;
+
 exports[`Typescript codeGeneration local / global duplicates 1`] = `
 Array [
   Object {

--- a/packages/apollo-codegen-typescript/src/__tests__/codeGeneration.ts
+++ b/packages/apollo-codegen-typescript/src/__tests__/codeGeneration.ts
@@ -634,4 +634,18 @@ describe("Typescript codeGeneration local / global", () => {
     expect(output).toMatchSnapshot();
     expect(generateGlobalSource(context)).toMatchSnapshot();
   });
+
+  test("default value in mutation argument", () => {
+    const context = compile(`
+      mutation ReviewMovie($episode: Episode! = NEWHOPE, $review: ReviewInput!) {
+        createReview(episode: $episode, review: $review) {
+          stars
+          commentary
+        }
+      }
+    `);
+
+    const output = generateSource(context);
+    expect(output).toMatchSnapshot();
+  });
 });

--- a/packages/apollo-codegen-typescript/src/language.ts
+++ b/packages/apollo-codegen-typescript/src/language.ts
@@ -14,6 +14,7 @@ export type ObjectProperty = {
   name: string;
   description?: string | null | undefined;
   type: t.TSType;
+  hasDefaultValue?: boolean;
 };
 
 export default class TypescriptGenerator {
@@ -61,7 +62,8 @@ export default class TypescriptGenerator {
       const field = fieldMap[fieldName];
       return {
         name: fieldName,
-        type: this.typeFromGraphQLType(field.type)
+        type: this.typeFromGraphQLType(field.type),
+        hasDefaultValue: !!field.defaultValue
       };
     });
 
@@ -92,7 +94,7 @@ export default class TypescriptGenerator {
       keyInheritsNullability?: boolean;
     } = {}
   ) {
-    return fields.map(({ name, description, type }) => {
+    return fields.map(({ name, description, type, hasDefaultValue }) => {
       const propertySignatureType = t.TSPropertySignature(
         t.identifier(name),
         t.TSTypeAnnotation(type)
@@ -100,7 +102,8 @@ export default class TypescriptGenerator {
 
       // TODO: Check if this works
       propertySignatureType.optional =
-        keyInheritsNullability && this.isNullableType(type);
+        hasDefaultValue ||
+        (keyInheritsNullability && this.isNullableType(type));
 
       if (this.options.useReadOnlyTypes) {
         propertySignatureType.readonly = true;


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Tooling!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [ ] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [ ] Make sure all of the significant new logic is covered by tests
- [ ] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests and linter rules pass

\*Make sure changelog entries note which project(s) has been affected. See older entries for examples on what this looks like.


Opening this PR to request some help / guidance for how to implement this feature fully. Our project has InputObjects with defaultValues for some fields. Those properties should be optional in the generated typescript types, because we don't need to specify them to satisfy GQL since it will use the defaultValue if we don't send anything. However, currently generated types require the properties to be present unless they are nullable.

This PR fixes the issue for nested properties in mutation inputs, but I can't figure out where to modify logic to support default values in top level mutation arguments. Any help would be appreciated!