### PR TITLE
fix(apollo-graphql): Preserve directive usages on SchemaDefinition nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - `apollo-graphql`
   - Export useful operation sanitization transforms [PR #2057](https://github.com/apollographql/apollo-tooling/pull/2057)
+  - Preserve directive usages on SchemaDefinition nodes in `buildSchemaFromSDL` [PR #2457](https://github.com/apollographql/apollo-tooling/pull/2457)
 
 ## `apollo@2.33.7`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -206,18 +206,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/generator/node_modules/@babel/types": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.16.0.tgz",
-      "integrity": "sha512-PJgg/k3SdLsGb3hhisFvtLOw5ts113klrpLuIPtCJIU+BB24fqq6lf8RWqKJEjzqXR9AEH1rIb5XTqwBHB+kQg==",
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.15.7",
-        "to-fast-properties": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@babel/helper-function-name": {
       "version": "7.10.4",
       "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz",
@@ -460,11 +448,11 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.0.tgz",
-      "integrity": "sha512-OBvfqnllOIdX4ojTHpwZbpvz4j3EWyjkZEdmjH0/cgsd6QOdSgU8rLSk6ard/pcW7rlmjdVSX/AWOaORR1uNOQ==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.16.0.tgz",
+      "integrity": "sha512-PJgg/k3SdLsGb3hhisFvtLOw5ts113klrpLuIPtCJIU+BB24fqq6lf8RWqKJEjzqXR9AEH1rIb5XTqwBHB+kQg==",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.14.9",
+        "@babel/helper-validator-identifier": "^7.15.7",
         "to-fast-properties": "^2.0.0"
       },
       "engines": {
@@ -19265,7 +19253,7 @@
       "dependencies": {
         "@babel/generator": "7.16.0",
         "@babel/parser": "^7.1.3",
-        "@babel/types": "7.15.0",
+        "@babel/types": "7.16.0",
         "apollo-env": "file:../apollo-env",
         "apollo-language-server": "file:../apollo-language-server",
         "ast-types": "^0.14.0",
@@ -19298,7 +19286,7 @@
       "license": "MIT",
       "dependencies": {
         "@babel/generator": "7.16.0",
-        "@babel/types": "7.15.0",
+        "@babel/types": "7.16.0",
         "apollo-codegen-core": "file:../apollo-codegen-core",
         "change-case": "^4.0.0",
         "common-tags": "^1.5.1",
@@ -19747,7 +19735,7 @@
       "license": "MIT",
       "dependencies": {
         "@babel/generator": "7.16.0",
-        "@babel/types": "7.15.0",
+        "@babel/types": "7.16.0",
         "apollo-codegen-core": "file:../apollo-codegen-core",
         "change-case": "^4.0.0",
         "common-tags": "^1.5.1",
@@ -20258,17 +20246,6 @@
         "@babel/types": "^7.16.0",
         "jsesc": "^2.5.1",
         "source-map": "^0.5.0"
-      },
-      "dependencies": {
-        "@babel/types": {
-          "version": "7.16.0",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.16.0.tgz",
-          "integrity": "sha512-PJgg/k3SdLsGb3hhisFvtLOw5ts113klrpLuIPtCJIU+BB24fqq6lf8RWqKJEjzqXR9AEH1rIb5XTqwBHB+kQg==",
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.15.7",
-            "to-fast-properties": "^2.0.0"
-          }
-        }
       }
     },
     "@babel/helper-function-name": {
@@ -20496,11 +20473,11 @@
       }
     },
     "@babel/types": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.0.tgz",
-      "integrity": "sha512-OBvfqnllOIdX4ojTHpwZbpvz4j3EWyjkZEdmjH0/cgsd6QOdSgU8rLSk6ard/pcW7rlmjdVSX/AWOaORR1uNOQ==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.16.0.tgz",
+      "integrity": "sha512-PJgg/k3SdLsGb3hhisFvtLOw5ts113klrpLuIPtCJIU+BB24fqq6lf8RWqKJEjzqXR9AEH1rIb5XTqwBHB+kQg==",
       "requires": {
-        "@babel/helper-validator-identifier": "^7.14.9",
+        "@babel/helper-validator-identifier": "^7.15.7",
         "to-fast-properties": "^2.0.0"
       }
     },
