### PR TITLE
Make Prettier ignore generated files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,28 +2,10 @@
 
 ## Upcoming
 
-- `apollo`
-  - <First `apollo` related entry goes here>
 - `apollo-codegen-flow`
-  - <First `apollo-codegen-flow` related entry goes here>
-- `apollo-codegen-scala`
-  - <First `apollo-codegen-scala` related entry goes here>
-- `apollo-codegen-swift`
-  - <First `apollo-codegen-swift` related entry goes here>
+  - Add `/* prettier-disable */` in generated files header [#2240](https://github.com/apollographql/apollo-tooling/pull/2240)
 - `apollo-codegen-typescript`
-  - <First `apollo-codegen-typescript` related entry goes here>
-- `apollo-codegen-core`
-  - <First `apollo-codegen-core` related entry goes here>
-- `apollo-env`
-  - <First `apollo-env` related entry goes here>
-- `apollo-graphql`
-  - <First `apollo-graphql` related entry goes here>
-- `apollo-language-server`
-  - <First `apollo-language-server` related entry goes here>
-- `apollo-tools`
-  - <First `apollo-tools` related entry goes here>
-- `vscode-apollo`
-  - <First `vscode-apollo` related entry goes here>
+  - Add `/* prettier-disable */` in generated files header [#2240](https://github.com/apollographql/apollo-tooling/pull/2240)
 
 ## `apollo@2.32.5`
 

--- a/packages/apollo-codegen-flow/src/__tests__/__snapshots__/codeGeneration.ts.snap
+++ b/packages/apollo-codegen-flow/src/__tests__/__snapshots__/codeGeneration.ts.snap
@@ -4,6 +4,7 @@ exports[`Flow codeGeneration covariant properties with $ReadOnlyArray 1`] = `
 Object {
   "common": "/* @flow */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 
@@ -24,6 +25,7 @@ export type Episode = \\"EMPIRE\\" | \\"JEDI\\" | \\"NEWHOPE\\";
       "content": FlowGeneratedFile {
         "fileContents": "/* @flow */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 
@@ -94,6 +96,7 @@ export type HeroNameVariables = {|
       "content": FlowGeneratedFile {
         "fileContents": "/* @flow */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 
@@ -134,6 +137,7 @@ export type humanFragment = {|
       "content": FlowGeneratedFile {
         "fileContents": "/* @flow */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 
@@ -160,6 +164,7 @@ exports[`Flow codeGeneration fragment spreads with inline fragments 1`] = `
 Object {
   "common": "/* @flow */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 
@@ -180,6 +185,7 @@ export type Episode = \\"EMPIRE\\" | \\"JEDI\\" | \\"NEWHOPE\\";
       "content": FlowGeneratedFile {
         "fileContents": "/* @flow */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 
@@ -250,6 +256,7 @@ export type HeroNameVariables = {
       "content": FlowGeneratedFile {
         "fileContents": "/* @flow */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 
@@ -290,6 +297,7 @@ export type humanFragment = {
       "content": FlowGeneratedFile {
         "fileContents": "/* @flow */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 
@@ -316,6 +324,7 @@ exports[`Flow codeGeneration fragment with fragment spreads 1`] = `
 Object {
   "common": "/* @flow */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 
@@ -331,6 +340,7 @@ Object {
       "content": FlowGeneratedFile {
         "fileContents": "/* @flow */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 
@@ -353,6 +363,7 @@ export type simpleFragment = {
       "content": FlowGeneratedFile {
         "fileContents": "/* @flow */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 
@@ -383,6 +394,7 @@ exports[`Flow codeGeneration fragment with fragment spreads with inline fragment
 Object {
   "common": "/* @flow */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 
@@ -403,6 +415,7 @@ export type Episode = \\"EMPIRE\\" | \\"JEDI\\" | \\"NEWHOPE\\";
       "content": FlowGeneratedFile {
         "fileContents": "/* @flow */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 
@@ -425,6 +438,7 @@ export type simpleFragment = {
       "content": FlowGeneratedFile {
         "fileContents": "/* @flow */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 
@@ -473,6 +487,7 @@ exports[`Flow codeGeneration handles multiline graphql comments 1`] = `
 Object {
   "common": "/* @flow */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 
@@ -488,6 +503,7 @@ Object {
       "content": FlowGeneratedFile {
         "fileContents": "/* @flow */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 
@@ -520,6 +536,7 @@ exports[`Flow codeGeneration inline fragment 1`] = `
 Object {
   "common": "/* @flow */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 
@@ -540,6 +557,7 @@ export type Episode = \\"EMPIRE\\" | \\"JEDI\\" | \\"NEWHOPE\\";
       "content": FlowGeneratedFile {
         "fileContents": "/* @flow */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 
@@ -578,6 +596,7 @@ exports[`Flow codeGeneration inline fragment on type conditions 1`] = `
 Object {
   "common": "/* @flow */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 
@@ -598,6 +617,7 @@ export type Episode = \\"EMPIRE\\" | \\"JEDI\\" | \\"NEWHOPE\\";
       "content": FlowGeneratedFile {
         "fileContents": "/* @flow */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 
@@ -666,6 +686,7 @@ exports[`Flow codeGeneration inline fragment on type conditions with differing i
 Object {
   "common": "/* @flow */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 
@@ -686,6 +707,7 @@ export type Episode = \\"EMPIRE\\" | \\"JEDI\\" | \\"NEWHOPE\\";
       "content": FlowGeneratedFile {
         "fileContents": "/* @flow */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 
@@ -770,6 +792,7 @@ Array [
     "content": FlowGeneratedFile {
       "fileContents": "/* @flow */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 
@@ -804,6 +827,7 @@ export type HeroNameVariables = {
     "content": FlowGeneratedFile {
       "fileContents": "/* @flow */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 
@@ -838,6 +862,7 @@ export type SomeOtherVariables = {
     "content": FlowGeneratedFile {
       "fileContents": "/* @flow */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 
@@ -873,6 +898,7 @@ export type ReviewMovieVariables = {
     "content": FlowGeneratedFile {
       "fileContents": "/* @flow */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 
@@ -899,6 +925,7 @@ exports[`Flow codeGeneration multiple files 3`] = `"common"`;
 exports[`Flow codeGeneration multiple files 4`] = `
 "/* @flow */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 
@@ -938,6 +965,7 @@ exports[`Flow codeGeneration query with fragment spreads 1`] = `
 Object {
   "common": "/* @flow */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 
@@ -958,6 +986,7 @@ export type Episode = \\"EMPIRE\\" | \\"JEDI\\" | \\"NEWHOPE\\";
       "content": FlowGeneratedFile {
         "fileContents": "/* @flow */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 
@@ -992,6 +1021,7 @@ export type HeroFragmentVariables = {
       "content": FlowGeneratedFile {
         "fileContents": "/* @flow */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 
@@ -1018,6 +1048,7 @@ exports[`Flow codeGeneration simple fragment 1`] = `
 Object {
   "common": "/* @flow */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 
@@ -1033,6 +1064,7 @@ Object {
       "content": FlowGeneratedFile {
         "fileContents": "/* @flow */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 
@@ -1059,6 +1091,7 @@ exports[`Flow codeGeneration simple hero query 1`] = `
 Object {
   "common": "/* @flow */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 
@@ -1079,6 +1112,7 @@ export type Episode = \\"EMPIRE\\" | \\"JEDI\\" | \\"NEWHOPE\\";
       "content": FlowGeneratedFile {
         "fileContents": "/* @flow */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 
@@ -1117,6 +1151,7 @@ exports[`Flow codeGeneration simple mutation 1`] = `
 Object {
   "common": "/* @flow */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 
@@ -1155,6 +1190,7 @@ export type ColorInput = {|
       "content": FlowGeneratedFile {
         "fileContents": "/* @flow */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 

--- a/packages/apollo-codegen-flow/src/codeGeneration.ts
+++ b/packages/apollo-codegen-flow/src/codeGeneration.ts
@@ -124,6 +124,7 @@ export class FlowAPIGenerator extends FlowGenerator {
       stripIndent`
         /* @flow */
         /* eslint-disable */
+        /* prettier-disable */
         // @generated
         // This file was automatically generated and should not be edited.
       `

--- a/packages/apollo-codegen-typescript/src/__tests__/__snapshots__/codeGeneration.ts.snap
+++ b/packages/apollo-codegen-typescript/src/__tests__/__snapshots__/codeGeneration.ts.snap
@@ -4,6 +4,7 @@ exports[`Typescript codeGeneration fragment spreads with inline fragments 1`] = 
 Object {
   "common": "/* tslint:disable */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 
@@ -29,6 +30,7 @@ export enum Episode {
       "content": TypescriptGeneratedFile {
         "fileContents": "/* tslint:disable */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 
@@ -108,6 +110,7 @@ export interface HeroNameVariables {
       "content": TypescriptGeneratedFile {
         "fileContents": "/* tslint:disable */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 
@@ -153,6 +156,7 @@ export interface humanFragment {
       "content": TypescriptGeneratedFile {
         "fileContents": "/* tslint:disable */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 
@@ -180,6 +184,7 @@ exports[`Typescript codeGeneration fragment with fragment spreads 1`] = `
 Object {
   "common": "/* tslint:disable */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 
@@ -196,6 +201,7 @@ Object {
       "content": TypescriptGeneratedFile {
         "fileContents": "/* tslint:disable */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 
@@ -219,6 +225,7 @@ export interface simpleFragment {
       "content": TypescriptGeneratedFile {
         "fileContents": "/* tslint:disable */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 
@@ -250,6 +257,7 @@ exports[`Typescript codeGeneration fragment with fragment spreads with inline fr
 Object {
   "common": "/* tslint:disable */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 
@@ -275,6 +283,7 @@ export enum Episode {
       "content": TypescriptGeneratedFile {
         "fileContents": "/* tslint:disable */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 
@@ -298,6 +307,7 @@ export interface simpleFragment {
       "content": TypescriptGeneratedFile {
         "fileContents": "/* tslint:disable */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 
@@ -347,6 +357,7 @@ exports[`Typescript codeGeneration handles multiline graphql comments 1`] = `
 Object {
   "common": "/* tslint:disable */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 
@@ -363,6 +374,7 @@ Object {
       "content": TypescriptGeneratedFile {
         "fileContents": "/* tslint:disable */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 
@@ -396,6 +408,7 @@ exports[`Typescript codeGeneration inline fragment 1`] = `
 Object {
   "common": "/* tslint:disable */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 
@@ -421,6 +434,7 @@ export enum Episode {
       "content": TypescriptGeneratedFile {
         "fileContents": "/* tslint:disable */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 
@@ -460,6 +474,7 @@ exports[`Typescript codeGeneration inline fragment on type conditions 1`] = `
 Object {
   "common": "/* tslint:disable */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 
@@ -485,6 +500,7 @@ export enum Episode {
       "content": TypescriptGeneratedFile {
         "fileContents": "/* tslint:disable */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 
@@ -558,6 +574,7 @@ exports[`Typescript codeGeneration inline fragment on type conditions with diffe
 Object {
   "common": "/* tslint:disable */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 
@@ -583,6 +600,7 @@ export enum Episode {
       "content": TypescriptGeneratedFile {
         "fileContents": "/* tslint:disable */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 
@@ -670,6 +688,7 @@ Array [
     "content": TypescriptGeneratedFile {
       "fileContents": "/* tslint:disable */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 
@@ -706,6 +725,7 @@ exports[`Typescript codeGeneration local / global duplicates 2`] = `
 TypescriptGeneratedFile {
   "fileContents": "/* tslint:disable */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 
@@ -736,6 +756,7 @@ Array [
     "content": TypescriptGeneratedFile {
       "fileContents": "/* tslint:disable */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 
@@ -817,6 +838,7 @@ export interface HeroNameVariables {
     "content": TypescriptGeneratedFile {
       "fileContents": "/* tslint:disable */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 
@@ -862,6 +884,7 @@ export interface humanFragment {
     "content": TypescriptGeneratedFile {
       "fileContents": "/* tslint:disable */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 
@@ -890,6 +913,7 @@ exports[`Typescript codeGeneration local / global fragment spreads with inline f
 TypescriptGeneratedFile {
   "fileContents": "/* tslint:disable */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 
@@ -919,6 +943,7 @@ Array [
     "content": TypescriptGeneratedFile {
       "fileContents": "/* tslint:disable */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 
@@ -942,6 +967,7 @@ export interface simpleFragment {
     "content": TypescriptGeneratedFile {
       "fileContents": "/* tslint:disable */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 
@@ -972,6 +998,7 @@ exports[`Typescript codeGeneration local / global fragment with fragment spreads
 TypescriptGeneratedFile {
   "fileContents": "/* tslint:disable */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 
@@ -992,6 +1019,7 @@ Array [
     "content": TypescriptGeneratedFile {
       "fileContents": "/* tslint:disable */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 
@@ -1015,6 +1043,7 @@ export interface simpleFragment {
     "content": TypescriptGeneratedFile {
       "fileContents": "/* tslint:disable */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 
@@ -1065,6 +1094,7 @@ exports[`Typescript codeGeneration local / global fragment with fragment spreads
 TypescriptGeneratedFile {
   "fileContents": "/* tslint:disable */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 
@@ -1094,6 +1124,7 @@ Array [
     "content": TypescriptGeneratedFile {
       "fileContents": "/* tslint:disable */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 
@@ -1126,6 +1157,7 @@ exports[`Typescript codeGeneration local / global handles multiline graphql comm
 TypescriptGeneratedFile {
   "fileContents": "/* tslint:disable */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 
@@ -1146,6 +1178,7 @@ Array [
     "content": TypescriptGeneratedFile {
       "fileContents": "/* tslint:disable */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 
@@ -1186,6 +1219,7 @@ exports[`Typescript codeGeneration local / global inline fragment 2`] = `
 TypescriptGeneratedFile {
   "fileContents": "/* tslint:disable */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 
@@ -1215,6 +1249,7 @@ Array [
     "content": TypescriptGeneratedFile {
       "fileContents": "/* tslint:disable */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 
@@ -1289,6 +1324,7 @@ exports[`Typescript codeGeneration local / global inline fragment on type condit
 TypescriptGeneratedFile {
   "fileContents": "/* tslint:disable */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 
@@ -1318,6 +1354,7 @@ Array [
     "content": TypescriptGeneratedFile {
       "fileContents": "/* tslint:disable */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 
@@ -1404,6 +1441,7 @@ exports[`Typescript codeGeneration local / global inline fragment on type condit
 TypescriptGeneratedFile {
   "fileContents": "/* tslint:disable */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 
@@ -1433,6 +1471,7 @@ Array [
     "content": TypescriptGeneratedFile {
       "fileContents": "/* tslint:disable */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 
@@ -1462,6 +1501,7 @@ exports[`Typescript codeGeneration local / global multiple nested list enum 2`] 
 TypescriptGeneratedFile {
   "fileContents": "/* tslint:disable */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 
@@ -1487,6 +1527,7 @@ Array [
     "content": TypescriptGeneratedFile {
       "fileContents": "/* tslint:disable */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 
@@ -1516,6 +1557,7 @@ exports[`Typescript codeGeneration local / global multiple nested non-null list 
 TypescriptGeneratedFile {
   "fileContents": "/* tslint:disable */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 
@@ -1541,6 +1583,7 @@ Array [
     "content": TypescriptGeneratedFile {
       "fileContents": "/* tslint:disable */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 
@@ -1578,6 +1621,7 @@ export interface HeroFragmentVariables {
     "content": TypescriptGeneratedFile {
       "fileContents": "/* tslint:disable */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 
@@ -1604,6 +1648,7 @@ exports[`Typescript codeGeneration local / global query with fragment spreads 2`
 TypescriptGeneratedFile {
   "fileContents": "/* tslint:disable */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 
@@ -1633,6 +1678,7 @@ Array [
     "content": TypescriptGeneratedFile {
       "fileContents": "/* tslint:disable */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 
@@ -1659,6 +1705,7 @@ exports[`Typescript codeGeneration local / global simple fragment 2`] = `
 TypescriptGeneratedFile {
   "fileContents": "/* tslint:disable */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 
@@ -1679,6 +1726,7 @@ Array [
     "content": TypescriptGeneratedFile {
       "fileContents": "/* tslint:disable */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 
@@ -1719,6 +1767,7 @@ exports[`Typescript codeGeneration local / global simple hero query 2`] = `
 TypescriptGeneratedFile {
   "fileContents": "/* tslint:disable */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 
@@ -1748,6 +1797,7 @@ Array [
     "content": TypescriptGeneratedFile {
       "fileContents": "/* tslint:disable */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 
@@ -1789,6 +1839,7 @@ exports[`Typescript codeGeneration local / global simple mutation 2`] = `
 TypescriptGeneratedFile {
   "fileContents": "/* tslint:disable */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 
@@ -1838,6 +1889,7 @@ Array [
     "content": TypescriptGeneratedFile {
       "fileContents": "/* tslint:disable */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 
@@ -1873,6 +1925,7 @@ export interface HeroNameVariables {
     "content": TypescriptGeneratedFile {
       "fileContents": "/* tslint:disable */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 
@@ -1908,6 +1961,7 @@ export interface SomeOtherVariables {
     "content": TypescriptGeneratedFile {
       "fileContents": "/* tslint:disable */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 
@@ -1944,6 +1998,7 @@ export interface ReviewMovieVariables {
     "content": TypescriptGeneratedFile {
       "fileContents": "/* tslint:disable */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 
@@ -1971,6 +2026,7 @@ exports[`Typescript codeGeneration multiple files 3`] = `"common"`;
 exports[`Typescript codeGeneration multiple files 4`] = `
 "/* tslint:disable */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 
@@ -2015,6 +2071,7 @@ exports[`Typescript codeGeneration query with fragment spreads 1`] = `
 Object {
   "common": "/* tslint:disable */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 
@@ -2040,6 +2097,7 @@ export enum Episode {
       "content": TypescriptGeneratedFile {
         "fileContents": "/* tslint:disable */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 
@@ -2075,6 +2133,7 @@ export interface HeroFragmentVariables {
       "content": TypescriptGeneratedFile {
         "fileContents": "/* tslint:disable */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 
@@ -2102,6 +2161,7 @@ exports[`Typescript codeGeneration simple fragment 1`] = `
 Object {
   "common": "/* tslint:disable */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 
@@ -2118,6 +2178,7 @@ Object {
       "content": TypescriptGeneratedFile {
         "fileContents": "/* tslint:disable */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 
@@ -2145,6 +2206,7 @@ exports[`Typescript codeGeneration simple hero query 1`] = `
 Object {
   "common": "/* tslint:disable */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 
@@ -2170,6 +2232,7 @@ export enum Episode {
       "content": TypescriptGeneratedFile {
         "fileContents": "/* tslint:disable */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 
@@ -2209,6 +2272,7 @@ exports[`Typescript codeGeneration simple mutation 1`] = `
 Object {
   "common": "/* tslint:disable */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 
@@ -2252,6 +2316,7 @@ export interface ReviewInput {
       "content": TypescriptGeneratedFile {
         "fileContents": "/* tslint:disable */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 

--- a/packages/apollo-codegen-typescript/src/codeGeneration.ts
+++ b/packages/apollo-codegen-typescript/src/codeGeneration.ts
@@ -236,6 +236,7 @@ export class TypescriptAPIGenerator extends TypescriptGenerator {
       stripIndent`
         /* tslint:disable */
         /* eslint-disable */
+        /* prettier-disable */
         // @generated
         // This file was automatically generated and should not be edited.
       `

--- a/packages/apollo/src/commands/client/__tests__/__snapshots__/generate.test.ts.snap
+++ b/packages/apollo/src/commands/client/__tests__/__snapshots__/generate.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`client:codegen extracts queries with a custom tagName provided as a flag 1`] = `
 "/* tslint:disable */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 
@@ -19,6 +20,7 @@ export interface SimpleQuery {
 exports[`client:codegen extracts queries with a custom tagName provided in the config 1`] = `
 "/* tslint:disable */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 
@@ -44,6 +46,7 @@ exports[`client:codegen generates operation IDs for swift files when flag is set
 exports[`client:codegen writes exact Flow types when the useFlowExactObjects flag is set 1`] = `
 "/* @flow */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 
@@ -55,6 +58,7 @@ export type SimpleQuery = {|
   hello: string
 |};/* @flow */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 
@@ -70,6 +74,7 @@ export type SimpleQuery = {|
 exports[`client:codegen writes flow types 1`] = `
 "/* @flow */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 
@@ -81,6 +86,7 @@ export type SimpleQuery = {
   hello: string
 };/* @flow */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 
@@ -180,6 +186,7 @@ Object {
 exports[`client:codegen writes read-only Flow types when the deprecated flag is set 1`] = `
 "/* @flow */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 
@@ -191,6 +198,7 @@ export type SimpleQuery = {
   +hello: string
 };/* @flow */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 
@@ -206,6 +214,7 @@ export type SimpleQuery = {
 exports[`client:codegen writes read-only Flow types when the flag is set 1`] = `
 "/* @flow */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 
@@ -217,6 +226,7 @@ export type SimpleQuery = {
   +hello: string
 };/* @flow */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 
@@ -338,6 +348,7 @@ public final class SimpleQueryQuery: GraphQLQuery {
 exports[`client:codegen writes types for query with only client-side data 1`] = `
 "/* tslint:disable */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 
@@ -357,6 +368,7 @@ export interface SimpleQuery {
 
 /* tslint:disable */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 
@@ -414,6 +426,7 @@ object SimpleQueryQuery extends com.apollographql.scalajs.GraphQLQuery {
 exports[`client:codegen writes types for typescript 1`] = `
 "/* tslint:disable */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 
@@ -427,6 +440,7 @@ export interface SimpleQuery {
 
 /* tslint:disable */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 
@@ -443,6 +457,7 @@ export interface SimpleQuery {
 exports[`client:codegen writes types for typescript with a custom extension 1`] = `
 "/* tslint:disable */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 
@@ -459,6 +474,7 @@ export interface SimpleQuery {
 exports[`client:codegen writes typescript types for query with client-side data when client schema in graphql file 1`] = `
 "/* tslint:disable */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 
@@ -492,6 +508,7 @@ export interface SimpleQuery {
 
 /* tslint:disable */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 
@@ -508,6 +525,7 @@ export interface SimpleQuery {
 exports[`client:codegen writes typescript types for query with client-side data when client schema in js file 1`] = `
 "/* tslint:disable */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 
@@ -541,6 +559,7 @@ export interface SimpleQuery {
 
 /* tslint:disable */
 /* eslint-disable */
+/* prettier-disable */
 // @generated
 // This file was automatically generated and should not be edited.
 


### PR DESCRIPTION
TypeScript and Flow generated files are already ignored by ESLint and TSLint. This PR makes Prettier ignore generated files as well.

TODO:

- [x] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [x] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests and linter rules pass
