### PR TITLE
apollo-tools: remove dependency on apollo-env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,8 +25,12 @@
 - `vscode-apollo`
   - <First `vscode-apollo` related entry goes here>
 
+## apollo-tools@0.5.1
+- Remove dependency on `apollo-env`, so using this package no longer installs polyfills.
+
 ## apollo-graphql@0.9.3
 - Complex directive arguments don't break `transformSchema` (Fixes #2162) [PR #2335](https://github.com/apollographql/apollo-tooling/pull/2335)
+
 ## apollo@2.33.2
 
 - Add a deprecation message to all `apollo service:*` commands, pointing people towards the [Apollo Rover CLI migration guide](https://go.apollo.dev/t/migration). <br/>

--- a/package-lock.json
+++ b/package-lock.json
@@ -18808,7 +18808,7 @@
       }
     },
     "packages/apollo": {
-      "version": "2.33.2",
+      "version": "2.33.3",
       "license": "MIT",
       "dependencies": {
         "@apollographql/apollo-tools": "file:../apollo-tools",
@@ -18861,7 +18861,7 @@
       }
     },
     "packages/apollo-codegen-core": {
-      "version": "0.40.1",
+      "version": "0.40.2",
       "license": "MIT",
       "dependencies": {
         "@babel/generator": "7.14.2",
@@ -18933,7 +18933,7 @@
       "integrity": "sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ=="
     },
     "packages/apollo-codegen-flow": {
-      "version": "0.38.1",
+      "version": "0.38.2",
       "license": "MIT",
       "dependencies": {
         "@babel/generator": "7.14.2",
@@ -19122,7 +19122,7 @@
       }
     },
     "packages/apollo-codegen-scala": {
-      "version": "0.39.1",
+      "version": "0.39.2",
       "license": "MIT",
       "dependencies": {
         "apollo-codegen-core": "file:../apollo-codegen-core",
@@ -19271,7 +19271,7 @@
       }
     },
     "packages/apollo-codegen-swift": {
-      "version": "0.40.1",
+      "version": "0.40.2",
       "license": "MIT",
       "dependencies": {
         "apollo-codegen-core": "file:../apollo-codegen-core",
@@ -19420,7 +19420,7 @@
       }
     },
     "packages/apollo-codegen-typescript": {
-      "version": "0.40.1",
+      "version": "0.40.2",
       "license": "MIT",
       "dependencies": {
         "@babel/generator": "7.14.2",
@@ -19622,7 +19622,7 @@
       }
     },
     "packages/apollo-graphql": {
-      "version": "0.9.2",
+      "version": "0.9.3",
       "license": "MIT",
       "dependencies": {
         "core-js-pure": "^3.10.2",
@@ -19637,7 +19637,7 @@
       }
     },
     "packages/apollo-language-server": {
-      "version": "1.26.1",
+      "version": "1.26.2",
       "license": "MIT",
       "dependencies": {
         "@apollo/federation": "0.25.0",
@@ -19683,9 +19683,6 @@
       "name": "@apollographql/apollo-tools",
       "version": "0.5.0",
       "license": "MIT",
-      "dependencies": {
-        "apollo-env": "file:../apollo-env"
-      },
       "engines": {
         "node": ">=8",
         "npm": ">=6"
@@ -20887,7 +20884,7 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "packages/vscode-apollo": {
-      "version": "1.19.1",
+      "version": "1.19.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -20911,10 +20908,7 @@
       }
     },
     "@apollographql/apollo-tools": {
-      "version": "file:packages/apollo-tools",
-      "requires": {
-        "apollo-env": "file:../apollo-env"
-      }
+      "version": "file:packages/apollo-tools"
     },
     "@apollographql/graphql-language-service-interface": {
       "version": "2.0.2",

--- a/packages/apollo-tools/package.json
+++ b/packages/apollo-tools/package.json
@@ -15,9 +15,6 @@
     "node": ">=8",
     "npm": ">=6"
   },
-  "dependencies": {
-    "apollo-env": "file:../apollo-env"
-  },
   "jest": {
     "preset": "ts-jest",
     "testEnvironment": "node",
@@ -33,9 +30,6 @@
     ],
     "transformIgnorePatterns": [
       "/node_modules/"
-    ],
-    "setupFiles": [
-      "apollo-env"
     ],
     "snapshotSerializers": [
       "<rootDir>/src/__tests__/snapshotSerializers/astSerializer.ts",

--- a/packages/apollo-tools/src/index.ts
+++ b/packages/apollo-tools/src/index.ts
@@ -1,5 +1,3 @@
-import "apollo-env";
-
 export * from "./utilities";
 
 export * from "./schema";

--- a/packages/apollo-tools/tsconfig.json
+++ b/packages/apollo-tools/tsconfig.json
@@ -5,6 +5,5 @@
     "outDir": "./lib"
   },
   "include": ["./src/**/*"],
-  "exclude": ["**/__tests__/*", "**/__mocks__/*"],
-  "references": [{ "path": "../apollo-env" }]
+  "exclude": ["**/__tests__/*", "**/__mocks__/*"]
 }


### PR DESCRIPTION
As far as I can tell, the only use `@apollographql/apollo-tools` makes
of `apollo-env` is the ability to use `Array.flat` in pre-12 Node. Now,
we probably should just make this whole repo require Node 12 like we are
doing for Apollo Server 3. But a simpler way to break this dependency is
to just implement a single-level Array.flat ourselves. (The calls to
Array.flat do not take advantage of its ability to flatten more than one
level of nested array.)

This will allow us to stop installing polyfills in Apollo Server 3 (see
apollographql/apollo-server#2634).
