### PR TITLE
ci: Disable single VS Code test because of failing VS Code test harness.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,24 +105,6 @@ jobs:
             ls ./oclif-dist/apollo-v${VERSION}/
             /go/bin/ghr -t ${GH_TOKEN} -c ${CIRCLE_SHA1} -delete apollo@${VERSION} "./oclif-dist/apollo-v${VERSION}/"
 
-  Test VSCode:
-    executor: { name: oss/node, tag: "12" }
-    steps:
-      - run:
-          name: Install deps for VSCode / GUI
-          command: sudo apt-get update && sudo apt-get install -y nodejs libgtk3.0 libxss1 libgconf-2-4 libasound2 libnss3 x11-xserver-utils xvfb
-      - oss/install_specific_npm_version
-      - checkout
-      - oss/npm_clean_install_with_caching
-      - run:
-          name: Initialize false display for headless env
-          command: Xvfb :99
-          background: true
-      - run:
-          name: Run VSCode tests
-          command: npm run test:vscode
-          environment:
-            DISPLAY: :99
   # Other tests, unrelated to typical code tests.
   Linting:
     executor: { name: oss/node, tag: "12" }
@@ -192,8 +174,6 @@ workflows:
           <<: *common_non_publish_filters
       - NodeJS 14:
           <<: *common_non_publish_filters
-      - Test VSCode:
-          <<: *common_non_publish_filters
       - Build VSCode:
           <<: *common_non_publish_filters
       - Linting:
@@ -216,11 +196,6 @@ workflows:
             - NodeJS 12
             - NodeJS 12 Windows
             - NodeJS 14
-            # VS Code tests just don't work anymore because of a
-            # transitive update that couldn't be tracked down.
-            # There is only one low-impact test that is run, so
-            # just disabling this test from blocking the workflows
-            # - Test VSCode
             - Build VSCode
       - Publish GitHub Release:
           <<: *common_publish_filters
@@ -235,11 +210,6 @@ workflows:
             - NodeJS 12
             - NodeJS 12 Windows
             - NodeJS 14
-            # VS Code tests just don't work anymore because of a
-            # transitive update that couldn't be tracked down.
-            # There is only one low-impact test that is run, so
-            # just disabling this test from blocking the workflows
-            # - Test VSCode
             - Build VSCode
             - Build CLI
       - oss/confirmation:


### PR DESCRIPTION
The "VS Code" testing that we have setup, while something that has been implemented for a while, is relatively under-used; there is only a single test today.

That testing framework was put in place some time ago, using a package and a technique that is now-deprecated and should be upgraded to a new pattern:

https://code.visualstudio.com/api/working-with-extensions/testing-extension#migrating-from-vscode

Unfortunately, something about the existing `vscode` extension's technique of automatically downloading VSCode versions from their infrastructure just stopped working randomly with no changes at all to the dependencies of this package.  I found this through a long git-bisect process which revealed that even old commits years ago and even the commit that first introduced the testing are now failing.

Since there is only one test which tests a very small unlikely to be touched statusbar component of the VS Code extension, I am disabling the VS Code testing in CircleCI since it's complicating all PRs right now and is not really providing much in the way of confidence around the overall stability of the VS Code extension anyhow.