### PR TITLE
Update markdown and json options to respect exit codes

### DIFF
--- a/packages/apollo/src/commands/service/check.ts
+++ b/packages/apollo/src/commands/service/check.ts
@@ -614,10 +614,12 @@ export default class ServiceCheck extends ProjectCommand {
 
     if (shouldOutputJson) {
       if (compositionErrors) {
-        return this.log(JSON.stringify({ errors: compositionErrors }, null, 2));
+        this.log(JSON.stringify({ errors: compositionErrors }, null, 2));
+        if (!shouldAlwaysExit0) this.exit(4);
+        return;
       }
 
-      return this.log(
+      this.log(
         JSON.stringify(
           {
             targetUrl:
@@ -632,6 +634,11 @@ export default class ServiceCheck extends ProjectCommand {
           2
         )
       );
+      if (
+        !shouldAlwaysExit0 &&
+        checkSchemaResult.diffToPrevious.severity === "FAILURE"
+      )
+        this.exit(1);
     } else if (shouldOutputMarkdown) {
       if (!graphID) {
         throw new Error(
@@ -646,7 +653,7 @@ export default class ServiceCheck extends ProjectCommand {
           );
         }
 
-        return this.log(
+        this.log(
           formatCompositionErrorsMarkdown({
             compositionErrors,
             graphName: graphID,
@@ -654,9 +661,11 @@ export default class ServiceCheck extends ProjectCommand {
             tag: config.variant
           })
         );
+        this.exit(4);
+        return;
       }
 
-      return this.log(
+      this.log(
         formatMarkdown({
           checkSchemaResult,
           graphName: graphID,
@@ -665,6 +674,12 @@ export default class ServiceCheck extends ProjectCommand {
           graphCompositionID
         })
       );
+      if (
+        !shouldAlwaysExit0 &&
+        checkSchemaResult.diffToPrevious.severity === "FAILURE"
+      )
+        this.exit(1);
+      return;
     }
 
     if (compositionErrors) {
@@ -707,7 +722,7 @@ export default class ServiceCheck extends ProjectCommand {
       if (shouldAlwaysExit0) {
         return;
       }
-      this.exit(1);
+      this.exit(4);
     } else {
       this.log(formatHumanReadable({ checkSchemaResult, graphCompositionID }));
 


### PR DESCRIPTION
Before this change, the --json and --markdown option would early return
and always exit with 0. This changes them to exit with non-zero codes
when the check is failing. The code that is accommodating these flags
could really afford to be abstracted and cleaned up quite a bit (in
fact, this whole file could), but it's a bit gnarly of a weekend
project, so this is just a fix for the bug.

Additionally, this updates checks to always exit with code 4 on
composition errors and code 1 on other breaking changes.

Fixes #1672 

<!--
  Thanks for filing a pull request on Apollo Tooling!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [ ] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [ ] Make sure all of the significant new logic is covered by tests
- [ ] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests and linter rules pass

\*Make sure changelog entries note which project(s) has been affected. See older entries for examples on what this looks like.
