### PR TITLE
fix(apollo): codegen fails on graphql error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Upcoming
 
 - `apollo`
-  - <First `apollo` related entry goes here>
+  - Fixed [#1980](https://github.com/apollographql/apollo-tooling/issues/1980): codegen now returns non-zero code when errors have been found.
 - `apollo-codegen-flow`
   - <First `apollo-codegen-flow` related entry goes here>
 - `apollo-codegen-scala`

--- a/packages/apollo/src/commands/client/__tests__/fixtures/errorQuery.graphql
+++ b/packages/apollo/src/commands/client/__tests__/fixtures/errorQuery.graphql
@@ -1,0 +1,3 @@
+query ErrornousQuery {
+  nosuchprop
+}

--- a/packages/apollo/src/generate.ts
+++ b/packages/apollo/src/generate.ts
@@ -1,4 +1,5 @@
 import { fs } from "apollo-codegen-core/lib/localfs";
+import { getValidationErrors } from "apollo-language-server";
 import path from "path";
 import { GraphQLSchema, DocumentNode, print } from "graphql";
 import URI from "vscode-uri";
@@ -58,8 +59,14 @@ export default function generate(
   nextToSources: boolean | string,
   options: GenerationOptions
 ): number {
+  const errors = getValidationErrors(schema, document);
+  if (errors && errors.length > 0) {
+    const messages = errors.map(e => e.toString()).join("\n");
+    throw new Error(
+      `Validation of GraphQL query document failed:\n${messages}`
+    );
+  }
   let writtenFiles = 0;
-  validateQueryDocument(schema, document);
 
   const { rootPath = process.cwd() } = options;
   if (outputPath.split(".").length <= 1 && !fs.existsSync(outputPath)) {


### PR DESCRIPTION
The client:codegen command was exiting with code 0 even if the queries had errors.
Fixes #1980

TODO:

- [X] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [X] Make sure all of the significant new logic is covered by tests
- [X] Rebase your changes on master so that they can be merged easily
- [X] Make sure all tests and linter rules pass

\*Make sure changelog entries note which project(s) has been affected. See older entries for examples on what this looks like.