### PR TITLE
Deprecate apollo CLI service:* commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,12 @@
 - `vscode-apollo`
   - <First `vscode-apollo` related entry goes here>
 
-### apollo-env@0.10.0
+## apollo@2.33.2
+
+- Add a deprecation message to all `apollo service:*` commands, pointing people towards the [Apollo Rover CLI migration guide](https://go.apollo.dev/t/migration). <br/>
+  [@hwillson](https://github.com/hwillson) in [#2308](https://github.com/apollographql/apollo-tooling/pull/2308)
+
+## apollo-env@0.10.0
 
 - deps: Updated `node-fetch` to v2.6.1
 

--- a/packages/apollo/README.md
+++ b/packages/apollo/README.md
@@ -23,7 +23,7 @@ $ npm install -g apollo
 $ apollo COMMAND
 running command...
 $ apollo (-v|--version|version)
-apollo/2.33.1 linux-x64 node-v14.16.1
+apollo/2.33.1 darwin-x64 node-v14.15.3
 $ apollo --help [COMMAND]
 USAGE
   $ apollo COMMAND
@@ -642,10 +642,16 @@ _See code: [@oclif/plugin-plugins](https://github.com/oclif/plugin-plugins/blob/
 
 ## `apollo service:check`
 
-Check a service against known operation workloads to find breaking changes
+[DEPRECATED] Check a service against known operation workloads to find breaking changes
 
 ```
-Check a service against known operation workloads to find breaking changes
+[DEPRECATED] Check a service against known operation workloads to find breaking changes
+-----------------------------------------------------------------
+DEPRECATED: This command will be removed from the `apollo` CLI in 
+its next major version. Replacement functionality is available in 
+the new Apollo Rover CLI: https://go.apollo.dev/t/migration
+-----------------------------------------------------------------
+
 
 USAGE
   $ apollo service:check
@@ -716,6 +722,13 @@ OPTIONS
       for more granularity (see: 
       https://en.wikipedia.org/wiki/ISO_8601#Durations)
 
+DESCRIPTION
+  -----------------------------------------------------------------
+  DEPRECATED: This command will be removed from the `apollo` CLI in 
+  its next major version. Replacement functionality is available in 
+  the new Apollo Rover CLI: https://go.apollo.dev/t/migration
+  -----------------------------------------------------------------
+
 ALIASES
   $ apollo schema:check
 ```
@@ -724,10 +737,16 @@ _See code: [src/commands/service/check.ts](https://github.com/apollographql/apol
 
 ## `apollo service:delete`
 
-Delete a federated service from Apollo and recompose remaining services
+[DEPRECATED] Delete a federated service from Apollo and recompose remaining services
 
 ```
-Delete a federated service from Apollo and recompose remaining services
+[DEPRECATED] Delete a federated service from Apollo and recompose remaining services
+-----------------------------------------------------------------
+DEPRECATED: This command will be removed from the `apollo` CLI in 
+its next major version. Replacement functionality is available in 
+the new Apollo Rover CLI: https://go.apollo.dev/t/migration
+-----------------------------------------------------------------
+
 
 USAGE
   $ apollo service:delete
@@ -758,16 +777,29 @@ OPTIONS
 
   --serviceName=serviceName  (required) Provides the name of the
                              implementing service for a federated graph
+
+DESCRIPTION
+  -----------------------------------------------------------------
+  DEPRECATED: This command will be removed from the `apollo` CLI in 
+  its next major version. Replacement functionality is available in 
+  the new Apollo Rover CLI: https://go.apollo.dev/t/migration
+  -----------------------------------------------------------------
 ```
 
 _See code: [src/commands/service/delete.ts](https://github.com/apollographql/apollo-tooling/blob/master/packages/apollo/src/commands/service/delete.ts)_
 
 ## `apollo service:download OUTPUT`
 
-Download the schema from your GraphQL endpoint.
+[DEPRECATED] Download the schema from your GraphQL endpoint.
 
 ```
-Download the schema from your GraphQL endpoint.
+[DEPRECATED] Download the schema from your GraphQL endpoint.
+-----------------------------------------------------------------
+DEPRECATED: This command will be removed from the `apollo` CLI in 
+its next major version. Replacement functionality is available in 
+the new Apollo Rover CLI: https://go.apollo.dev/t/migration
+-----------------------------------------------------------------
+
 
 USAGE
   $ apollo service:download OUTPUT
@@ -797,6 +829,13 @@ OPTIONS
 
   --key=key                The API key to use for authentication to Apollo
 
+DESCRIPTION
+  -----------------------------------------------------------------
+  DEPRECATED: This command will be removed from the `apollo` CLI in 
+  its next major version. Replacement functionality is available in 
+  the new Apollo Rover CLI: https://go.apollo.dev/t/migration
+  -----------------------------------------------------------------
+
 ALIASES
   $ apollo schema:download
 ```
@@ -805,10 +844,16 @@ _See code: [src/commands/service/download.ts](https://github.com/apollographql/a
 
 ## `apollo service:list`
 
-List the services in a graph
+[DEPRECATED] List the services in a graph
 
 ```
-List the services in a graph
+[DEPRECATED] List the services in a graph
+-----------------------------------------------------------------
+DEPRECATED: This command will be removed from the `apollo` CLI in 
+its next major version. Replacement functionality is available in 
+the new Apollo Rover CLI: https://go.apollo.dev/t/migration
+-----------------------------------------------------------------
+
 
 USAGE
   $ apollo service:list
@@ -831,16 +876,29 @@ OPTIONS
                          if using the `--header` flag.
 
   --key=key              The API key to use for authentication to Apollo
+
+DESCRIPTION
+  -----------------------------------------------------------------
+  DEPRECATED: This command will be removed from the `apollo` CLI in 
+  its next major version. Replacement functionality is available in 
+  the new Apollo Rover CLI: https://go.apollo.dev/t/migration
+  -----------------------------------------------------------------
 ```
 
 _See code: [src/commands/service/list.ts](https://github.com/apollographql/apollo-tooling/blob/master/packages/apollo/src/commands/service/list.ts)_
 
 ## `apollo service:push`
 
-Push a service definition to Apollo
+[DEPRECATED] Push a service definition to Apollo
 
 ```
-Push a service definition to Apollo
+[DEPRECATED] Push a service definition to Apollo
+-----------------------------------------------------------------
+DEPRECATED: This command will be removed from the `apollo` CLI in 
+its next major version. Replacement functionality is available in 
+the new Apollo Rover CLI: https://go.apollo.dev/t/migration
+-----------------------------------------------------------------
+
 
 USAGE
   $ apollo service:push
@@ -891,6 +949,13 @@ OPTIONS
   --serviceURL=serviceURL
       Provides the url to the location of the implementing service for a 
       federated graph
+
+DESCRIPTION
+  -----------------------------------------------------------------
+  DEPRECATED: This command will be removed from the `apollo` CLI in 
+  its next major version. Replacement functionality is available in 
+  the new Apollo Rover CLI: https://go.apollo.dev/t/migration
+  -----------------------------------------------------------------
 
 ALIASES
   $ apollo schema:publish

--- a/packages/apollo/package.json
+++ b/packages/apollo/package.json
@@ -111,6 +111,9 @@
         "tsConfig": "<rootDir>/tsconfig.test.json",
         "diagnostics": false
       }
-    }
+    },
+    "setupFilesAfterEnv": [
+      "<rootDir>/test-utils/setup.js"
+    ]
   }
 }

--- a/packages/apollo/src/Command.ts
+++ b/packages/apollo/src/Command.ts
@@ -284,10 +284,13 @@ export abstract class ProjectCommand extends Command {
   }
 
   protected printDeprecationWarning() {
+    const separator = "-".repeat(65);
     console.error(
+      `\n${separator}\n` +
       "DEPRECATED: This command will be removed from the `apollo` CLI in \n" +
       "its next major version. Replacement functionality is available in \n" +
-      "the new Apollo Rover CLI: https://go.apollo.dev/t/migration \n"
+      "the new Apollo Rover CLI: https://go.apollo.dev/t/migration\n" +
+      `${separator}\n`
     );
   }
 }

--- a/packages/apollo/src/Command.ts
+++ b/packages/apollo/src/Command.ts
@@ -283,15 +283,15 @@ export abstract class ProjectCommand extends Command {
     // called after run and catch regardless of whether or not the command errored
   }
 
+  static DEPRECATION_MSG =
+    "\n-----------------------------------------------------------------\n" +
+    "DEPRECATED: This command will be removed from the `apollo` CLI in \n" +
+    "its next major version. Replacement functionality is available in \n" +
+    "the new Apollo Rover CLI: https://go.apollo.dev/t/migration\n" +
+    "-----------------------------------------------------------------\n";
+
   protected printDeprecationWarning() {
-    const separator = "-".repeat(65);
-    console.error(
-      `\n${separator}\n` +
-      "DEPRECATED: This command will be removed from the `apollo` CLI in \n" +
-      "its next major version. Replacement functionality is available in \n" +
-      "the new Apollo Rover CLI: https://go.apollo.dev/t/migration\n" +
-      `${separator}\n`
-    );
+    console.error(ProjectCommand.DEPRECATION_MSG);
   }
 }
 

--- a/packages/apollo/src/Command.ts
+++ b/packages/apollo/src/Command.ts
@@ -282,6 +282,14 @@ export abstract class ProjectCommand extends Command {
   async finally(err) {
     // called after run and catch regardless of whether or not the command errored
   }
+
+  protected printDeprecationWarning() {
+    console.error(
+      "DEPRECATED: This command will be removed from the `apollo` CLI in \n" +
+      "its next major version. Replacement functionality is available in \n" +
+      "the new Apollo Rover CLI: https://go.apollo.dev/t/migration \n"
+    );
+  }
 }
 
 export abstract class ClientCommand extends ProjectCommand {

--- a/packages/apollo/src/commands/service/check.ts
+++ b/packages/apollo/src/commands/service/check.ts
@@ -294,6 +294,8 @@ export default class ServiceCheck extends ProjectCommand {
   };
 
   async run() {
+    this.printDeprecationWarning();
+
     // @ts-ignore we're going to populate `taskOutput` later
     const taskOutput: TasksOutput = {};
 

--- a/packages/apollo/src/commands/service/check.ts
+++ b/packages/apollo/src/commands/service/check.ts
@@ -229,7 +229,8 @@ export function formatHumanReadable({
 export default class ServiceCheck extends ProjectCommand {
   static aliases = ["schema:check"];
   static description =
-    "Check a service against known operation workloads to find breaking changes";
+    "[DEPRECATED] Check a service against known operation workloads to find breaking changes" +
+    ProjectCommand.DEPRECATION_MSG;
   static flags = {
     ...ProjectCommand.flags,
     tag: flags.string({

--- a/packages/apollo/src/commands/service/delete.ts
+++ b/packages/apollo/src/commands/service/delete.ts
@@ -6,7 +6,8 @@ import { graphUndefinedError } from "../../utils/sharedMessages";
 
 export default class ServiceDelete extends ProjectCommand {
   static description =
-    "Delete a federated service from Apollo and recompose remaining services";
+    "[DEPRECATED] Delete a federated service from Apollo and recompose remaining services" +
+    ProjectCommand.DEPRECATION_MSG;
   static flags = {
     ...ProjectCommand.flags,
     tag: flags.string({

--- a/packages/apollo/src/commands/service/delete.ts
+++ b/packages/apollo/src/commands/service/delete.ts
@@ -46,6 +46,8 @@ export default class ServiceDelete extends ProjectCommand {
   };
 
   async run() {
+    this.printDeprecationWarning();
+
     let result;
     const { flags } = this.parse(ServiceDelete);
 

--- a/packages/apollo/src/commands/service/download.ts
+++ b/packages/apollo/src/commands/service/download.ts
@@ -8,7 +8,9 @@ import { dirname as getDirName } from "path";
 
 export default class ServiceDownload extends ProjectCommand {
   static aliases = ["schema:download"];
-  static description = "Download the schema from your GraphQL endpoint.";
+  static description =
+    "[DEPRECATED] Download the schema from your GraphQL endpoint." +
+    ProjectCommand.DEPRECATION_MSG;
 
   static flags = {
     ...ProjectCommand.flags,

--- a/packages/apollo/src/commands/service/download.ts
+++ b/packages/apollo/src/commands/service/download.ts
@@ -46,6 +46,8 @@ export default class ServiceDownload extends ProjectCommand {
   ];
 
   async run() {
+    this.printDeprecationWarning();
+
     await this.runTasks(({ args, project, flags, config }) => [
       {
         title: `Saving schema to ${args.output}`,

--- a/packages/apollo/src/commands/service/list.ts
+++ b/packages/apollo/src/commands/service/list.ts
@@ -84,7 +84,9 @@ function formatHumanReadable({
 }
 
 export default class ServiceList extends ProjectCommand {
-  static description = "List the services in a graph";
+  static description =
+    "[DEPRECATED] List the services in a graph" +
+    ProjectCommand.DEPRECATION_MSG;
   static flags = {
     ...ProjectCommand.flags,
     tag: flags.string({

--- a/packages/apollo/src/commands/service/list.ts
+++ b/packages/apollo/src/commands/service/list.ts
@@ -107,6 +107,8 @@ export default class ServiceList extends ProjectCommand {
   };
 
   async run() {
+    this.printDeprecationWarning();
+
     // @ts-ignore we're going to populate `taskOutput` later
     const taskOutput: TasksOutput = {};
 

--- a/packages/apollo/src/commands/service/push.ts
+++ b/packages/apollo/src/commands/service/push.ts
@@ -65,6 +65,8 @@ export default class ServicePush extends ProjectCommand {
   };
 
   async run() {
+    this.printDeprecationWarning();
+
     let result;
     let isFederated;
     let gitContext;

--- a/packages/apollo/src/commands/service/push.ts
+++ b/packages/apollo/src/commands/service/push.ts
@@ -10,7 +10,9 @@ import { graphUndefinedError } from "../../utils/sharedMessages";
 
 export default class ServicePush extends ProjectCommand {
   static aliases = ["schema:publish"];
-  static description = "Push a service definition to Apollo";
+  static description =
+    "[DEPRECATED] Push a service definition to Apollo" +
+    ProjectCommand.DEPRECATION_MSG;
   static flags = {
     ...ProjectCommand.flags,
     tag: flags.string({

--- a/packages/apollo/test-utils/setup.js
+++ b/packages/apollo/test-utils/setup.js
@@ -1,0 +1,7 @@
+global.console = {
+  log: jest.fn(),
+  error: jest.fn(),
+  warn: console.warn,
+  info: console.info,
+  debug: console.debug,
+};


### PR DESCRIPTION
This PR deprecates the `apollo` CLI `service:*` commands by:

- Printing (to `stderr`) deprecation messages for all runtime `apollo service:*` commands (pointing people to the [Rover migration guide](https://go.apollo.dev/t/migration))
- Printing deprecation messages when using `apollo service:*` CLI `help` commands
- Labelling all `service:*` commands as deprecated in the `README`

`service:*` functionality has not been removed since this PR will be rolled out in a patch release. After Rover is officially released, we’ll push out a new major version of `apollo` that fully removes the `service:*` commands.

Reference: https://github.com/apollographql/rover/issues/471