### PR TITLE
Swift Codegen: Split up appending of fragments to query document

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - `apollo-codegen-scala`
   - <First `apollo-codegen-scala` related entry goes here>
 - `apollo-codegen-swift`
-  - <First `apollo-codegen-scala` related entry goes here>
+  - Fix issue where a query referencing many fragments caused type checking for `queryDocument` to time out [#2198](https://github.com/apollographql/apollo-tooling/pull/2198)
 - `apollo-codegen-typescript`
   - <First `apollo-codegen-typescript` related entry goes here>
 - `apollo-codegen-core`

--- a/packages/apollo-codegen-swift/src/__tests__/__snapshots__/codeGeneration.ts.snap
+++ b/packages/apollo-codegen-swift/src/__tests__/__snapshots__/codeGeneration.ts.snap
@@ -315,7 +315,11 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
 
   public let operationName: String = \\"Hero\\"
 
-  public var queryDocument: String { return operationDefinition.appending(\\"\\\\n\\" + HeroDetails.fragmentDefinition) }
+  public var queryDocument: String {
+    var document: String = operationDefinition
+    document.append(\\"\\\\n\\" + HeroDetails.fragmentDefinition)
+    return document
+  }
 
   public init() {
   }
@@ -460,7 +464,11 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
 
   public let operationName: String = \\"Hero\\"
 
-  public var queryDocument: String { return operationDefinition.appending(\\"\\\\n\\" + DroidDetails.fragmentDefinition) }
+  public var queryDocument: String {
+    var document: String = operationDefinition
+    document.append(\\"\\\\n\\" + DroidDetails.fragmentDefinition)
+    return document
+  }
 
   public init() {
   }
@@ -633,7 +641,11 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
 
   public let operationName: String = \\"Hero\\"
 
-  public var queryDocument: String { return operationDefinition.appending(\\"\\\\n\\" + HeroDetails.fragmentDefinition) }
+  public var queryDocument: String {
+    var document: String = operationDefinition
+    document.append(\\"\\\\n\\" + HeroDetails.fragmentDefinition)
+    return document
+  }
 
   public init() {
   }
@@ -834,7 +846,11 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
 
   public let operationIdentifier: String? = \\"90d0d674eb6a7b33776f63200d6cec3d09f881247c360a2ac9a29037a02210c4\\"
 
-  public var queryDocument: String { return operationDefinition.appending(\\"\\\\n\\" + HeroDetails.fragmentDefinition) }
+  public var queryDocument: String {
+    var document: String = operationDefinition
+    document.append(\\"\\\\n\\" + HeroDetails.fragmentDefinition)
+    return document
+  }
 
   public init() {
   }

--- a/packages/apollo-codegen-swift/src/codeGeneration.ts
+++ b/packages/apollo-codegen-swift/src/codeGeneration.ts
@@ -262,17 +262,20 @@ export class SwiftAPIGenerator extends SwiftGenerator<CompilerContext> {
 
         if (fragmentsReferenced.size > 0) {
           this.printNewlineIfNeeded();
-          this.printOnNewline(
-            swift`public var queryDocument: String { return operationDefinition`
-          );
-          fragmentsReferenced.forEach(fragmentName => {
-            this.print(
-              swift`.appending("\\n" + ${this.helpers.structNameForFragmentName(
-                fragmentName
-              )}.fragmentDefinition)`
+          this.printOnNewline(swift`public var queryDocument: String`);
+          this.withinBlock(() => {
+            this.printOnNewline(
+              swift`var document: String = operationDefinition`
             );
+            fragmentsReferenced.forEach(fragmentName => {
+              this.printOnNewline(
+                swift`document.append("\\n" + ${this.helpers.structNameForFragmentName(
+                  fragmentName
+                )}.fragmentDefinition)`
+              );
+            });
+            this.printOnNewline(swift`return document`);
           });
-          this.print(swift` }`);
         }
 
         this.printNewlineIfNeeded();


### PR DESCRIPTION
Splits the appending of fragments to the query document into separate
sub expressions to fix an issue where a query that references lots of fragments
causes the Swift type checker to fail with the following message:
```
error: the compiler is unable to type-check this expression in reasonable time; try breaking up the expression into distinct sub-expressions
```

TODO:

- [x] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
