### PR TITLE
Expose `didExist` in removeServiceAndCompose

### DIFF
--- a/packages/apollo-language-server/src/engine/index.ts
+++ b/packages/apollo-language-server/src/engine/index.ts
@@ -205,6 +205,14 @@ export class ApolloEngineClient extends GraphQLDataSource {
         throw new Error("Error in response from Apollo");
       }
 
+      if (
+        !data.service.removeImplementingServiceAndTriggerComposition.didExist
+      ) {
+        throw new Error(
+          `Provided ${variables.name} does not exist in graph: ${variables.id}`
+        );
+      }
+
       return data.service.removeImplementingServiceAndTriggerComposition;
     });
   }

--- a/packages/apollo-language-server/src/engine/operations/removeServiceAndCompose.ts
+++ b/packages/apollo-language-server/src/engine/operations/removeServiceAndCompose.ts
@@ -11,6 +11,7 @@ export const REMOVE_SERVICE_AND_COMPOSE = gql`
         graphVariant: $graphVariant
         name: $name
       ) {
+        didExist
         compositionConfig {
           implementingServiceLocations {
             name

--- a/packages/apollo-language-server/src/graphqlTypes.ts
+++ b/packages/apollo-language-server/src/graphqlTypes.ts
@@ -458,6 +458,10 @@ export interface RemoveServiceAndCompose_service_removeImplementingServiceAndTri
 export interface RemoveServiceAndCompose_service_removeImplementingServiceAndTriggerComposition {
   __typename: "CompositionAndRemoveResult";
   /**
+   * Whether the removed implementing service existed
+   */
+  didExist: boolean;
+  /**
    * The produced composition config. Will be null if there are any errors
    */
   compositionConfig: RemoveServiceAndCompose_service_removeImplementingServiceAndTriggerComposition_compositionConfig | null;


### PR DESCRIPTION
When trying to remove a federated service from Apollo Studio Managed Federation config using `apollo service:delete --serviceName`, the CLI does not return an error if the provided `serviceName` does not exist in the defined graph in Apollo Studio. This PR exposes `didExist` and provides an error when the service being deleted does not exist. 
