### PR TITLE
Allow GitLab remote URLs in sanitizeGitRemote()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - `apollo`
   - Update CLI default API domain from `engine-graphql.apollographql.com` to `graphql.api.apollographql.com`.
     Users that have set up support for corporate proxies or firewalls may need to update configurations.
+  - Accept GitLab remote URLs when fetching git info for service:check and service:push [#2104](https://github.com/apollographql/apollo-tooling/pull/2104)
 - `apollo-codegen-flow`
   - <First `apollo-codegen-flow` related entry goes here>
 - `apollo-codegen-scala`

--- a/packages/apollo/src/__tests__/git.test.ts
+++ b/packages/apollo/src/__tests__/git.test.ts
@@ -20,7 +20,9 @@ describe("Git integration", () => {
 
 describe("strip usernames/passwords from git remotes", () => {
   it("returns empty for unknown remotes", () => {
-    let clean = sanitizeGitRemote("https://un@gitlab.com/apollographql/test");
+    let clean = sanitizeGitRemote(
+      "https://un@sourceforge.net/apollographql/test"
+    );
     expect(clean).toBeNull();
   });
   it("removes username from remote with only a username present", () => {
@@ -49,6 +51,11 @@ describe("strip usernames/passwords from git remotes", () => {
     expect(bbClean).toEqual(
       "https://REDACTED@bitbucket.org/apollographql/test"
     );
+
+    let glClean = sanitizeGitRemote(
+      "https://un:p%40ssw%3Ard@gitlab.com/apollographql/test"
+    );
+    expect(glClean).toEqual("https://REDACTED@gitlab.com/apollographql/test");
   });
   it("works with non-url remotes from github with git user ONLY", () => {
     let clean = sanitizeGitRemote(
@@ -74,6 +81,19 @@ describe("strip usernames/passwords from git remotes", () => {
     );
     expect(clean2).toEqual(
       "REDACTED@bitbucket.org:apollographql/apollo-tooling.git"
+    );
+  });
+  it("works with non-url remotes from gitlab with git user ONLY", () => {
+    let clean = sanitizeGitRemote(
+      "git@gitlab.com:apollographql/apollo-tooling.git"
+    );
+    expect(clean).toEqual("git@gitlab.com:apollographql/apollo-tooling.git");
+
+    let clean2 = sanitizeGitRemote(
+      "bob@gitlab.com:apollographql/apollo-tooling.git"
+    );
+    expect(clean2).toEqual(
+      "REDACTED@gitlab.com:apollographql/apollo-tooling.git"
     );
   });
   it("does not allow non-url remotes from unrecognized providers (not github)", () => {

--- a/packages/apollo/src/git.ts
+++ b/packages/apollo/src/git.ts
@@ -29,7 +29,7 @@ const findGitRoot = (start?: string | string[]): string | void => {
  * git remote (`git ls-remote --get-url`)
  *
  * This can be made more generic in the future, allowing for more options
- * for git providers. right now, we only support github & bitbucket. other remotes
+ * for git providers. right now, we only support github, gitlab, and bitbucket. other remotes
  * serve no purpose currently in Apollo Studio.
  */
 
@@ -37,9 +37,14 @@ export const sanitizeGitRemote = (remote?: string) => {
   if (!remote) return null;
   const info = gitUrlParse(remote);
 
-  // we only support github and bitbucket sources
+  // we only support github, gitlab, and bitbucket sources
   const source = info.source.toLowerCase();
-  if (source !== "github.com" && source !== "bitbucket.org") return null;
+  if (
+    source !== "github.com" &&
+    source !== "gitlab.com" &&
+    source !== "bitbucket.org"
+  )
+    return null;
 
   if (info.user !== "" && info.user !== "git") {
     info.user = "REDACTED";


### PR DESCRIPTION
Now that the backend properly sanitizes remote URLs, we don't have to worry about GitLab remote URLs containing sensitive information. This PR adds GitLab back to the safelist for remote URLs in `sanitizeGitRemote()`.

TODO:

- [x] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
