### PR TITLE
Deprecate `client:codegen` command

### DIFF
--- a/.changeset/chilled-yaks-refuse.md
+++ b/.changeset/chilled-yaks-refuse.md
@@ -1,0 +1,5 @@
+---
+"apollo": minor
+---
+
+Deprecate the client:codegen command

--- a/packages/apollo-language-server/src/graphqlTypes.ts
+++ b/packages/apollo-language-server/src/graphqlTypes.ts
@@ -1742,18 +1742,12 @@ export enum ValidationErrorType {
   WARNING = "WARNING",
 }
 
-/**
- * Filter options to exclude by client reference ID, client name, and client version.
- */
 export interface ClientInfoFilter {
   name?: string | null;
   referenceID?: string | null;
   version?: string | null;
 }
 
-/**
- * This is stored with a schema when it is uploaded
- */
 export interface GitContextInput {
   branch?: string | null;
   commit?: string | null;
@@ -1856,11 +1850,9 @@ export interface OperationDocumentInput {
   name?: string | null;
 }
 
-/**
- * Options to filter by operation name.
- */
 export interface OperationNameFilterInput {
   name: string;
+  version?: string | null;
 }
 
 /**

--- a/packages/apollo/src/Command.ts
+++ b/packages/apollo/src/Command.ts
@@ -345,6 +345,7 @@ export abstract class ClientCommand extends ProjectCommand {
     }),
   };
   public project!: GraphQLClientProject;
+
   constructor(argv, config) {
     super(argv, config);
     this.type = "client";

--- a/packages/apollo/src/commands/client/codegen.ts
+++ b/packages/apollo/src/commands/client/codegen.ts
@@ -8,7 +8,7 @@ import chalk from "chalk";
 import { Debug } from "apollo-language-server";
 
 import { TargetType, default as generate } from "../../generate";
-import { ClientCommand } from "../../Command";
+import { ClientCommand, ProjectCommand } from "../../Command";
 
 const waitForKey = async () => {
   console.log("Press any key to stop.");
@@ -25,7 +25,7 @@ const waitForKey = async () => {
 export default class Generate extends ClientCommand {
   static aliases = ["codegen:generate"];
   static description =
-    "Generate static types for GraphQL queries. Can use the published schema in the Apollo registry or a downloaded schema.";
+    "[DEPRECATED] Generate static types for GraphQL queries. Can use the published schema in the Apollo registry or a downloaded schema.";
 
   static flags = {
     ...ClientCommand.flags,
@@ -111,6 +111,10 @@ export default class Generate extends ClientCommand {
       description:
         'By default, TypeScript will output "ts" files. Set "tsFileExtension" to specify a different file extension, for example "d.ts"',
     }),
+
+    suppressDeprecationWarning: flags.boolean({
+      description: 'Silence the deprecation warning output by the codegen command',
+    }),
   };
 
   static args = [
@@ -125,11 +129,27 @@ export default class Generate extends ClientCommand {
     },
   ];
 
+  DEPRECATION_MSG =
+  "\n--------------------------------------------------------------------------------\n" +
+  "DEPRECATED: This command will be removed from the `apollo` CLI in \n" +
+  "its next major version. Replacement functionality is available via \n" +
+  "the `graphql-code-generator` project: https://www.graphql-code-generator.com/\n" +
+  "This message can be suppressed with the --suppressDeprecationWarning flag.\n" +
+  "--------------------------------------------------------------------------------\n";
+
+  protected printDeprecationWarning() {
+    console.error(this.DEPRECATION_MSG);
+  }
+
   async run() {
     const {
-      flags: { watch },
+      flags: { watch, suppressDeprecationWarning },
       args: { output },
     } = this.parse(Generate);
+
+    if (!suppressDeprecationWarning) {
+      this.printDeprecationWarning();
+    }
 
     let write;
     const run = () =>

--- a/packages/apollo/src/commands/client/codegen.ts
+++ b/packages/apollo/src/commands/client/codegen.ts
@@ -113,7 +113,8 @@ export default class Generate extends ClientCommand {
     }),
 
     suppressDeprecationWarning: flags.boolean({
-      description: 'Silence the deprecation warning output by the codegen command',
+      description:
+        "Silence the deprecation warning output by the codegen command",
     }),
   };
 
@@ -130,12 +131,12 @@ export default class Generate extends ClientCommand {
   ];
 
   DEPRECATION_MSG =
-  "\n--------------------------------------------------------------------------------\n" +
-  "DEPRECATED: This command will be removed from the `apollo` CLI in \n" +
-  "its next major version. Replacement functionality is available via \n" +
-  "the `graphql-code-generator` project: https://www.graphql-code-generator.com/\n" +
-  "This message can be suppressed with the --suppressDeprecationWarning flag.\n" +
-  "--------------------------------------------------------------------------------\n";
+    "\n--------------------------------------------------------------------------------\n" +
+    "DEPRECATED: This command will be removed from the `apollo` CLI in \n" +
+    "its next major version. Replacement functionality is available via \n" +
+    "the `graphql-code-generator` project: https://www.graphql-code-generator.com/\n" +
+    "This message can be suppressed with the --suppressDeprecationWarning flag.\n" +
+    "--------------------------------------------------------------------------------\n";
 
   protected printDeprecationWarning() {
     console.error(this.DEPRECATION_MSG);


### PR DESCRIPTION
Related: https://github.com/apollographql/apollo-tooling/issues/2614

This change officially deprecates the codegen utility in the Apollo CLI. The recommendation going forward is to use the `graphql-code-generator` utility.

For iOS (for which there is no existing replacement): patch fixes will still be entertained and released on the v2.x line, but no further development will be done unless it's necessary. Apollo iOS intends to release their own codegen in the relatively near future.

While we do encourage moving away from the CLI as quickly as possible, I'm sympathetic to the fact that a change might not be feasible right away. I've included the `--suppressDeprecationWarning` flag in order to silence the console output when running the `client:codegen` command.

I haven't added tests for the printing of this command, but I did test locally to ensure the notice is printed (and is also suppressible with the flag).