### PR TITLE
Expose error messages from backend auth to error logger

### DIFF
--- a/packages/apollo-language-server/src/engine/GraphQLDataSource.ts
+++ b/packages/apollo-language-server/src/engine/GraphQLDataSource.ts
@@ -15,6 +15,7 @@ import { fetch } from "apollo-env";
 export interface GraphQLResponse<T> {
   data?: T;
   errors?: GraphQLError[];
+  extensions?: { nonWebAuthErrorMessage?: string | null };
 }
 export class GraphQLDataSource<TContext = any> {
   public baseURL!: string;

--- a/packages/apollo-language-server/src/engine/index.ts
+++ b/packages/apollo-language-server/src/engine/index.ts
@@ -85,8 +85,12 @@ export class ApolloEngineClient extends GraphQLDataSource {
     return this.execute<ListServices>({
       query: LIST_SERVICES,
       variables
-    }).then(({ data, errors }) => {
+    }).then(({ data, errors, extensions }) => {
       // use error logger
+      if (extensions && extensions.nonWebAuthErrorMessage) {
+        throw new Error(extensions.nonWebAuthErrorMessage);
+      }
+
       if (errors) {
         throw new Error(errors.map(error => error.message).join("\n"));
       }
@@ -106,8 +110,12 @@ export class ApolloEngineClient extends GraphQLDataSource {
     return this.execute<CheckSchema>({
       query: CHECK_SCHEMA,
       variables
-    }).then(({ data, errors }) => {
+    }).then(({ data, errors, extensions }) => {
       // use error logger
+      if (extensions && extensions.nonWebAuthErrorMessage) {
+        throw new Error(extensions.nonWebAuthErrorMessage);
+      }
+
       if (errors) {
         throw new Error(errors.map(error => error.message).join("\n"));
       }
@@ -127,8 +135,12 @@ export class ApolloEngineClient extends GraphQLDataSource {
     return this.execute<UploadSchema>({
       query: UPLOAD_SCHEMA,
       variables
-    }).then(({ data, errors }) => {
+    }).then(({ data, errors, extensions }) => {
       // use error logger
+      if (extensions && extensions.nonWebAuthErrorMessage) {
+        throw new Error(extensions.nonWebAuthErrorMessage);
+      }
+
       if (errors) {
         throw new Error(errors.map(error => error.message).join("\n"));
       }
@@ -150,8 +162,12 @@ export class ApolloEngineClient extends GraphQLDataSource {
     return this.execute<UploadAndComposePartialSchema>({
       query: UPLOAD_AND_COMPOSE_PARTIAL_SCHEMA,
       variables
-    }).then(({ data, errors }) => {
+    }).then(({ data, errors, extensions }) => {
       // use error logger
+      if (extensions && extensions.nonWebAuthErrorMessage) {
+        throw new Error(extensions.nonWebAuthErrorMessage);
+      }
+
       if (errors) {
         throw new Error(errors.map(error => error.message).join("\n"));
       }
@@ -173,8 +189,12 @@ export class ApolloEngineClient extends GraphQLDataSource {
     return this.execute<CheckPartialSchema>({
       query: CHECK_PARTIAL_SCHEMA,
       variables
-    }).then(({ data, errors }) => {
+    }).then(({ data, errors, extensions }) => {
       // use error logger
+      if (extensions && extensions.nonWebAuthErrorMessage) {
+        throw new Error(extensions.nonWebAuthErrorMessage);
+      }
+
       if (errors) {
         throw new Error(errors.map(error => error.message).join("\n"));
       }
@@ -196,7 +216,11 @@ export class ApolloEngineClient extends GraphQLDataSource {
     return this.execute<RemoveServiceAndCompose>({
       query: REMOVE_SERVICE_AND_COMPOSE,
       variables
-    }).then(({ data, errors }) => {
+    }).then(({ data, errors, extensions }) => {
+      if (extensions && extensions.nonWebAuthErrorMessage) {
+        throw new Error(extensions.nonWebAuthErrorMessage);
+      }
+
       if (errors) {
         throw new Error(errors.map(error => error.message).join("\n"));
       }
@@ -213,8 +237,12 @@ export class ApolloEngineClient extends GraphQLDataSource {
     return this.execute<ValidateOperations>({
       query: VALIDATE_OPERATIONS,
       variables
-    }).then(({ data, errors }) => {
+    }).then(({ data, errors, extensions }) => {
       // use error logger
+      if (extensions && extensions.nonWebAuthErrorMessage) {
+        throw new Error(extensions.nonWebAuthErrorMessage);
+      }
+
       if (errors) {
         throw new Error(errors.map(error => error.message).join("\n"));
       }
@@ -235,8 +263,12 @@ export class ApolloEngineClient extends GraphQLDataSource {
     return this.execute<RegisterOperations>({
       query: REGISTER_OPERATIONS,
       variables
-    }).then(({ data, errors }) => {
+    }).then(({ data, errors, extensions }) => {
       // use error logger
+      if (extensions && extensions.nonWebAuthErrorMessage) {
+        throw new Error(extensions.nonWebAuthErrorMessage);
+      }
+
       if (errors) {
         throw new Error(errors.map(error => error.message).join("\n"));
       }
@@ -255,12 +287,18 @@ export class ApolloEngineClient extends GraphQLDataSource {
   }
 
   async loadSchemaTagsAndFieldStats(serviceID: string) {
-    const { data, errors } = await this.execute<SchemaTagsAndFieldStats>({
+    const { data, errors, extensions } = await this.execute<
+      SchemaTagsAndFieldStats
+    >({
       query: SCHEMA_TAGS_AND_FIELD_STATS,
       variables: {
         id: serviceID
       }
     });
+
+    if (extensions && extensions.nonWebAuthErrorMessage) {
+      throw new Error(extensions.nonWebAuthErrorMessage);
+    }
 
     if (!(data && data.service && data.service.schemaTags) || errors) {
       throw new Error(


### PR DESCRIPTION
The backend will (soon) expose errors that occur during auth in a field `nonWebAuthErrorMessage` within GraphQL response extensions. This PR changes queries to the backend to throw when this field is truthy, so that the message may be shown to users.

A few notes about `nonWebAuthErrorMessage`:
- Some auth errors result in GraphQL request execution still proceeding, but with identity `Anonymous`. `nonWebAuthErrorMessage` is useful for these kinds of situations to know what went wrong and how the user should respond.
- `nonWebAuthErrorMessage` may not be set for every kind of auth error (e.g. ones that result in a non-GraphQL response).

TODO:

- [ ] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
