### PR TITLE
Update codegen to work for AbcCTum (Was converting to AbcCtum)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - `apollo-codegen-scala`
   - <First `apollo-codegen-scala` related entry goes here>
 - `apollo-codegen-swift`
-   - <First `apollo-codegen-swift` related entry goes here>
+   - Fix bug in generated compound type names that lead to structName being inconsistent throughout codegen [#2170](https://github.com/apollographql/apollo-tooling/pull/2170)
 - `apollo-codegen-typescript`
   - <First `apollo-codegen-typescript` related entry goes here>
 - `apollo-codegen-core`

--- a/packages/apollo-codegen-swift/src/__tests__/__snapshots__/codeGeneration.ts.snap
+++ b/packages/apollo-codegen-swift/src/__tests__/__snapshots__/codeGeneration.ts.snap
@@ -949,17 +949,6 @@ exports[`Swift code generation #initializerDeclarationForProperties() should gen
 }"
 `;
 
-exports[`Swift code generation #propertyDeclarationForField()  1`] = `
-"public var :  {
-  get {
-    return TestCTum(unsafeResultMap: resultMap[\\"testCTA\\"]! as! ResultMap)
-  }
-  set {
-    resultMap.updateValue(newValue.resultMap, forKey: \\"testCTA\\")
-  }
-}"
-`;
-
 exports[`Swift code generation #propertyDeclarationForField() should generate structName as testCTum for key testCTA 1`] = `
 "public var :  {
   get {

--- a/packages/apollo-codegen-swift/src/__tests__/__snapshots__/codeGeneration.ts.snap
+++ b/packages/apollo-codegen-swift/src/__tests__/__snapshots__/codeGeneration.ts.snap
@@ -949,6 +949,28 @@ exports[`Swift code generation #initializerDeclarationForProperties() should gen
 }"
 `;
 
+exports[`Swift code generation #propertyDeclarationForField()  1`] = `
+"public var :  {
+  get {
+    return TestCTum(unsafeResultMap: resultMap[\\"testCTA\\"]! as! ResultMap)
+  }
+  set {
+    resultMap.updateValue(newValue.resultMap, forKey: \\"testCTA\\")
+  }
+}"
+`;
+
+exports[`Swift code generation #propertyDeclarationForField() should generate structName as testCTum for key testCTA 1`] = `
+"public var :  {
+  get {
+    return TestCTum(unsafeResultMap: resultMap[\\"testCTA\\"]! as! ResultMap)
+  }
+  set {
+    resultMap.updateValue(newValue.resultMap, forKey: \\"testCTA\\")
+  }
+}"
+`;
+
 exports[`Swift code generation #structDeclarationForFragment() should generate a struct declaration for a fragment that includes a fragment spread 1`] = `
 "public struct HeroDetails: GraphQLFragment {
   /// The raw GraphQL definition of this fragment.

--- a/packages/apollo-codegen-swift/src/codeGeneration.ts
+++ b/packages/apollo-codegen-swift/src/codeGeneration.ts
@@ -769,7 +769,7 @@ export class SwiftAPIGenerator extends SwiftGenerator<CompilerContext> {
     this.printOnNewline(swift`public var ${propertyName}: ${typeName}`);
     this.withinBlock(() => {
       if (isCompositeType(unmodifiedFieldType)) {
-        const structName = this.helpers.structNameForPropertyName(propertyName);
+        const structName = this.helpers.structNameForPropertyName(responseKey);
 
         if (isList(type)) {
           this.printOnNewline(swift`get`);


### PR DESCRIPTION
Key is AbcCTA, which get's converted by singularize to structName: AbcCTum (this is already not great, but not the bug causing compilation issues)
The key is used to create the structName.
In this place the property (abcCtum) was being used instead which made: AbcCtum (AbcCTum and AbcCtum don't match, notice the T vs t)

CC @designatednerd 