@@ -24457,7 +24434,7 @@
       "requires": {
         "@babel/generator": "7.16.0",
         "@babel/parser": "^7.1.3",
-        "@babel/types": "7.15.0",
+        "@babel/types": "7.16.0",
         "apollo-env": "file:../apollo-env",
         "apollo-language-server": "file:../apollo-language-server",
         "ast-types": "^0.14.0",
@@ -24484,7 +24461,7 @@
       "version": "file:packages/apollo-codegen-flow",
       "requires": {
         "@babel/generator": "7.16.0",
-        "@babel/types": "7.15.0",
+        "@babel/types": "7.16.0",
         "apollo-codegen-core": "file:../apollo-codegen-core",
         "change-case": "^4.0.0",
         "common-tags": "^1.5.1",
@@ -24924,7 +24901,7 @@
       "version": "file:packages/apollo-codegen-typescript",
       "requires": {
         "@babel/generator": "7.16.0",
-        "@babel/types": "7.15.0",
+        "@babel/types": "7.16.0",
         "apollo-codegen-core": "file:../apollo-codegen-core",
         "change-case": "^4.0.0",
         "common-tags": "^1.5.1",

--- a/packages/apollo-graphql/src/schema/__tests__/buildSchemaFromSDL.test.ts
+++ b/packages/apollo-graphql/src/schema/__tests__/buildSchemaFromSDL.test.ts
@@ -371,8 +371,8 @@ type MutationRoot {
           }
         `
       );
-      expect(schema.astNode?.directives).toHaveLength(1);
-      expect(schema.astNode?.directives![0].name.value).toEqual("contact");
+      expect(schema.astNode!.directives).toHaveLength(1);
+      expect(schema.astNode!.directives![0].name.value).toEqual("contact");
     });
   });
 

--- a/packages/apollo-graphql/src/schema/__tests__/buildSchemaFromSDL.test.ts
+++ b/packages/apollo-graphql/src/schema/__tests__/buildSchemaFromSDL.test.ts
@@ -351,6 +351,29 @@ type MutationRoot {
         `"Unknown directive \\"@something\\"."`
       );
     });
+
+    it(`should preserve directive usages from the schema definition node`, () => {
+      const schema = buildSchemaFromSDL(
+        gql`
+          directive @contact(
+            name: String!
+            url: String!
+            description: String
+          ) on SCHEMA
+
+          schema
+            @contact(
+              name: "Contact"
+              url: "http://example.com/contact"
+              description: "Testing"
+            ) {
+            query: Query
+          }
+        `
+      );
+      expect(schema.astNode?.directives).toHaveLength(1);
+      expect(schema.astNode?.directives![0].name.value).toEqual("contact");
+    });
   });
 
   describe(`resolvers`, () => {

--- a/packages/apollo-graphql/src/schema/buildSchemaFromSDL.ts
+++ b/packages/apollo-graphql/src/schema/buildSchemaFromSDL.ts
@@ -218,7 +218,7 @@ export function buildSchemaFromSDL(
         : undefined
     ),
     astNode: {
-      kind: 'SchemaDefinition',
+      kind: Kind.SCHEMA_DEFINITION,
       directives: schemaDirectives,
       operationTypes: [] // satisfies typescript, will be ignored
     }

--- a/packages/apollo-graphql/src/schema/buildSchemaFromSDL.ts
+++ b/packages/apollo-graphql/src/schema/buildSchemaFromSDL.ts
@@ -132,7 +132,7 @@ export function buildSchemaFromSDL(
       directiveDefinitions.push(definition);
     } else if (definition.kind === Kind.SCHEMA_DEFINITION) {
       schemaDefinitions.push(definition);
-      schemaDirectives.push(...(definition.directives ?? []))
+      schemaDirectives.push(...(definition.directives ?? []));
     } else if (definition.kind === Kind.SCHEMA_EXTENSION) {
       schemaExtensions.push(definition);
     }

--- a/packages/apollo-graphql/src/schema/buildSchemaFromSDL.ts
+++ b/packages/apollo-graphql/src/schema/buildSchemaFromSDL.ts
@@ -132,7 +132,9 @@ export function buildSchemaFromSDL(
       directiveDefinitions.push(definition);
     } else if (definition.kind === Kind.SCHEMA_DEFINITION) {
       schemaDefinitions.push(definition);
-      schemaDirectives.push(...(definition.directives ?? []));
+      schemaDirectives.push(
+        ...(definition.directives ? definition.directives : [])
+      );
     } else if (definition.kind === Kind.SCHEMA_EXTENSION) {
       schemaExtensions.push(definition);
     }

--- a/packages/apollo-graphql/src/schema/buildSchemaFromSDL.ts
+++ b/packages/apollo-graphql/src/schema/buildSchemaFromSDL.ts
@@ -18,7 +18,8 @@ import {
   isAbstractType,
   isScalarType,
   isEnumType,
-  GraphQLEnumValueConfig
+  GraphQLEnumValueConfig,
+  DirectiveNode
 } from "graphql";
 import { validateSDL } from "graphql/validation/validate";
 import { isDocumentNode, isNode } from "../utilities/graphql";
@@ -108,6 +109,7 @@ export function buildSchemaFromSDL(
 
   const schemaDefinitions: SchemaDefinitionNode[] = [];
   const schemaExtensions: SchemaExtensionNode[] = [];
+  const schemaDirectives: DirectiveNode[] = [];
 
   for (const definition of documentAST.definitions) {
     if (isTypeDefinitionNode(definition)) {
@@ -130,6 +132,7 @@ export function buildSchemaFromSDL(
       directiveDefinitions.push(definition);
     } else if (definition.kind === Kind.SCHEMA_DEFINITION) {
       schemaDefinitions.push(definition);
+      schemaDirectives.push(...(definition.directives ?? []))
     } else if (definition.kind === Kind.SCHEMA_EXTENSION) {
       schemaExtensions.push(definition);
     }
@@ -211,7 +214,12 @@ export function buildSchemaFromSDL(
       typeName
         ? (schema.getType(typeName) as GraphQLObjectType<any, any>)
         : undefined
-    )
+    ),
+    astNode: {
+      kind: 'SchemaDefinition',
+      directives: schemaDirectives,
+      operationTypes: [] // satisfies typescript, will be ignored
+    }
   });
 
   for (const module of modules) {


### PR DESCRIPTION
updates buildSchemaFromSDL to pass through applied directives on the `schema` definition node.

<!--
  Thanks for filing a pull request on Apollo Tooling!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [x] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass

\*Make sure changelog entries note which project(s) has been affected. See older entries for examples on what this looks like.
