### PR TITLE
Remove `moment` as a dependency for `apollo-language-server`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ## vNEXT
 
+- `apollo-language-server`
+  - Remove `moment` as a dependency [#2595](https://github.com/apollographql/apollo-tooling/pull/2595)
+
 ## `apollo@2.33.10`
 - This release includes a number of patch updates for dependencies within the following packages. Behavior changes aren't expected and should be considered reportable issues.
   - apollo-codegen-core@0.40.8

--- a/package-lock.json
+++ b/package-lock.json
@@ -19224,7 +19224,6 @@
         "lodash.debounce": "^4.0.8",
         "lodash.merge": "^4.6.1",
         "minimatch": "^5.0.0",
-        "moment": "2.29.1",
         "vscode-languageserver": "^5.1.0",
         "vscode-uri": "1.0.6"
       },
@@ -24616,7 +24615,6 @@
         "lodash.debounce": "^4.0.8",
         "lodash.merge": "^4.6.1",
         "minimatch": "^5.0.0",
-        "moment": "2.29.1",
         "vscode-languageserver": "^5.1.0",
         "vscode-uri": "1.0.6"
       }

--- a/packages/apollo-language-server/package.json
+++ b/packages/apollo-language-server/package.json
@@ -39,7 +39,6 @@
     "lodash.debounce": "^4.0.8",
     "lodash.merge": "^4.6.1",
     "minimatch": "^5.0.0",
-    "moment": "2.29.1",
     "vscode-languageserver": "^5.1.0",
     "vscode-uri": "1.0.6"
   },

--- a/packages/apollo-language-server/src/__tests__/format.test.ts
+++ b/packages/apollo-language-server/src/__tests__/format.test.ts
@@ -1,0 +1,43 @@
+import { formatMS } from "../format";
+
+const SECOND_AS_MS = 1000;
+const MIN_AS_MS = 60 * SECOND_AS_MS;
+const HOUR_AS_MS = 60 * MIN_AS_MS;
+
+describe("formatMS", () => {
+  describe("hours display", () => {
+    it("works with no digits", () => {
+      const value = 2 * HOUR_AS_MS;
+      expect(formatMS(value, 0)).toEqual("2hr");
+    });
+
+    it("works with 1 digit", () => {
+      const value = 2 * HOUR_AS_MS;
+      expect(formatMS(value, 1)).toEqual("2.0hr");
+    });
+  });
+
+  describe("minutes display", () => {
+    it("works with no digits", () => {
+      const value = 3 * MIN_AS_MS;
+      expect(formatMS(value, 0)).toEqual("3min");
+    });
+
+    it("works with 1 digit", () => {
+      const value = 3 * MIN_AS_MS;
+      expect(formatMS(value, 1)).toEqual("3.0min");
+    });
+  });
+
+  describe("seconds display", () => {
+    it("works with no digits", () => {
+      const value = 4 * SECOND_AS_MS;
+      expect(formatMS(value, 0)).toEqual("4s");
+    });
+
+    it("works with 1 digit", () => {
+      const value = 4 * SECOND_AS_MS;
+      expect(formatMS(value, 1)).toEqual("4.0s");
+    });
+  });
+});

--- a/packages/apollo-language-server/src/format.ts
+++ b/packages/apollo-language-server/src/format.ts
@@ -1,4 +1,6 @@
-import moment from "moment";
+const ONE_SECOND_AS_MS = 1000;
+const ONE_MINUTE_AS_MS = 60 * ONE_SECOND_AS_MS;
+const ONE_HOUR_AS_MS = 60 * ONE_MINUTE_AS_MS;
 
 export function formatMS(
   ms: number,
@@ -8,9 +10,9 @@ export function formatMS(
 ) {
   if (ms === 0 || ms === null) return "0";
   const bounds = [
-    moment.duration(1, "hour").asMilliseconds(),
-    moment.duration(1, "minute").asMilliseconds(),
-    moment.duration(1, "second").asMilliseconds(),
+    ONE_HOUR_AS_MS,
+    ONE_MINUTE_AS_MS,
+    ONE_SECOND_AS_MS,
     1,
     0.001,
     0.000001


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Tooling!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

There is really no strong need for `moment` to a dependency of `apollo-language-server` when it is used just to calculate durations in milliseconds. A simple constant will suffice instead.

Also added some tests to prove that this change works but is by no means exhaustive.

Related: https://github.com/apollographql/apollo-tooling/issues/2323.

TODO:

- [x] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass

\*Make sure changelog entries note which project(s) has been affected. See older entries for examples on what this looks like.
