### PR TITLE
Swift codegen: Include namespace in fragment struct type names

### DIFF
--- a/packages/apollo-codegen-swift/src/codeGeneration.ts
+++ b/packages/apollo-codegen-swift/src/codeGeneration.ts
@@ -339,7 +339,7 @@ export class SwiftAPIGenerator extends SwiftGenerator<CompilerContext> {
     outputIndividualFiles: boolean,
     suppressMultilineStringLiterals: boolean
   ) {
-    const structName = this.helpers.structNameForFragmentName(fragmentName);
+    const structName = this.helpers.structDeclarationNameForFragmentName(fragmentName);
 
     this.structDeclarationForSelectionSet(
       {

--- a/packages/apollo-codegen-swift/src/helpers.ts
+++ b/packages/apollo-codegen-swift/src/helpers.ts
@@ -125,7 +125,22 @@ export class Helpers {
     return pascalCase(Inflector.singularize(propertyName));
   }
 
-  structNameForFragmentName(fragmentName: string) {
+  /**
+   * Returns the Swift name for a struct representing a fragment. This must contain
+   * the application namespace in case the fragment name is the same as the name of any
+   * field in the current query, otherwise, Swift will assume the type reference is to
+   * the struct that we're inside the namespace of.
+   */
+   structNameForFragmentName(fragmentName: string) {
+    const prefix = this.options.namespace ? `${this.options.namespace}.` : "";
+    return `${prefix}${pascalCase(fragmentName)}`;
+  }
+
+  /**
+   * Returns the Swift struct name that is being declared. When declaring a struct in Swift,
+   * no namespace can be included in the name.
+  */
+  structDeclarationNameForFragmentName(fragmentName: string) {
     return pascalCase(fragmentName);
   }
 


### PR DESCRIPTION
Fixes #2396

By placing the namespace in front of any fragment struct name, we can ensure that the fragment type will be unambiguous. If the fragment is used in a query that has a node (and therefore type name) with the same name as the fragment's type name, Swift doesn't get confused about which type is being referred to.

However, the namespace is not included in the name when declaring the fragment's struct, so there's a new method that is used to get the name for its declaration.

TODO:

- [ ] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [ ] Make sure all of the significant new logic is covered by tests
- [ ] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests and linter rules pass

\*Make sure changelog entries note which project(s) has been affected. See older entries for examples on what this looks like.
