### PR TITLE
[GM-1636] cli: service:{check,push} --commitId

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
   - Update CLI default API domain from `engine-graphql.apollographql.com` to `graphql.api.apollographql.com`.
     Users that have set up support for corporate proxies or firewalls may need to update configurations.
   - Accept GitLab remote URLs when fetching git info for service:check and service:push [#2104](https://github.com/apollographql/apollo-tooling/pull/2104)
+  - `--commitId` in `service:check` and `service:push` overrides the current commit ID otherwise read through [env-ci](https://www.npmjs.com/package/env-ci).
+  - `service:push` now takes `--author` and `--branch` matching `service:check`.
 - `apollo-codegen-flow`
   - <First `apollo-codegen-flow` related entry goes here>
 - `apollo-codegen-scala`

--- a/packages/apollo/src/commands/service/check.ts
+++ b/packages/apollo/src/commands/service/check.ts
@@ -253,6 +253,9 @@ export default class ServiceCheck extends ProjectCommand {
     branch: flags.string({
       description: "The branch name to associate with this check"
     }),
+    commitId: flags.string({
+      description: "The SHA-1 hash of the commit to associate with this check"
+    }),
     author: flags.string({
       description: "The author to associate with this proposed schema"
     }),
@@ -381,7 +384,8 @@ export default class ServiceCheck extends ProjectCommand {
                   gitContext: {
                     ...gitInfoFromEnv,
                     ...(flags.author ? { committer: flags.author } : undefined),
-                    ...(flags.branch ? { branch: flags.branch } : undefined)
+                    ...(flags.branch ? { branch: flags.branch } : undefined),
+                    ...(flags.commitId ? { commit: flags.commitId } : undefined)
                   }
                 });
 

--- a/packages/apollo/src/commands/service/push.ts
+++ b/packages/apollo/src/commands/service/push.ts
@@ -29,6 +29,16 @@ export default class ServicePush extends ProjectCommand {
       description:
         "The ID of the graph in Apollo to publish your service to. Overrides config file if set."
     }),
+    branch: flags.string({
+      description: "The branch name to associate with this publication"
+    }),
+    commitId: flags.string({
+      description:
+        "The SHA-1 hash of the commit to associate with this publication"
+    }),
+    author: flags.string({
+      description: "The author to associate with this publication"
+    }),
     localSchemaFile: flags.string({
       description:
         "Path to one or more local GraphQL schema file(s), as introspection result or SDL. Supports comma-separated list of paths (ex. `--localSchemaFile=schema.graphql,extensions.graphql`)"
@@ -74,7 +84,13 @@ export default class ServicePush extends ProjectCommand {
 
           isFederated = flags.serviceName;
 
-          gitContext = await gitInfo(this.log);
+          const gitInfoFromEnv = await gitInfo(this.log);
+          gitContext = {
+            ...gitInfoFromEnv,
+            ...(flags.author ? { committer: flags.author } : undefined),
+            ...(flags.branch ? { branch: flags.branch } : undefined),
+            ...(flags.commitId ? { commit: flags.commitId } : undefined)
+          };
 
           // handle partial schema uploading
           if (isFederated) {


### PR DESCRIPTION
Add `--author` and `--branch` to `service:push` to match `service:check`,
and `--commitId` to both. Makes it easy to override this information, as
CI environments can provide erroneous information.