### PR TITLE
fix(vscode-apollo): never automatically open or focus output channel tab

### DIFF
--- a/packages/vscode-apollo/src/languageServerClient.ts
+++ b/packages/vscode-apollo/src/languageServerClient.ts
@@ -2,7 +2,8 @@ import {
   ServerOptions,
   TransportKind,
   LanguageClientOptions,
-  LanguageClient
+  LanguageClient,
+  RevealOutputChannelOn
 } from "vscode-languageclient";
 import { workspace, OutputChannel } from "vscode";
 
@@ -61,7 +62,8 @@ export function getLanguageServerClient(
         )
       ]
     },
-    outputChannel
+    outputChannel,
+    revealOutputChannelOn: RevealOutputChannelOn.Never
   };
 
   return new LanguageClient(


### PR DESCRIPTION
Users on twitter were reporting that this extension was focusing the output channel on each file save. I had the same issue with `vscode-graphql`, and it seems to have to do with changes in `vscode` itself. 

This is the approach that suited us, but possibly you will want to handle it differently, such as only open on `Error`, or using a different setting based on the environment.

TODO:

- [ ] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [ ] Make sure all of the significant new logic is covered by tests
- [ ] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests and linter rules pass

\*Make sure changelog entries note which project(s) has been affected. See older entries for examples on what this looks like.
