### PR TITLE
fix(apollo-graphql): support complex directive args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 - `apollo-env`
   - <First `apollo-env` related entry goes here>
 - `apollo-graphql`
-  - <First `apollo-graphql` related entry goes here>
+  - Complex directive arguments don't break `transformSchema` (Fixes #2162)
 - `apollo-language-server`
   - <First `apollo-language-server` related entry goes here>
 - `apollo-tools`

--- a/packages/apollo-graphql/src/schema/__tests__/transformSchema.test.ts
+++ b/packages/apollo-graphql/src/schema/__tests__/transformSchema.test.ts
@@ -1,0 +1,23 @@
+import { buildSchema, printSchema } from "graphql";
+import { transformSchema } from "../transformSchema";
+
+describe("transformSchema", () => {
+  test("no-op transform leaves types untouched", () => {
+    const schema = buildSchema(`#graphql
+    type Query {
+      foo: String @test(baz: { bar: "hello" })
+    }
+
+    input DirectiveArg {
+      bar: String
+    }
+
+    # https://github.com/apollographql/apollo-tooling/issues/2162
+    directive @test(baz: DirectiveArg) on FIELD_DEFINITION
+    `);
+
+    const newSchema = transformSchema(schema, namedType => namedType);
+
+    expect(printSchema(newSchema)).toEqual(printSchema(schema));
+  });
+});

--- a/packages/apollo-graphql/src/schema/transformSchema.ts
+++ b/packages/apollo-graphql/src/schema/transformSchema.ts
@@ -19,7 +19,8 @@ import {
   GraphQLUnionType,
   isInputObjectType,
   GraphQLInputObjectType,
-  GraphQLInputFieldConfigMap
+  GraphQLInputFieldConfigMap,
+  GraphQLDirective
 } from "graphql";
 import { mapValues } from "../utilities/mapValues";
 
@@ -53,7 +54,8 @@ export function transformSchema(
     types: Object.values(typeMap),
     query: replaceMaybeType(schemaConfig.query),
     mutation: replaceMaybeType(schemaConfig.mutation),
-    subscription: replaceMaybeType(schemaConfig.subscription)
+    subscription: replaceMaybeType(schemaConfig.subscription),
+    directives: replaceDirectives(schemaConfig.directives)
   });
 
   function recreateNamedType(type: GraphQLNamedType): GraphQLNamedType {
@@ -144,5 +146,15 @@ export function transformSchema(
       ...arg,
       type: replaceType(arg.type)
     }));
+  }
+
+  function replaceDirectives(directives: GraphQLDirective[]) {
+    return directives.map(directive => {
+      const config = directive.toConfig();
+      return new GraphQLDirective({
+        ...config,
+        args: replaceArgs(config.args)
+      });
+    });
   }
 }


### PR DESCRIPTION
This change fixes `transformSchema`, which previously left directives as-in after transforming types. This meant that Input types used in directive arguments would appear duplicated in the schema. It now recreates schema directives and their arguments like it does with named schema types.

Fixes #2162

<!--
  Thanks for filing a pull request on Apollo Tooling!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [x] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass

\*Make sure changelog entries note which project(s) has been affected. See older entries for examples on what this looks like.
