### PR TITLE
Remove TTY package due to security vulnerability

### DIFF
--- a/packages/apollo/src/commands/client/codegen.ts
+++ b/packages/apollo/src/commands/client/codegen.ts
@@ -2,7 +2,6 @@ import "apollo-env";
 import { flags } from "@oclif/command";
 import path from "path";
 import { Kind, DocumentNode } from "graphql";
-import tty from "tty";
 import { Gaze } from "gaze";
 import URI from "vscode-uri";
 import chalk from "chalk";
@@ -273,7 +272,8 @@ export default class Generate extends ClientCommand {
           Debug.error("Error while generating types: " + e.message);
         }
       });
-      if (tty.isatty((process.stdin as any).fd)) {
+
+      if (process.stdin.isTTY) {
         await waitForKey();
         watcher.close();
         process.exit(0);


### PR DESCRIPTION
Removal of usage of tty npm package as it's been removed from npm due to potential security issues. 

https://www.npmjs.com/package/tty

<!--
  Thanks for filing a pull request on Apollo Tooling!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [ ] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [ ] Make sure all of the significant new logic is covered by tests
- [ ] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass

\*Make sure changelog entries note which project(s) has been affected. See older entries for examples on what this looks like.
