### PR TITLE
Install missing `sha.js` dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 - `apollo-env`
   - <First `apollo-env` related entry goes here>
 - `apollo-graphql`
-  - <First `apollo-graphql` related entry goes here>
+  - Add missing `sha.js` dependency [PR #2283](https://github.com/apollographql/apollo-tooling/pull/2283)
 - `apollo-language-server`
   - <First `apollo-language-server` related entry goes here>
 - `apollo-tools`

--- a/package-lock.json
+++ b/package-lock.json
@@ -2972,6 +2972,15 @@
       "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
       "dev": true
     },
+    "@types/sha.js": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@types/sha.js/-/sha.js-2.4.0.tgz",
+      "integrity": "sha512-amxKgPy6WJTKuw8mpUwjX2BSxuBtBmZfRwIUDIuPJKNwGN8CWDli8JTg5ONTWOtcTkHIstvT7oAhhYXqEjStHQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/sinon": {
       "version": "9.0.9",
       "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-9.0.9.tgz",
@@ -4916,7 +4925,8 @@
       "version": "file:packages/apollo-graphql",
       "requires": {
         "core-js-pure": "^3.10.2",
-        "lodash.sortby": "^4.7.0"
+        "lodash.sortby": "^4.7.0",
+        "sha.js": "^2.4.11"
       }
     },
     "apollo-language-server": {

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "@types/nock": "10.0.3",
     "@types/node": "8.10.66",
     "@types/node-fetch": "2.5.10",
+    "@types/sha.js": "2.4.0",
     "@types/table": "6.0.0",
     "cross-env": "7.0.3",
     "graphql": "15.2.0",

--- a/packages/apollo-graphql/package.json
+++ b/packages/apollo-graphql/package.json
@@ -12,7 +12,8 @@
   },
   "dependencies": {
     "core-js-pure": "^3.10.2",
-    "lodash.sortby": "^4.7.0"
+    "lodash.sortby": "^4.7.0",
+    "sha.js": "^2.4.11"
   },
   "peerDependencies": {
     "graphql": "^14.2.1 || ^15.0.0"

--- a/packages/apollo-graphql/src/utilities/createHash.ts
+++ b/packages/apollo-graphql/src/utilities/createHash.ts
@@ -4,7 +4,10 @@ export function createHash(kind: string): import("crypto").Hash {
   if (isNodeLike) {
     // Use module.require instead of just require to avoid bundling whatever
     // crypto polyfills a non-Node bundler might fall back to.
-    return module.require("crypto").createHash(kind);
+    return (module.require("crypto") as typeof import("crypto")).createHash(
+      kind
+    );
   }
-  return require("sha.js")(kind);
+
+  return (require("sha.js") as typeof import("sha.js"))(kind);
 }


### PR DESCRIPTION
Related to #2274, which removes a dependency on `apollo-env` which transitively required this package (presumably, unconfirmed but I will validate).

This also adds typings to the require() statements for the respective modules.

<!--
  Thanks for filing a pull request on Apollo Tooling!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [x] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass

\*Make sure changelog entries note which project(s) has been affected. See older entries for examples on what this looks like.
